### PR TITLE
Add @:attribute directive

### DIFF
--- a/core/shared/src/test/scala/laika/directive/std/StandardDirectiveSpec.scala
+++ b/core/shared/src/test/scala/laika/directive/std/StandardDirectiveSpec.scala
@@ -97,7 +97,7 @@ class StandardDirectiveSpec extends AnyFlatSpec
   }
 
 
-  "The relativePath directive" should "translate a relative path" in {
+  "The path directive" should "translate a relative path" in {
     val input = """aa @:path(theme.css) bb"""
     parseTemplateWithConfig(input, "laika.links.excludeFromValidation = [\"/\"]") shouldBe Right(RootElement(TemplateRoot(
       TemplateString("aa "),
@@ -123,6 +123,35 @@ class StandardDirectiveSpec extends AnyFlatSpec
       TemplateString("aa "),
       TemplateElement(InvalidSpan(msg, source(dirSrc, input)).copy(fallback = Text(dirSrc))),
       TemplateString(" bb")
+    )))
+  }
+  
+  "The attribute directive" should "produce a string value for a valid config value" in {
+    val input = """<a @:attribute(src, foo.bar)/>"""
+    parseTemplateWithConfig(input, "foo.bar = ../image.jpg") shouldBe Right(RootElement(TemplateRoot(
+      TemplateString("<a "),
+      TemplateString("""src="../image.jpg""""),
+      TemplateString("/>")
+    )))
+  }
+
+  it should "produce an empty string for a missing config value" in {
+    val input = """<a @:attribute(src, foo.baz)/>"""
+    parseTemplateWithConfig(input, "foo.bar = ../image.jpg") shouldBe Right(RootElement(TemplateRoot(
+      TemplateString("<a "),
+      TemplateString(""),
+      TemplateString("/>")
+    )))
+  }
+
+  it should "fail with an invalid config value" in {
+    val dirSrc = "@:attribute(src, foo.bar)"
+    val input = s"""<a $dirSrc/>"""
+    val msg = "One or more errors processing directive 'attribute': value with key 'foo.bar' is a structured value (Array, Object, AST) which is not supported by this directive"
+    parseTemplateWithConfig(input, "foo.bar = [1,2,3]") shouldBe Right(RootElement(TemplateRoot(
+      TemplateString("<a "),
+      TemplateElement(InvalidSpan(msg, source(dirSrc, input)).copy(fallback = Text(dirSrc))),
+      TemplateString("/>")
     )))
   }
 

--- a/core/shared/src/test/scala/laika/directive/std/StandardDirectiveSpec.scala
+++ b/core/shared/src/test/scala/laika/directive/std/StandardDirectiveSpec.scala
@@ -101,7 +101,7 @@ class StandardDirectiveSpec extends AnyFlatSpec
     val input = """aa @:path(theme.css) bb"""
     parseTemplateWithConfig(input, "laika.links.excludeFromValidation = [\"/\"]") shouldBe Right(RootElement(TemplateRoot(
       TemplateString("aa "),
-      TemplateString("../theme/theme.css"),
+      TemplateElement(RawLink.internal("../theme/theme.css")),
       TemplateString(" bb")
     )))
   }
@@ -110,7 +110,7 @@ class StandardDirectiveSpec extends AnyFlatSpec
     val input = """aa @:path(/theme/theme.css) bb"""
     parseTemplateWithConfig(input, "laika.links.excludeFromValidation = [\"/\"]") shouldBe Right(RootElement(TemplateRoot(
       TemplateString("aa "),
-      TemplateString("../theme/theme.css"),
+      TemplateElement(RawLink.internal("../theme/theme.css")),
       TemplateString(" bb")
     )))
   }

--- a/docs/src/07-reference/01-standard-directives.md
+++ b/docs/src/07-reference/01-standard-directives.md
@@ -388,7 +388,7 @@ HTML Templates
 --------------
 
 These directives can only be used in HTML or EPUB templates, 
-as they drive the inclusion of tags in the HTML `<head>` section.
+as they drive the inclusion of tags in the HTML `<head>` section or render content in HTML/XML syntax.
 
 If you use the Helium theme and do not design your own templates or themes, 
 you do not need to use these directives directly, as the Helium template already contain them.
@@ -447,6 +447,30 @@ In the latter case all files found in that directory or any sub-directory will b
 Note that the paths, like everything in Laika, are within the virtual path of the input tree you configured.
 See [Virtual Tree Abstraction] for details.
 
