### PR TITLE
Include optional source path in all SourceCursor instances

### DIFF
--- a/core/shared/src/main/scala/laika/api/MarkupParser.scala
+++ b/core/shared/src/main/scala/laika/api/MarkupParser.scala
@@ -59,16 +59,18 @@ class MarkupParser (val format: MarkupFormat, val config: OperationConfig) {
     */
   val fileSuffixes: Set[String] = format.fileSuffixes
   
+  private val fallbackPath: Path = Root / "doc"
+  
   private val docParser = DocumentParser.forMarkup(format, config.markupExtensions, config.configProvider)
 
   /** Parses the specified markup string into a document AST structure.
     */
-  def parse (input: String): Either[ParserError, Document] = parse(DocumentInput(Root / "doc", SourceCursor(input)))
+  def parse (input: String): Either[ParserError, Document] = parse(DocumentInput(fallbackPath, input))
 
   /** Parses the specified markup string into a document AST structure.
     * The given (virtual) path will be assigned to the result.
     */
-  def parse (input: String, path: Path): Either[ParserError, Document] = parse(DocumentInput(path, SourceCursor(input)))
+  def parse (input: String, path: Path): Either[ParserError, Document] = parse(DocumentInput(path, input))
 
   /** Parses the specified markup input into a document AST structure.
     */
@@ -100,10 +102,10 @@ class MarkupParser (val format: MarkupFormat, val config: OperationConfig) {
   }
 
   def parseUnresolved (input: String): Either[ParserError, UnresolvedDocument] = 
-    parseUnresolved(DocumentInput(Root, SourceCursor(input)))
+    parseUnresolved(DocumentInput(fallbackPath, input))
 
   def parseUnresolved (input: String, path: Path): Either[ParserError, UnresolvedDocument] = 
-    parseUnresolved(DocumentInput(path, SourceCursor(input)))
+    parseUnresolved(DocumentInput(path, input))
 
   /** Returns an unresolved document without applying
     * the default rewrite rules and without resolving the configuration header (if present). 

--- a/core/shared/src/main/scala/laika/parse/SourceCursor.scala
+++ b/core/shared/src/main/scala/laika/parse/SourceCursor.scala
@@ -236,7 +236,7 @@ class LineSource private (val input: String, private val parentRef: SourceCursor
   }
 
   override def toString: String = {
-    val pathStr = path.fold("")(_ + ": ")
+    val pathStr = path.fold("")(_.toString + ": ")
     s"LineSource(${pathStr}offset $offset - length ${input.length} - root offset ${root.offset})"
   }
 }

--- a/core/shared/src/main/scala/laika/parse/markup/DocumentParser.scala
+++ b/core/shared/src/main/scala/laika/parse/markup/DocumentParser.scala
@@ -36,6 +36,10 @@ object DocumentParser {
   
   case class DocumentInput (path: Path, source: SourceCursor)
   
+  object DocumentInput {
+    def apply(path: Path, input: String): DocumentInput = new DocumentInput(path, SourceCursor(input, path))
+  }
+  
   case class ParserError (message: String, path: Path) extends 
     RuntimeException(s"Error parsing document '$path': $message")
   

--- a/core/shared/src/main/scala/laika/parse/text/WhitespacePreprocessor.scala
+++ b/core/shared/src/main/scala/laika/parse/text/WhitespacePreprocessor.scala
@@ -102,7 +102,7 @@ object WhitespacePreprocessor {
   val forInput: DocumentInput => DocumentInput = { input =>
     val raw = input.source.input
     val preprocessed = forString(raw.toString)
-    input.copy(source = SourceCursor(preprocessed))
+    input.copy(source = SourceCursor(preprocessed, input.path))
   }
 
 }

--- a/core/shared/src/test/scala/laika/api/ParseAPISpec.scala
+++ b/core/shared/src/test/scala/laika/api/ParseAPISpec.scala
@@ -62,7 +62,7 @@ class ParseAPISpec extends AnyFlatSpec
       |
       |[id]: http://foo/""".stripMargin
     MarkupParser.of(Markdown).build.parseUnresolved(input).toOption.get.document.content should be (RootElement(
-      p(LinkIdReference(List(Text("link")), "id", source("[link][id]", input))), 
+      p(LinkIdReference(List(Text("link")), "id", source("[link][id]", input, defaultPath))), 
       LinkDefinition("id", ExternalTarget("http://foo/"), None)
     ))
   }
@@ -94,9 +94,9 @@ class ParseAPISpec extends AnyFlatSpec
                   |[invalid2]""".stripMargin
     val doc = MarkupParser.of(Markdown).build.parseUnresolved(input).toOption.get.document
     doc.rewrite(TemplateRewriter.rewriteRules(DocumentCursor(doc))).content should be (RootElement(
-      p(InvalidSpan("Unresolved link id reference 'invalid1'", source("[invalid1]", input))),
+      p(InvalidSpan("Unresolved link id reference 'invalid1'", source("[invalid1]", input, defaultPath))),
       p("Text"),
-      p(InvalidSpan("Unresolved link id reference 'invalid2'", source("[invalid2]", input))),
+      p(InvalidSpan("Unresolved link id reference 'invalid2'", source("[invalid2]", input, defaultPath))),
     ))
   }
   

--- a/core/shared/src/test/scala/laika/ast/sample/TestSourceBuilders.scala
+++ b/core/shared/src/test/scala/laika/ast/sample/TestSourceBuilders.scala
@@ -16,6 +16,7 @@
 
 package laika.ast.sample
 
+import laika.ast.Path.Root
 import laika.ast._
 import laika.parse.{LineSource, SourceCursor, SourceFragment}
 
@@ -23,6 +24,8 @@ import laika.parse.{LineSource, SourceCursor, SourceFragment}
  * @author Jens Halm
  */
 trait TestSourceBuilders {
+  
+  val defaultPath: Path = Root / "doc"
 
   def toSource (label: FootnoteLabel): String = label match {
     case Autonumber => "[#]_"
@@ -34,6 +37,11 @@ trait TestSourceBuilders {
   def source (fragment: String, root: String): SourceFragment = {
     val offset = root.indexOf(fragment)
     LineSource(fragment, SourceCursor(root).consume(offset))
+  }
+
+  def source (fragment: String, root: String, path: Path): SourceFragment = {
+    val offset = root.indexOf(fragment)
+    LineSource(fragment, SourceCursor(root, path).consume(offset))
   }
 
   def generatedSource (fragment: String): SourceFragment = LineSource(fragment, SourceCursor(fragment))

--- a/core/shared/src/test/scala/laika/config/ParserBundleSpec.scala
+++ b/core/shared/src/test/scala/laika/config/ParserBundleSpec.scala
@@ -20,6 +20,7 @@ import laika.api.MarkupParser
 import laika.api.builder.OperationConfig
 import laika.ast.Path.Root
 import laika.ast._
+import laika.ast.sample.TestSourceBuilders
 import laika.bundle._
 import laika.factory.MarkupFormat
 import laika.parse._
@@ -60,7 +61,7 @@ class ParserBundleSpec extends AnyWordSpec with Matchers {
     }
   }
 
-  trait BundleSetup extends SetupBase {
+  trait BundleSetup extends SetupBase with TestSourceBuilders {
 
     def appBundles: Seq[ExtensionBundle]
 
@@ -224,7 +225,7 @@ class ParserBundleSpec extends AnyWordSpec with Matchers {
 
     def preProcess (append: String): DocumentInput => DocumentInput = { input =>
       val raw = input.source.input
-      input.copy(source = SourceCursor(raw + append))
+      input.copy(source = SourceCursor(raw + append, input.path))
     }
 
     def processDoc (append: String): UnresolvedDocument => UnresolvedDocument = { unresolved => unresolved.copy(
@@ -411,7 +412,7 @@ class ParserBundleSpec extends AnyWordSpec with Matchers {
       val appBundles = Nil
 
       val input = "${cursor.currentDocument.content}"
-      val contextRef = TemplateContextReference(CursorKeys.documentContent, required = true, LineSource(input, SourceCursor(input)))
+      val contextRef = TemplateContextReference(CursorKeys.documentContent, required = true, generatedSource(input))
       val templateParser = config.templateParser
       templateParser should not be empty
       templateParser.get.parse(input).toOption shouldBe Some(TemplateRoot(contextRef))

--- a/core/shared/src/test/scala/laika/directive/SpanDirectiveAPISpec.scala
+++ b/core/shared/src/test/scala/laika/directive/SpanDirectiveAPISpec.scala
@@ -173,6 +173,8 @@ class SpanDirectiveAPISpec extends AnyFlatSpec
     }
 
     def invalid (fragment: String, error: String): InvalidSpan = InvalidSpan(error, source(fragment, input))
+    
+    def invalid (fragment: String, error: String, path: Path): InvalidSpan = InvalidSpan(error, source(fragment, input, path))
 
     def ss (spans: Span*): Span = SpanSequence(spans)
     
@@ -457,7 +459,7 @@ class SpanDirectiveAPISpec extends AnyFlatSpec
     val input = "aa [RFC-222][@:rfx(222)] bb"
     parseAsMarkdown(input) shouldBe Right(Paragraph(
       Text("aa "),
-      invalid("[RFC-222][@:rfx(222)]", "Unknown link directive: rfx"),
+      invalid("[RFC-222][@:rfx(222)]", "Unknown link directive: rfx", defaultPath),
       Text(" bb")
     ))
   }
@@ -466,7 +468,7 @@ class SpanDirectiveAPISpec extends AnyFlatSpec
     val input = "aa [RFC-222][@:rfc(foo)] bb"
     parseAsMarkdown(input) shouldBe Right(Paragraph(
       Text("aa "),
-      invalid("[RFC-222][@:rfc(foo)]", "Invalid link directive: Not a valid RFC id: foo"),
+      invalid("[RFC-222][@:rfc(foo)]", "Invalid link directive: Not a valid RFC id: foo", defaultPath),
       Text(" bb")
     ))
   }
@@ -475,7 +477,7 @@ class SpanDirectiveAPISpec extends AnyFlatSpec
     val input = "aa [RFC-222][@:rfc foo] bb"
     parseAsMarkdown(input) shouldBe Right(Paragraph(
       Text("aa "),
-      invalid("[RFC-222][@:rfc foo]", "Invalid link directive: `(' expected but `f` found"),
+      invalid("[RFC-222][@:rfc foo]", "Invalid link directive: `(' expected but `f` found", defaultPath),
       Text(" bb")
     ))
   }

--- a/core/shared/src/test/scala/laika/directive/std/LinkDirectiveSpec.scala
+++ b/core/shared/src/test/scala/laika/directive/std/LinkDirectiveSpec.scala
@@ -107,7 +107,7 @@ class LinkDirectiveSpec extends AnyFlatSpec
     val msg = "One or more errors processing directive 'api': unresolved internal reference: local/path/internal/foo/Foo.html"
     parse(input).content should be (RootElement(p(
       Text("aa "),
-      InvalidSpan(msg, source(directive, input)),
+      InvalidSpan(msg, source(directive, input, defaultPath)),
       Text(" bb")
     )))
   }
@@ -118,7 +118,7 @@ class LinkDirectiveSpec extends AnyFlatSpec
     val msg = "One or more errors processing directive 'api': No base URI defined for 'foo.bar.Baz' and no default URI available."
     parse(input).content should be (RootElement(p(
       Text("aa "),
-      InvalidSpan(msg, source(directive, input)),
+      InvalidSpan(msg, source(directive, input, defaultPath)),
       Text(" bb")
     )))
   }
@@ -208,7 +208,7 @@ class LinkDirectiveSpec extends AnyFlatSpec
     val msg = "One or more errors processing directive 'api': No base URI defined for 'foo.bar.Baz' and no default URI available."
     parse(input).content should be (RootElement(p(
       Text("aa "),
-      InvalidSpan(msg, source(directive, input)),
+      InvalidSpan(msg, source(directive, input, defaultPath)),
       Text(" bb")
     )))
   }

--- a/core/shared/src/test/scala/laika/directive/std/SelectDirectiveSpec.scala
+++ b/core/shared/src/test/scala/laika/directive/std/SelectDirectiveSpec.scala
@@ -111,7 +111,7 @@ class SelectDirectiveSpec extends AnyFlatSpec
                    |
                   |bb""".stripMargin
     val message = "One or more errors processing directive 'select': too few occurrences of separator directive 'choice': expected min: 2, actual: 1"
-    val invalid = InvalidBlock(message, source(directive, input))
+    val invalid = InvalidBlock(message, source(directive, input, defaultPath))
     parse(input) should be (RootElement(p("aa"), invalid, p("bb")))
   }
 
@@ -135,7 +135,7 @@ class SelectDirectiveSpec extends AnyFlatSpec
          |
          |bb""".stripMargin
     val message = "One or more errors processing directive 'select': No label defined for choice 'c' in selection 'config'"
-    val invalid = InvalidBlock(message, source(directive, input))
+    val invalid = InvalidBlock(message, source(directive, input, defaultPath))
     parse(input) should be (RootElement(p("aa"),
       invalid, p("bb")))
   }

--- a/core/shared/src/test/scala/laika/parse/SourceCursorSpec.scala
+++ b/core/shared/src/test/scala/laika/parse/SourceCursorSpec.scala
@@ -16,6 +16,7 @@
 
 package laika.parse
 
+import laika.ast.Path.Root
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -96,6 +97,10 @@ class SourceCursorSpec extends AnyWordSpec with Matchers {
     "indicate the correct column" in {
       cursor.consume(5).position.column shouldBe 2
     }
+    
+    "keep the path information" in {
+      SourceCursor("foo", Root / "bar").path shouldBe Some(Root / "bar")
+    }
 
   }
 
@@ -103,7 +108,7 @@ class SourceCursorSpec extends AnyWordSpec with Matchers {
     
     import cats.data.NonEmptyChain
 
-    val root = new RootSource(new InputString("000\nabc\ndef"), 4, 0)
+    val root = new RootSource(new InputString("000\nabc\ndef", Some(Root / "doc")), 4, 0)
     val lines = NonEmptyChain(
       LineSource("abc", root),
       LineSource("def", root.consume(4))
@@ -176,6 +181,10 @@ class SourceCursorSpec extends AnyWordSpec with Matchers {
 
     "indicate the correct column" in {
       cursor.consume(5).position.column shouldBe 2
+    }
+
+    "keep the path information" in {
+      cursor.path shouldBe Some(Root / "doc")
     }
 
   }

--- a/core/shared/src/test/scala/laika/rst/std/StandardTextRolesSpec.scala
+++ b/core/shared/src/test/scala/laika/rst/std/StandardTextRolesSpec.scala
@@ -196,8 +196,8 @@ class StandardTextRolesSpec extends AnyFlatSpec
       |
       |some :foo:`text`""".stripMargin
     val result = RootElement(
-      InvalidBlock("unknown text role: raw", source(role, input)),
-      p(Text("some "), InvalidSpan("unknown text role: foo", source(":foo:`text`", input)))
+      InvalidBlock("unknown text role: raw", source(role, input, defaultPath)),
+      p(Text("some "), InvalidSpan("unknown text role: foo", source(":foo:`text`", input, defaultPath)))
     )
     parse(input) should be (result)
   }

--- a/docs/src/07-reference/06-release-notes.md
+++ b/docs/src/07-reference/06-release-notes.md
@@ -17,6 +17,8 @@ Release Notes
     * `@:path`: Validates and translates a path in a template to a path relative to the rendered document the template
       is applied to.
     * `@:attribute`: Renders an optional HTML or XML attribute.
+* Error Reporting: When a parser error originates in a template the error formatter now includes the path info
+  for the template instead of making the error appear as if it came from the markup document
 
 
 0.17.1 (Mar 19, 2021)

--- a/io/src/main/scala/laika/io/runtime/InputRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/InputRuntime.scala
@@ -34,9 +34,9 @@ object InputRuntime {
 
   def readParserInput[F[_]: Sync] (doc: TextInput[F]): F[DocumentInput] = doc.input.use {
     case PureReader(input) => 
-      Sync[F].pure(DocumentInput(doc.path, SourceCursor(input)))
+      Sync[F].pure(DocumentInput(doc.path, SourceCursor(input, doc.path)))
     case StreamReader(reader, sizeHint) => 
-      readAll(reader, sizeHint).map(source => DocumentInput(doc.path, SourceCursor(source)))
+      readAll(reader, sizeHint).map(source => DocumentInput(doc.path, SourceCursor(source, doc.path)))
   }
 
   def readAll[F[_]: Sync] (reader: Reader, sizeHint: Int): F[String] = {

--- a/io/src/test/scala/laika/ast/ConfigSpec.scala
+++ b/io/src/test/scala/laika/ast/ConfigSpec.scala
@@ -190,7 +190,8 @@ class ConfigSpec extends IOWordSpec
         Root / "input.rst" -> Contents.markupWithConfig
       )
       val msg = RuntimeMessage(MessageLevel.Error, "Missing required reference: 'foox'")
-      val expected = result(TemplateElement(InvalidSpan(msg, source("${foox}", Contents.templateWithMissingRef))))
+      val src = source("${foox}", Contents.templateWithMissingRef, DefaultTemplatePath.forHTML)
+      val expected = result(TemplateElement(InvalidSpan(msg, src)))
       parseRST(build(inputs)).assertEquals(expected)
     }
 

--- a/io/src/test/scala/laika/io/TreeParserSpec.scala
+++ b/io/src/test/scala/laika/io/TreeParserSpec.scala
@@ -194,7 +194,7 @@ class TreeParserSpec extends IOWordSpec
       )
       val invalidDocuments = inputs.map { case (path, markup) => 
         val msg = s"unresolved link id reference: link${markup.charAt(5)}"
-        val invalidSpan = InvalidSpan(msg, generatedSource(markup))
+        val invalidSpan = InvalidSpan(msg, source(markup, markup, path))
         InvalidDocument(NonEmptyChain.one(invalidSpan), path)
       }
       val expectedError = InvalidDocuments(NonEmptyChain.fromChainUnsafe(Chain.fromSeq(invalidDocuments)))


### PR DESCRIPTION
This improves error reporting in case the error originates in a template and not in the markup document the template had been applied to. Previously the line number from the template was printed without a hint that this line does not point to the markup document, but to the template.