### PR TITLE
Allow multiple blocks in directive options

### DIFF
--- a/src/main/scala/laika/parse/rst/ExplicitBlockParsers.scala
+++ b/src/main/scala/laika/parse/rst/ExplicitBlockParsers.scala
@@ -282,7 +282,7 @@ trait ExplicitBlockParsers extends laika.parse.BlockParsers { self: InlineParser
       val name = ':' ~> escapedUntil(':') <~ (guard(eol) | ' ')
 
       val item = (ws min 1) >> { firstIndent =>
-          (name ~ indentedBlock(firstIndent.length + 1, endsOnBlankLine = true)) ^^ 
+          (name ~ indentedBlock(firstIndent.length + 1)) ^^
         { case name ~ block => 
             (name, (block.lines mkString "\n").trim)
         }}


### PR DESCRIPTION
Hi,

I am using Laika to implement a reStructuredText processor with a custom directive that looks like:

```
.. newslide::
   :title: The title
   :layout: //the layout is CSS-like
        slide#this p[1] { anchor:(1,2); width:50 }

        slide#this ul[1] li { }
```

I want to be able to have blank lines inside the `layout` option; this PR removes the `endsOnBlankLine` argument from the `indentedBlock` parser. This makes the behavior closer to the field list parser in `laika.parse.rst.ListParsers.scala`. With this change I get the desired result from parsing the above directive, e.g. the value of the 'layout' option is a String containing both of the indented paragraphs.

All of the tests are passing in Scala 2.10.2 (except for `SectionNumberSpec`, because of a non-existing file that I assume is due to be added to the test resources eventually). The current HEAD doesn't compile on 2.9.3.