+
+### `@:attribute`
+
+This directive can also be used in XSL-FO templates for PDF as it renders attribute syntax that is valid in both,
+HTML and XML.
+
+The primary use case for this directive is to render an attribute value from the configuration that may not be present:
+
+```laika-html
+<a @:attribute(src, myConf.myURL)/>
+```
+
+In the above example, the `src` attribute will only be rendered if the `myConf.myURL` key is defined in the 
+configuration. 
+Like all configuration values it can originate in global scope, in directory configuration or in a configuration 
+header of a markup document.
+
+When the value is not optional, it is recommended not to use this directive, 
+as a missing value will not trigger any warnings or errors, but instead just cause the omission of the attribute.
+Required attributes can be rendered with standard substitution syntax instead:
+
+```laika-html
+<a src="${myConf.myURL}"/>
+```
 
 Conditionals and Loops
 ----------------------

--- a/docs/src/07-reference/06-release-notes.md
+++ b/docs/src/07-reference/06-release-notes.md
@@ -12,10 +12,11 @@ Release Notes
     * Simplify requirements to just `Sync` for sequential transformation and `Async` for parallel execution.
     * PDF support: remove the old callback hacks for integration with the blocking, synchronous `ResourceResolver` API
       of Apache FOP by using the new `Dispatcher` from CE3 instead.
-* Support Scala 3.0
+* Support for Scala 3.0
 * New Directives:
     * `@:path`: Validates and translates a path in a template to a path relative to the rendered document the template
       is applied to.
+    * `@:attribute`: Renders an optional HTML or XML attribute.
 
 
 0.17.1 (Mar 19, 2021)

--- a/io/src/main/resources/laika/helium/templates/default.template.html
+++ b/io/src/main/resources/laika/helium/templates/default.template.html
@@ -13,7 +13,7 @@
       <meta name="description" content="${_}"/>
     @:@
     @:for(helium.favIcons)
-      ${_}
+      <link rel="icon" @:attribute(sizes, _.sizes) @:attribute(type, _.type) href="@:path(_.target)"/>
     @:@
     @:for(helium.webFonts)
       <link rel="stylesheet" href="${_}">

--- a/io/src/main/resources/laika/helium/templates/landing.template.html
+++ b/io/src/main/resources/laika/helium/templates/landing.template.html
@@ -13,7 +13,7 @@
       <meta name="description" content="${_}"/>
     @:@
     @:for(helium.favIcons)
-      ${_}
+      <link rel="icon" @:attribute(sizes, _.sizes) @:attribute(type, _.type) href="@:path(_.target)"/>
     @:@
     @:for(helium.webFonts)
       <link rel="stylesheet" href="${_}">

--- a/io/src/test/scala/laika/helium/HeliumHTMLHeadSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumHTMLHeadSpec.scala
@@ -20,6 +20,7 @@ import cats.effect.{IO, Resource}
 import laika.api.{MarkupParser, Renderer, Transformer}
 import laika.ast.Path
 import laika.ast.Path.Root
+import laika.config.LaikaKeys
 import laika.format.{HTML, Markdown}
 import laika.helium.config.Favicon
 import laika.io.IOFunSuite
@@ -53,6 +54,7 @@ class HeliumHTMLHeadSpec extends IOFunSuite with InputBuilder with ResultExtract
   def transformer (theme: ThemeProvider): Resource[IO, TreeTransformer[IO]] = Transformer
     .from(Markdown)
     .to(HTML)
+    .withConfigValue(LaikaKeys.links.child("excludeFromValidation"), Seq("/"))
     .parallel[IO]
     .withTheme(theme)
     .build
@@ -208,8 +210,8 @@ class HeliumHTMLHeadSpec extends IOFunSuite with InputBuilder with ResultExtract
     )
     val expected = meta ++ """
                    |<title></title>
-                   |<link rel="icon" sizes="32x32" type="image/png" href="icon-1.png" />
-                   |<link rel="icon" sizes="64x64" type="image/png" href="icon-2.png" />
+                   |<link rel="icon" sizes="32x32" type="image/png" href="icon-1.png"/>
+                   |<link rel="icon" sizes="64x64" type="image/png" href="icon-2.png"/>
                    |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
                    |<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/tonsky/FiraCode@1.207/distr/fira_code.css">
                    |<link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
@@ -237,8 +239,8 @@ class HeliumHTMLHeadSpec extends IOFunSuite with InputBuilder with ResultExtract
       )
     val expected = meta ++ """
                    |<title></title>
-                   |<link rel="icon" sizes="32x32" type="image/png" href="../../img/icon-1.png" />
-                   |<link rel="icon" sizes="64x64" type="image/png" href="../../img/icon-2.png" />
+                   |<link rel="icon" sizes="32x32" type="image/png" href="../../img/icon-1.png"/>
+                   |<link rel="icon" sizes="64x64" type="image/png" href="../../img/icon-2.png"/>
                    |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
                    |<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/tonsky/FiraCode@1.207/distr/fira_code.css">
                    |<link rel="stylesheet" type="text/css" href="../helium/icofont.min.css" />


### PR DESCRIPTION
The primary use case for this directive is to render an attribute value from the configuration that may not be present:

```
<a @:attribute(src, myConf.myURL)/>
```