### PR TITLE
Add renderUnversioned flag to config for versioning

### DIFF
--- a/core/shared/src/main/scala/laika/rewrite/Version.scala
+++ b/core/shared/src/main/scala/laika/rewrite/Version.scala
@@ -60,8 +60,14 @@ object Version {
   * @param olderVersions list of older versions that have previously been rendered (may be empty)
   * @param newerVersions list of newer versions that have previously been rendered (may be empty)
   * @param excludeFromScanning paths to be skipped when scanning the output directory for existing versions (e.g. for API docs)
+  * @param renderUnversioned indicates whether unversioned documents should be rendered 
+  *                          (setting this to false may be useful when re-rendering older versions)
   */
-case class Versions (currentVersion: Version, olderVersions: Seq[Version], newerVersions: Seq[Version] = Nil, excludeFromScanning: Seq[Path] = Nil) {
+case class Versions (currentVersion: Version, 
+                     olderVersions: Seq[Version], 
+                     newerVersions: Seq[Version] = Nil, 
+                     excludeFromScanning: Seq[Path] = Nil,
+                     renderUnversioned: Boolean = true) {
   
   def allVersions: Seq[Version] = newerVersions ++: currentVersion +: olderVersions
   
@@ -77,8 +83,9 @@ object Versions {
       olderVersions       <- config.get[Seq[Version]]("olderVersions", Nil)
       newerVersions       <- config.get[Seq[Version]]("newerVersions", Nil)
       excludeFromScanning <- config.get[Seq[Path]]("excludeFromScanning", Nil)
+      renderUnversioned   <- config.get[Boolean]("renderUnversioned", false)
     } yield {
-      Versions(currentVersion, olderVersions, newerVersions, excludeFromScanning)
+      Versions(currentVersion, olderVersions, newerVersions, excludeFromScanning, renderUnversioned)
     }
   }
 
@@ -88,6 +95,7 @@ object Versions {
       .withValue("olderVersions", versions.olderVersions)
       .withValue("newerVersions", versions.newerVersions)
       .withValue("excludeFromScanning", versions.excludeFromScanning)
+      .withValue("renderUnversioned", versions.renderUnversioned)
       .build
   }
   

--- a/core/shared/src/test/scala/laika/config/ConfigCodecSpec.scala
+++ b/core/shared/src/test/scala/laika/config/ConfigCodecSpec.scala
@@ -270,7 +270,8 @@ class ConfigCodecSpec extends AnyWordSpec with Matchers {
       ),
       Seq(
         Version("0.43.x", "0.43", label = Some("dev"))
-      )
+      ),
+      renderUnversioned = false
     )
     
     "decode an instance with all fields populated" in {
@@ -285,6 +286,7 @@ class ConfigCodecSpec extends AnyWordSpec with Matchers {
           |    newerVersions = [
           |      { displayValue = "0.43.x", pathSegment = "0.43", fallbackLink = "index.html", label = "dev" }
           |    ]
+          |    renderUnversioned = false
           |  }
           |}
          """.stripMargin

--- a/core/shared/src/test/scala/laika/rewrite/PathTranslatorSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/PathTranslatorSpec.scala
@@ -21,7 +21,7 @@ import laika.ast.RelativePath.CurrentTree
 import laika.ast._
 import laika.ast.sample.{BuilderKey, SampleConfig, SampleTrees}
 import laika.config.LaikaKeys
-import laika.rewrite.nav.{ConfigurablePathTranslator, TargetFormats, TargetLookup}
+import laika.rewrite.nav.{ConfigurablePathTranslator, TargetFormats, TargetLookup, TranslatorConfig}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -49,10 +49,12 @@ class PathTranslatorSpec extends AnyFunSuite with Matchers {
       .suffix("md")
       .buildCursor
   }
-  
-  val versionedRef = ConfigurablePathTranslator(rootCursor.config, "html", "html", Root / "tree-1" / "doc-3.md", new TargetLookup(rootCursor))
-  val unversionedRef = ConfigurablePathTranslator(rootCursor.config, "html", "html", Root / "doc-1.md", new TargetLookup(rootCursor))
-  val epubRef = ConfigurablePathTranslator(rootCursor.config, "epub.xhtml", "epub", Root / "tree-1" / "doc-3.md", new TargetLookup(rootCursor))
+
+  val translatorConfig = TranslatorConfig.readFrom(rootCursor.config).getOrElse(TranslatorConfig.empty)
+  val lookup = new TargetLookup(rootCursor)
+  val versionedRef = ConfigurablePathTranslator(translatorConfig, "html", "html", Root / "tree-1" / "doc-3.md", lookup)
+  val unversionedRef = ConfigurablePathTranslator(translatorConfig, "html", "html", Root / "doc-1.md", lookup)
+  val epubRef = ConfigurablePathTranslator(translatorConfig, "epub.xhtml", "epub", Root / "tree-1" / "doc-3.md", lookup)
   
   
   test("between two unversioned documents") {

--- a/docs/src/03-preparing-content/01-directory-structure.md
+++ b/docs/src/03-preparing-content/01-directory-structure.md
@@ -347,6 +347,28 @@ When overriding for an individual document, you can do this with the standard HO
 enclosed between `{%` and `%}`.
 
 
+**Re-Rendering Older Versions**
+
+When switching to a maintenance branch to fix something in the documentation for an older version,
+you might want to ensure that the build step excludes unversioned documents as you most likely would want
+them to originate in the sources for the newest version.
+
+You can achieve this by setting the `renderUnversioned` flag to `false` in your version config on
+the maintenance branch:
+
+```scala
+val versions = Versions(
+  currentVersion = Version("0.42.x", "0.42"),
+  olderVersions = Seq(),
+  newerVersions = Seq(
+    Version("0.43.x", "0.43", label = Some("dev"))
+  ),
+  renderUnversioned = false
+)
+Helium.defaults.site.versions(versions)
+```
+
+
 Virtual Tree Abstraction
 ------------------------
 

--- a/docs/src/07-reference/06-release-notes.md
+++ b/docs/src/07-reference/06-release-notes.md
@@ -17,6 +17,8 @@ Release Notes
     * `@:path`: Validates and translates a path in a template to a path relative to the rendered document the template
       is applied to.
     * `@:attribute`: Renders an optional HTML or XML attribute.
+* Versioning: new `renderUnversioned` flag, that can be set to false when rendering older versions 
+  (e.g. from a maintenance branch) to ensure that unversioned files always come from the main branch (newest version).
 * Error Reporting: When a parser error originates in a template the error formatter now includes the path info
   for the template instead of making the error appear as if it came from the markup document
 

--- a/io/src/main/scala/laika/helium/builder/InitVersionsDirective.scala
+++ b/io/src/main/scala/laika/helium/builder/InitVersionsDirective.scala
@@ -20,7 +20,7 @@ import laika.ast.Path.Root
 import laika.ast.{Path, TemplateString}
 import laika.directive.Templates
 import laika.rewrite.Versions
-import laika.rewrite.nav.{ConfigurablePathTranslator, TranslatorSpec}
+import laika.rewrite.nav.{ConfigurablePathTranslator, TranslatorConfig, TranslatorSpec}
 
 /**
   * @author Jens Halm
@@ -34,7 +34,8 @@ private[helium] object InitVersionsDirective {
         val localRootPrefix = "../" * cursor.path.depth
         val lookup: Path => Option[TranslatorSpec] = path => 
           if (path == cursor.path) Some(TranslatorSpec(isStatic = false, isVersioned = false)) else None
-        val translator = ConfigurablePathTranslator(cursor.root.config, "html", "html", Root / "doc", lookup)
+        val config = TranslatorConfig.readFrom(cursor.root.config).getOrElse(TranslatorConfig.empty)
+        val translator = ConfigurablePathTranslator(config, "html", "html", Root / "doc", lookup)
         val currentPath = translator.translate(cursor.path).toString
         val currentVersion = versions.currentVersion.displayValue
         s"""<script>initVersions("$localRootPrefix", "$currentPath", "$currentVersion");</script>"""

--- a/io/src/test/scala/laika/render/fo/XSLFORendererSpec.scala
+++ b/io/src/test/scala/laika/render/fo/XSLFORendererSpec.scala
@@ -27,7 +27,7 @@ import laika.config.{ConfigBuilder, LaikaKeys}
 import laika.format.XSLFO
 import laika.parse.GeneratedSource
 import laika.parse.code.CodeCategory
-import laika.rewrite.nav.{BasicPathTranslator, ConfigurablePathTranslator, TargetFormats, TranslatorSpec}
+import laika.rewrite.nav.{BasicPathTranslator, ConfigurablePathTranslator, TargetFormats, TranslatorConfig, TranslatorSpec}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -723,9 +723,12 @@ class XSLFORendererSpec extends AnyFlatSpec
     val elem = p(Text("some "), SpanLink(target)("link"), Text(" span"))
     val fo = s"""<fo:block $defaultParagraphStyles>some """ +
       """<fo:basic-link color="#931813" external-destination="http://external/foo.html#ref" font-weight="bold">link</fo:basic-link> span</fo:block>"""
-    val config = ConfigBuilder.empty.withValue(LaikaKeys.siteBaseURL, "http://external/").build
-    val lookup: Path => Option[TranslatorSpec] = path => if (path == Root / "doc") Some(TranslatorSpec(false, false)) else None
-    val translator = ConfigurablePathTranslator(config, "fo", "pdf", Root / "doc", lookup)
+    val translator = {
+      val config = ConfigBuilder.empty.withValue(LaikaKeys.siteBaseURL, "http://external/").build
+      val tConfig = TranslatorConfig.readFrom(config).getOrElse(TranslatorConfig.empty)
+      val lookup: Path => Option[TranslatorSpec] = path => if (path == Root / "doc") Some(TranslatorSpec(false, false)) else None
+      ConfigurablePathTranslator(tConfig, "fo", "pdf", Root / "doc", lookup)
+    }
     defaultRenderer.render(elem, Root / "doc", translator, TestTheme.foStyles) should be (fo)
   }
 

--- a/pdf/src/main/scala/laika/render/pdf/FOConcatenation.scala
+++ b/pdf/src/main/scala/laika/render/pdf/FOConcatenation.scala
@@ -26,7 +26,7 @@ import laika.format.{PDF, XSLFO}
 import laika.io.model.RenderedTreeRoot
 import laika.parse.markup.DocumentParser.InvalidDocument
 import laika.rewrite.DefaultTemplatePath
-import laika.rewrite.nav.{ConfigurablePathTranslator, TranslatorSpec}
+import laika.rewrite.nav.{ConfigurablePathTranslator, TranslatorConfig, TranslatorSpec}
 
 /** Concatenates the XSL-FO that serves as a basis for producing the final PDF output
   * and applies the default XSL-FO template to the entire result.
@@ -65,18 +65,22 @@ object FOConcatenation {
         config = finalConfig
       )
       val renderer = Renderer.of(XSLFO).withConfig(opConfig).build
-      val lookup = {
-        def isVersioned (config: Config): Boolean = config.get[Boolean](LaikaKeys.versioned).getOrElse(false)
-        val map = result.allDocuments.map { doc =>
-          (doc.path.withoutFragment, TranslatorSpec(isStatic = false, isVersioned = isVersioned(doc.config)))
-        }.toMap
-        map.get _
+      val pathTranslator = {
+        val lookup = {
+          def isVersioned (config: Config): Boolean = config.get[Boolean](LaikaKeys.versioned).getOrElse(false)
+          val map = result.allDocuments.map { doc =>
+            (doc.path.withoutFragment, TranslatorSpec(isStatic = false, isVersioned = isVersioned(doc.config)))
+          }.toMap
+          map.get _
+        }
+        val translatorConfig = TranslatorConfig.readFrom(result.config).getOrElse(TranslatorConfig.empty)
+        ConfigurablePathTranslator(translatorConfig, "fo", "pdf", Path.Root / "merged.fo", lookup)
       }
       template
         .applyTo(finalDoc)
         .leftMap(err => ConfigException(err))
         .flatMap(templatedDoc => InvalidDocument.from(templatedDoc, opConfig.failOnMessages).toLeft(templatedDoc))
-        .map(renderer.render(_, ConfigurablePathTranslator(result.config, "fo", "pdf", Path.Root / "merged.fo", lookup), result.styles))
+        .map(renderer.render(_, pathTranslator, result.styles))
     }
 
     val defaultTemplate = TemplateDocument(DefaultTemplatePath.forFO, result.defaultTemplate)


### PR DESCRIPTION
The flag can be set to false when rendering older versions (e.g. from a maintenance branch) to ensure that unversioned files always come from the main branch (newest version).