### PR TITLE
Udate Apache FOP dependency to version 2.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ val jTidy      = "net.sf.jtidy"           %  "jtidy"       % "r938"  % "test"
 
 val catsEffect = "org.typelevel"          %% "cats-effect" % "3.0.1"
 
-val fop        = "org.apache.xmlgraphics" %  "fop"         % "2.3"
+val fop        = "org.apache.xmlgraphics" %  "fop"         % "2.6"
 val http4s     = Seq(
                    "org.http4s"           %% "http4s-dsl"          % "0.21.20",
                    "org.http4s"           %% "http4s-blaze-server" % "0.21.20"

--- a/docs/src/07-reference/06-release-notes.md
+++ b/docs/src/07-reference/06-release-notes.md
@@ -19,6 +19,8 @@ Release Notes
     * `@:attribute`: Renders an optional HTML or XML attribute.
 * Versioning: new `renderUnversioned` flag, that can be set to false when rendering older versions 
   (e.g. from a maintenance branch) to ensure that unversioned files always come from the main branch (newest version).
+* PDF Support: upgrade to Apache FOP 2.6 (2.4 and 2.5 were both skipped as they had an issue with dependencies 
+  in their POMs)
 * Error Reporting: When a parser error originates in a template the error formatter now includes the path info
   for the template instead of making the error appear as if it came from the markup document
 


### PR DESCRIPTION
(2.4 and 2.5 had been skipped as both versions had an issue with dependencies in their POM)