### PR TITLE
Add @:path directive

### DIFF
--- a/core/shared/src/main/scala/laika/directive/std/StandardDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/StandardDirectives.scala
@@ -116,7 +116,7 @@ object StandardDirectives extends DirectiveRegistry {
     }
   }
 
-  lazy val relativePath: Templates.Directive = Templates.create("relativePath") {
+  lazy val path: Templates.Directive = Templates.create("path") {
     import Templates.dsl._
     
     (attribute(0).as[Path], cursor).mapN { (path, cursor) =>
@@ -232,7 +232,7 @@ object StandardDirectives extends DirectiveRegistry {
     IncludeDirectives.templateEmbed,
     HTMLHeadDirectives.linkCSS,
     HTMLHeadDirectives.linkJS,
-    relativePath
+    path
   )
 
   /** The complete list of standard directives for links.

--- a/core/shared/src/test/scala/laika/directive/std/StandardDirectiveSpec.scala
+++ b/core/shared/src/test/scala/laika/directive/std/StandardDirectiveSpec.scala
@@ -97,7 +97,7 @@ class StandardDirectiveSpec extends AnyFlatSpec
 
 
   "The relativePath directive" should "translate a relative path" in {
-    val input = """aa @:relativePath(theme.css) bb"""
+    val input = """aa @:path(theme.css) bb"""
     parseTemplateWithConfig(input, "") shouldBe Right(RootElement(TemplateRoot(
       TemplateString("aa "),
       TemplateString("../theme/theme.css"),
@@ -106,7 +106,7 @@ class StandardDirectiveSpec extends AnyFlatSpec
   }
 
   it should "translate an absolute path" in {
-    val input = """aa @:relativePath(/theme/theme.css) bb"""
+    val input = """aa @:path(/theme/theme.css) bb"""
     parseTemplateWithConfig(input, "") shouldBe Right(RootElement(TemplateRoot(
       TemplateString("aa "),
       TemplateString("../theme/theme.css"),

--- a/docs/src/07-reference/01-standard-directives.md
+++ b/docs/src/07-reference/01-standard-directives.md
@@ -56,6 +56,22 @@ Serves as a shortcut for creating links to the source code of types, e.g. `@:sou
 See [Linking to Source Code] for details.
 
 
+### `@:path`
+
+Can only be used in templates.
+
+Renders a validated path from the virtual input tree which can be absolute or relative. 
+If it is relative, it is interpreted as relative to the template, 
+but when rendering translated for every document the template is applied to as relative to that rendered document.
+
+Example:
+```laika-html
+<link rel="icon" href="@:path(../styles/manual.css)" />
+```
+
+See [Disabling Validation] when you only want to path translation without the validation.
+
+
 Inclusions
 ----------
 

--- a/docs/src/07-reference/06-release-notes.md
+++ b/docs/src/07-reference/06-release-notes.md
@@ -12,6 +12,10 @@ Release Notes
     * Simplify requirements to just `Sync` for sequential transformation and `Async` for parallel execution.
     * PDF support: remove the old callback hacks for integration with the blocking, synchronous `ResourceResolver` API
       of Apache FOP by using the new `Dispatcher` from CE3 instead.
+* Support Scala 3.0
+* New Directives:
+    * `@:path`: Validates and translates a path in a template to a path relative to the rendered document the template
+      is applied to.
 
 
 0.17.1 (Mar 19, 2021)


### PR DESCRIPTION
Validates and translates a path in a template to a path relative to the rendered document the template is applied to.