### PR TITLE
 Add InputTreeBuilder.addProvidedPath method

### DIFF
--- a/docs/src/07-reference/06-release-notes.md
+++ b/docs/src/07-reference/06-release-notes.md
@@ -19,6 +19,8 @@ Release Notes
     * `@:attribute`: Renders an optional HTML or XML attribute.
 * Versioning: new `renderUnversioned` flag, that can be set to false when rendering older versions 
   (e.g. from a maintenance branch) to ensure that unversioned files always come from the main branch (newest version).
+* Link Validation: new `addProvidedPath` method on `InputTreeBuilder` that adds a path representing a document which is 
+  processed by some external tool, making it available during link validation.
 * PDF Support: upgrade to Apache FOP 2.6 (2.4 and 2.5 were both skipped as they had an issue with dependencies 
   in their POMs)
 * Error Reporting: When a parser error originates in a template the error formatter now includes the path info

--- a/io/src/main/scala/laika/io/runtime/ParserRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/ParserRuntime.scala
@@ -105,7 +105,7 @@ object ParserRuntime {
       
       def rewriteTree (root: DocumentTreeRoot): Either[InvalidDocuments, ParsedTree[F]] = { // TODO - move to TreeResultBuilder
         val rootToRewrite = root.copy(
-          staticDocuments = inputs.binaryInputs.map(doc => StaticDocument(doc.path, doc.formats))
+          staticDocuments = inputs.binaryInputs.map(doc => StaticDocument(doc.path, doc.formats)) ++ inputs.providedPaths
         )
         val finalTree = rootToRewrite.rewrite(op.config.rewriteRulesFor(rootToRewrite))
         InvalidDocuments.from(finalTree, op.config.failOnMessages)

--- a/sbt/src/main/scala/laika/sbt/Tasks.scala
+++ b/sbt/src/main/scala/laika/sbt/Tasks.scala
@@ -91,13 +91,13 @@ object Tasks {
 
     lazy val tree = {
       val inputs = generateAPI.value.foldLeft(laikaInputs.value.delegate) {
-        (inputs, path) => inputs.addString("", apiPath / path) // TODO - temporary hack until the builder API is enhanced
+        (inputs, path) => inputs.addProvidedPath(apiPath / path)
       }
       val tree = parser.use(_.fromInput(inputs).parse).unsafeRunSync()
 
       Logs.runtimeMessages(streams.value.log, tree.root, userConfig.logMessages)
 
-      tree.copy(staticDocuments = tree.staticDocuments.filterNot(_.path.isSubPath(apiPath))) // TODO - remove filter when the above gets fixed
+      tree
     }
     
     def renderWithFormat[FMT] (format: RenderFormat[FMT], targetDir: File, formatDesc: String): Set[File] = {


### PR DESCRIPTION
New `addProvidedPath` method on `InputTreeBuilder` that adds a path representing a document which is processed by some external tool, making it available during link validation.