### PR TITLE
Fix typo: change "directoy" to "directory"

### DIFF
--- a/src/main/scala/laika/api/Transform.scala
+++ b/src/main/scala/laika/api/Transform.scala
@@ -516,7 +516,7 @@ object Transform {
      */
     def apply (root: File, codec: Codec) = {
       require(root.exists, "Directory "+root.getAbsolutePath()+" does not exist")
-      require(root.isDirectory, "File "+root.getAbsolutePath()+" is not a directoy")
+      require(root.isDirectory, "File "+root.getAbsolutePath()+" is not a directory")
       
       val sourceDir = new File(root, "source")
       val targetDir = new File(root, "target")

--- a/src/main/scala/laika/io/InputProvider.scala
+++ b/src/main/scala/laika/io/InputProvider.scala
@@ -122,7 +122,7 @@ object InputProvider {
    */
   def forRootDirectory (root: File, docTypeMatcher: Path => DocumentType)(implicit codec: Codec): InputProvider = {
     require(root.exists, "Directory "+root.getAbsolutePath()+" does not exist")
-    require(root.isDirectory, "File "+root.getAbsolutePath()+" is not a directoy")
+    require(root.isDirectory, "File "+root.getAbsolutePath()+" is not a directory")
     
     new DirectoryInputProvider(root, Root, docTypeMatcher, codec)
   }

--- a/src/main/scala/laika/io/OutputProvider.scala
+++ b/src/main/scala/laika/io/OutputProvider.scala
@@ -71,7 +71,7 @@ object OutputProvider {
     
     def newChild (name: String) = {
       val f = new File(dir, name)
-      require(!f.exists || f.isDirectory, "File "+f.getAbsolutePath+" exists and is not a directoy")
+      require(!f.exists || f.isDirectory, "File "+f.getAbsolutePath+" exists and is not a directory")
       if (!f.exists && !f.mkdir()) throw new IllegalStateException("Unable to create directory "+f.getAbsolutePath)
       new DirectoryOutputProvider(f, path / name, codec)
     }


### PR DESCRIPTION
Some error messages for "is not a directory" had a typo.
