### PR TITLE
Improved Error Handling for Rewrite Rules and Cursor API

### DIFF
--- a/core/shared/src/main/scala/laika/api/builder/OperationConfig.scala
+++ b/core/shared/src/main/scala/laika/api/builder/OperationConfig.scala
@@ -137,10 +137,8 @@ case class OperationConfig (bundles: Seq[ExtensionBundle] = Nil,
   /** The combined rewrite rule for the specified document, obtained by merging the rewrite rules defined in all bundles.
     * This combined rule gets applied to the document between parse and render operations.
     */
-  def rewriteRulesFor (doc: Document): ConfigResult[RewriteRules] = {
-    val cursor = DocumentCursor(doc)
-    rewriteRulesFor(cursor.root.target)(cursor)
-  }
+  def rewriteRulesFor (doc: Document): ConfigResult[RewriteRules] =
+    DocumentCursor(doc).flatMap(cursor => rewriteRulesFor(cursor.root.target)(cursor))
 
   /** Provides the overrides for the specified render format.
     */

--- a/core/shared/src/main/scala/laika/api/builder/OperationConfig.scala
+++ b/core/shared/src/main/scala/laika/api/builder/OperationConfig.scala
@@ -16,9 +16,11 @@
 
 package laika.api.builder
 
+import laika.ast.RewriteRules.RewriteRulesBuilder
 import laika.config.{Config, ConfigBuilder, ConfigEncoder, DefaultKey, Key}
 import laika.ast._
 import laika.bundle.{BundleOrigin, ConfigProvider, DocumentTypeMatcher, ExtensionBundle, MarkupExtensions}
+import laika.config.Config.ConfigResult
 import laika.directive.DirectiveSupport
 import laika.directive.std.StandardDirectives
 import laika.factory.{MarkupFormat, RenderFormat}
@@ -129,13 +131,13 @@ case class OperationConfig (bundles: Seq[ExtensionBundle] = Nil,
   /** The combined rewrite rule, obtained by merging the rewrite rules defined in all bundles.
     * This combined rule gets applied to the document between parse and render operations.
     */
-  def rewriteRulesFor (root: DocumentTreeRoot): DocumentCursor => RewriteRules =
+  def rewriteRulesFor (root: DocumentTreeRoot): RewriteRulesBuilder =
     RewriteRules.chainFactories(mergedBundle.rewriteRules ++ RewriteRules.defaultsFor(root, slugBuilder))
 
   /** The combined rewrite rule for the specified document, obtained by merging the rewrite rules defined in all bundles.
     * This combined rule gets applied to the document between parse and render operations.
     */
-  def rewriteRulesFor (doc: Document): RewriteRules = {
+  def rewriteRulesFor (doc: Document): ConfigResult[RewriteRules] = {
     val cursor = DocumentCursor(doc)
     rewriteRulesFor(cursor.root.target)(cursor)
   }

--- a/core/shared/src/main/scala/laika/api/builder/TransformerBuilderOps.scala
+++ b/core/shared/src/main/scala/laika/api/builder/TransformerBuilderOps.scala
@@ -16,6 +16,7 @@
 
 package laika.api.builder
 
+import laika.ast.RewriteRules.RewriteRulesBuilder
 import laika.ast._
 import laika.bundle.ExtensionBundle
 
@@ -134,7 +135,7 @@ trait TransformerBuilderOps[FMT] extends ParserBuilderOps with RendererBuilderOp
   def creatingRule (newRules: DocumentCursor => RewriteRules): ThisType = using(new ExtensionBundle {
     val description: String = "Custom rewrite rules"
     override val useInStrictMode: Boolean = true
-    override def rewriteRules: Seq[DocumentCursor => RewriteRules] = Seq(newRules)
+    override def rewriteRules: Seq[RewriteRulesBuilder] = Seq(newRules.andThen(Right(_)))
   })
 
 }

--- a/core/shared/src/main/scala/laika/ast/documents.scala
+++ b/core/shared/src/main/scala/laika/ast/documents.scala
@@ -18,7 +18,8 @@ package laika.ast
 
 import cats.data.NonEmptySet
 import laika.ast.RelativePath.CurrentTree
-import laika.config.Config.IncludeMap
+import laika.ast.RewriteRules.RewriteRulesBuilder
+import laika.config.Config.{ConfigResult, IncludeMap}
 import laika.config._
 import laika.rewrite.nav.{AutonumberConfig, TargetFormats}
 import laika.rewrite.{DefaultTemplatePath, TemplateRewriter}
@@ -426,7 +427,7 @@ case class DocumentTree (path: Path,
    *  The specified factory function will be invoked for each document contained in this
    *  tree and must return the rewrite rules for that particular document.
    */
-  def rewrite (rules: DocumentCursor => RewriteRules): DocumentTree = TreeCursor(this).rewriteTarget(rules)
+  def rewrite (rules: RewriteRulesBuilder): Either[TreeConfigErrors, DocumentTree] = TreeCursor(this).rewriteTarget(rules)
 
   protected val configScope: Origin.Scope = Origin.TreeScope
   
@@ -509,6 +510,6 @@ case class DocumentTreeRoot (tree: DocumentTree,
     * The specified factory function will be invoked for each document contained in this tree
     * and must return the rewrite rules for that particular document.
     */
-  def rewrite (rules: DocumentCursor => RewriteRules): DocumentTreeRoot = RootCursor(this).rewriteTarget(rules)
+  def rewrite (rules: RewriteRulesBuilder): Either[TreeConfigErrors, DocumentTreeRoot] = RootCursor(this).rewriteTarget(rules)
 
 }

--- a/core/shared/src/main/scala/laika/bundle/ExtensionBundle.scala
+++ b/core/shared/src/main/scala/laika/bundle/ExtensionBundle.scala
@@ -16,6 +16,7 @@
 
 package laika.bundle
 
+import laika.ast.RewriteRules.RewriteRulesBuilder
 import laika.ast._
 import laika.config.Config
 import laika.parse.css.CSSParsers
@@ -106,7 +107,7 @@ trait ExtensionBundle { self =>
     * which is a partial function from `Element` to `Option[Element]` that allows
     * to remove or replace elements from the tree.
     */
-  def rewriteRules: Seq[DocumentCursor => RewriteRules] = Seq.empty
+  def rewriteRules: Seq[RewriteRulesBuilder] = Seq.empty
 
   /** The overrides for renderers defined by this bundle.
     *

--- a/core/shared/src/main/scala/laika/config/Config.scala
+++ b/core/shared/src/main/scala/laika/config/Config.scala
@@ -197,7 +197,10 @@ class ObjectConfig (private[laika] val root: ObjectValue,
         }
         case _ => field.value
       }
-      decoder(Traced(res, field.origin))
+      decoder(Traced(res, field.origin)).left.map {
+        case de @ DecodingError(_, child) => de.withKey(child.fold(key)(key.child))
+        case other => other
+      }
     }
   }
   

--- a/core/shared/src/main/scala/laika/config/ConfigError.scala
+++ b/core/shared/src/main/scala/laika/config/ConfigError.scala
@@ -38,7 +38,10 @@ case class InvalidType(expected: String, actual: ConfigValue) extends ConfigErro
 }
 
 /** An error that occurred when decoding a configuration value to a target type. */
-case class DecodingError (message: String) extends ConfigError
+case class DecodingError (error: String, key: Option[Key] = None) extends ConfigError {
+  val message: String = key.fold("")(k => s"Error decoding '${k.toString}': ") + error
+  def withKey (key: Key): DecodingError = copy(key = Some(key))
+}
 
 /** A generic error for invalid values. */
 case class ValidationError(message: String) extends ConfigError

--- a/core/shared/src/main/scala/laika/config/Key.scala
+++ b/core/shared/src/main/scala/laika/config/Key.scala
@@ -34,6 +34,7 @@ case class Key(segments: Seq[String]) {
   
   def local: Key = if (segments.isEmpty) this else Key(segments.last)
   
+  @deprecated("key to path conversion is no longer necessary in any Laika API", "0.18.0")
   def toPath: Path = Path(segments.toList)
 
   override def toString: String = if (segments.isEmpty) "<RootKey>" else segments.mkString(".")

--- a/core/shared/src/main/scala/laika/directive/api.scala
+++ b/core/shared/src/main/scala/laika/directive/api.scala
@@ -99,6 +99,11 @@ trait BuilderContext[E <: Element] {
 
     val body: Option[BodyContent] = content.body
     
+    def message (error: ConfigError): String = error match {
+      case de: DecodingError => de.error // do not include key in message
+      case other => other.message
+    }
+    
     def attribute[T] (id: AttributeKey, decoder: ConfigDecoder[T], inherit: Boolean): Result[Option[T]] =
       content.attributes
         .getOpt[Traced[T]](id.key)(ConfigDecoder.tracedValue(decoder))
@@ -106,7 +111,7 @@ trait BuilderContext[E <: Element] {
           if (traced.origin.scope == DirectiveScope || inherit) Some(traced.value)
           else None
         })
-        .left.map(e => Seq(s"error converting ${id.desc}: ${e.message}"))
+        .left.map(e => Seq(s"error converting ${id.desc}: ${message(e)}"))
     
   }
 

--- a/core/shared/src/main/scala/laika/rewrite/TemplateRewriter.scala
+++ b/core/shared/src/main/scala/laika/rewrite/TemplateRewriter.scala
@@ -43,10 +43,11 @@ trait TemplateRewriter {
    */
   def applyTemplates (tree: DocumentTreeRoot, context: TemplateContext): Either[ConfigError, DocumentTreeRoot] = {
     
-    val cursor = RootCursor(tree, Some(context.finalFormat))
-    
     for {
-      newCover <- cursor.coverDocument.filter(shouldRender(context.finalFormat)).traverse(applyTemplate(_, context))
+      cursor   <- RootCursor(tree, Some(context.finalFormat))
+      newCover <- cursor.coverDocument
+                    .filter(shouldRender(context.finalFormat))
+                    .traverse(applyTemplate(_, context))
       newTree  <- applyTemplates(cursor.tree, context)
     } yield {
       cursor.target.copy(

--- a/core/shared/src/main/scala/laika/rewrite/nav/PathTranslator.scala
+++ b/core/shared/src/main/scala/laika/rewrite/nav/PathTranslator.scala
@@ -106,12 +106,14 @@ private[laika] case class TranslatorConfig(versions: Option[Versions],
 
 private[laika] object TranslatorConfig {
   def readFrom (config: Config): ConfigResult[TranslatorConfig] = for {
-    versions <- config.getOpt[Versions]
-    siteBaseURL <- config.getOpt[String](LaikaKeys.siteBaseURL)
-  } yield TranslatorConfig(versions, TitleDocumentConfig.inputName(config), TitleDocumentConfig.outputName(config), siteBaseURL)
+    versions           <- config.getOpt[Versions]
+    titleDocInputName  <- TitleDocumentConfig.inputName(config)
+    titleDocOutputName <- TitleDocumentConfig.outputName(config)
+    siteBaseURL        <- config.getOpt[String](LaikaKeys.siteBaseURL)
+  } yield TranslatorConfig(versions, titleDocInputName, titleDocOutputName, siteBaseURL)
   
   val empty: TranslatorConfig = 
-    TranslatorConfig(None, TitleDocumentConfig.inputName(Config.empty), TitleDocumentConfig.outputName(Config.empty), None)
+    TranslatorConfig(None, TitleDocumentConfig.defaultInputName, TitleDocumentConfig.defaultOutputName, None)
 }
 
 private[laika] class TargetLookup (cursor: RootCursor) extends (Path => Option[TranslatorSpec]) {

--- a/core/shared/src/main/scala/laika/rewrite/nav/SectionBuilder.scala
+++ b/core/shared/src/main/scala/laika/rewrite/nav/SectionBuilder.scala
@@ -16,8 +16,10 @@
 
 package laika.rewrite.nav
 
+import laika.ast.RewriteRules.RewriteRulesBuilder
 import laika.ast._
 import laika.collection.Stack
+import laika.config.Config.ConfigResult
 import laika.config.LaikaKeys
 import laika.parse.GeneratedSource
 import laika.rewrite.nav
@@ -29,7 +31,7 @@ import scala.collection.mutable.ListBuffer
   * 
   * @author Jens Halm
   */
-object SectionBuilder extends (DocumentCursor => RewriteRules) {
+object SectionBuilder extends RewriteRulesBuilder {
 
   
   class DefaultRule (cursor: DocumentCursor) {
@@ -123,6 +125,6 @@ object SectionBuilder extends (DocumentCursor => RewriteRules) {
   /** Provides the default rewrite rules for building the section structure
    *  for the specified document (without applying them).
    */
-  def apply (cursor: DocumentCursor): RewriteRules = new DefaultRule(cursor).rewrite
+  def apply (cursor: DocumentCursor): ConfigResult[RewriteRules] = Right(new DefaultRule(cursor).rewrite)
   
 }

--- a/core/shared/src/main/scala/laika/rewrite/nav/TitleDocumentConfig.scala
+++ b/core/shared/src/main/scala/laika/rewrite/nav/TitleDocumentConfig.scala
@@ -16,6 +16,7 @@
 
 package laika.rewrite.nav
 
+import laika.config.Config.ConfigResult
 import laika.config.{Config, LaikaKeys}
 
 /** Configuration for the names of title documents in the input and output trees.
@@ -24,17 +25,17 @@ import laika.config.{Config, LaikaKeys}
   */
 object TitleDocumentConfig {
 
-  private val defaultInputName: String = "README"
-  private val defaultOutputName: String = "index"
+  val defaultInputName: String = "README"
+  val defaultOutputName: String = "index"
 
   /** The name to denote a title document in an input tree as configured in the specified instance.
     */
-  def inputName (config: Config): String =
-    config.get[String](LaikaKeys.titleDocuments.inputName).toOption.getOrElse(defaultInputName)
+  def inputName (config: Config): ConfigResult[String] =
+    config.get[String](LaikaKeys.titleDocuments.inputName, defaultInputName)
 
   /** The name to assign to a title document before rendering as configured in the specified instance.
     */
-  def outputName (config: Config): String =
-    config.get[String](LaikaKeys.titleDocuments.outputName).toOption.getOrElse(defaultOutputName)
+  def outputName (config: Config): ConfigResult[String] =
+    config.get[String](LaikaKeys.titleDocuments.outputName, defaultOutputName)
 
 }

--- a/core/shared/src/main/scala/laika/rst/bundle/RewriteRules.scala
+++ b/core/shared/src/main/scala/laika/rst/bundle/RewriteRules.scala
@@ -16,7 +16,9 @@
 
 package laika.rst.bundle
 
+import laika.ast.RewriteRules.RewriteRulesBuilder
 import laika.ast._
+import laika.config.Config.ConfigResult
 import laika.parse.SourceFragment
 import laika.rst.ast.{CustomizedTextRole, InterpretedText, SubstitutionDefinition, SubstitutionReference}
 import laika.rst.ext.TextRoles.TextRole
@@ -29,7 +31,7 @@ import laika.rst.ext.TextRoles.TextRole
  * 
  *  @author Jens Halm
  */
-class RewriteRules (textRoles: Seq[TextRole]) extends (DocumentCursor => laika.ast.RewriteRules) {
+class RewriteRules (textRoles: Seq[TextRole]) extends RewriteRulesBuilder {
 
   val baseRoleElements: Map[String, String => Span] = textRoles.map { role => (role.name, role.default) }.toMap
 
@@ -60,7 +62,7 @@ class RewriteRules (textRoles: Seq[TextRole]) extends (DocumentCursor => laika.a
    *  for the specified document. These rules usually get executed
    *  alongside the generic default rules.
    */
-  def apply (cursor: DocumentCursor): laika.ast.RewriteRules = new DefaultRules(cursor).rewrite
+  def apply (cursor: DocumentCursor): ConfigResult[laika.ast.RewriteRules] = Right(new DefaultRules(cursor).rewrite)
   
   
 }

--- a/core/shared/src/main/scala/laika/rst/bundle/RstExtensionSupport.scala
+++ b/core/shared/src/main/scala/laika/rst/bundle/RstExtensionSupport.scala
@@ -16,6 +16,7 @@
 
 package laika.rst.bundle
 
+import laika.ast.RewriteRules.RewriteRulesBuilder
 import laika.ast.{Block, DocumentCursor, RewriteRule, Span}
 import laika.bundle.{BundleOrigin, ExtensionBundle, ParserBundle}
 import laika.parse.markup.RecursiveParsers
@@ -42,7 +43,7 @@ class RstExtensionSupport (blockDirectives: Seq[Directive[Block]],
   
   override val useInStrictMode: Boolean = true
 
-  override def rewriteRules: Seq[DocumentCursor => laika.ast.RewriteRules] = Seq(new RewriteRules(textRoles))
+  override def rewriteRules: Seq[RewriteRulesBuilder] = Seq(new RewriteRules(textRoles))
 
   override lazy val parsers: ParserBundle = ParserBundle(
     blockParsers = Seq(

--- a/core/shared/src/test/scala/laika/api/ParseAPISpec.scala
+++ b/core/shared/src/test/scala/laika/api/ParseAPISpec.scala
@@ -93,11 +93,13 @@ class ParseAPISpec extends AnyFlatSpec
                   |
                   |[invalid2]""".stripMargin
     val doc = MarkupParser.of(Markdown).build.parseUnresolved(input).toOption.get.document
-    doc.rewrite(TemplateRewriter.rewriteRules(DocumentCursor(doc))).content should be (RootElement(
-      p(InvalidSpan("Unresolved link id reference 'invalid1'", source("[invalid1]", input, defaultPath))),
-      p("Text"),
-      p(InvalidSpan("Unresolved link id reference 'invalid2'", source("[invalid2]", input, defaultPath))),
-    ))
+    DocumentCursor(doc)
+      .flatMap(cursor => doc.rewrite(TemplateRewriter.rewriteRules(cursor)))
+      .map(_.content) should be (Right(RootElement(
+        p(InvalidSpan("Unresolved link id reference 'invalid1'", source("[invalid1]", input, defaultPath))),
+        p("Text"),
+        p(InvalidSpan("Unresolved link id reference 'invalid2'", source("[invalid2]", input, defaultPath))),
+      )))
   }
   
 }

--- a/core/shared/src/test/scala/laika/api/TransformAPISpec.scala
+++ b/core/shared/src/test/scala/laika/api/TransformAPISpec.scala
@@ -75,9 +75,9 @@ class TransformAPISpec extends AnyFlatSpec
   
   it should "allow to specify a custom rewrite rule that depends on the document" in {
     val modifiedOutput = output.replace("zzz", "2")
-    val transformCustom = builder creatingRule { cursor => RewriteRules.forSpans { 
+    val transformCustom = builder.buildingRule { cursor => Right(RewriteRules.forSpans { 
       case Text("text zzz ",_) => Replace(Text("text " + cursor.target.content.content.length + " ")) 
-    }}
+    })}
     transformCustom.build.transform(input).toOption.get should be (modifiedOutput)
   }
 

--- a/core/shared/src/test/scala/laika/ast/DocumentAPISpec.scala
+++ b/core/shared/src/test/scala/laika/ast/DocumentAPISpec.scala
@@ -31,7 +31,7 @@ class DocumentAPISpec extends AnyFlatSpec
   with ParagraphCompanionShortcuts {
 
 
-  val defaultParser = MarkupParser.of(Markdown).build
+  val defaultParser: MarkupParser = MarkupParser.of(Markdown).build
 
   "The Document API" should "allow to specify a title in a config section" in {
     val markup = """{% laika.title: Foo and Bar %}
@@ -95,8 +95,8 @@ class DocumentAPISpec extends AnyFlatSpec
     
     val doc = defaultParser.parseUnresolved(markup).toOption.get.document
 
-    val rewritten1 = OperationConfig.default.rewriteRulesFor(doc).map(doc.rewrite)
-    val rewritten2 = rewritten1.flatMap(doc => OperationConfig.default.rewriteRulesFor(doc).map(doc.rewrite))
+    val rewritten1 = OperationConfig.default.rewriteRulesFor(doc).flatMap(doc.rewrite)
+    val rewritten2 = rewritten1.flatMap(doc => OperationConfig.default.rewriteRulesFor(doc).flatMap(doc.rewrite))
     rewritten1.map(_.content) should be (rewritten2.map(_.content))
   }
 
@@ -117,7 +117,7 @@ class DocumentAPISpec extends AnyFlatSpec
     }
     val rewritten = OperationConfig.default
       .rewriteRulesFor(raw.copy(position = TreePosition.root))
-      .map(r => raw.rewrite(testRule ++ r))
+      .flatMap(r => raw.rewrite(testRule ++ r))
     rewritten.map(_.content) should be (Right(RootElement(
       Title(List(Text("Title")), Id("title") + Style.title),
       Section(Header(1, List(Text("Section 1")), Id("section-1") + Style.section), List(p("Swapped"))),

--- a/core/shared/src/test/scala/laika/ast/DocumentTreeAPISpec.scala
+++ b/core/shared/src/test/scala/laika/ast/DocumentTreeAPISpec.scala
@@ -75,9 +75,9 @@ class DocumentTreeAPISpec extends AnyFlatSpec
     new TreeModel {
       val tree     = treeWithDoc(Root, "doc", rootElement(p("a")))
       val expected = treeWithDoc(Root, "doc", rootElement(p("/")))
-      tree.rewrite { cursor => RewriteRules.forBlocks { 
+      tree.rewrite { cursor => Right(RewriteRules.forBlocks { 
         case Paragraph(Seq(Text("a",_)),_) => Replace(p(cursor.root.target.tree.path.toString)) 
-      }}.assertEquals(expected)
+      })}.assertEquals(expected)
     }
   }
   
@@ -85,9 +85,9 @@ class DocumentTreeAPISpec extends AnyFlatSpec
     new TreeModel {
       val tree     = treeWithDoc(Root, "doc", rootElement(p("a")))
       val expected = treeWithDoc(Root, "doc", rootElement(p("/")))
-      tree.rewrite { cursor => RewriteRules.forBlocks { 
+      tree.rewrite { cursor => Right(RewriteRules.forBlocks { 
         case Paragraph(Seq(Text("a",_)),_) => Replace(p(cursor.parent.target.path.toString)) 
-      }}.assertEquals(expected)
+      })}.assertEquals(expected)
     }
   }
   
@@ -95,9 +95,9 @@ class DocumentTreeAPISpec extends AnyFlatSpec
     new TreeModel {
       val tree     = treeWithSubtree(Root, "sub", "doc", rootElement(p("a")))
       val expected = treeWithSubtree(Root, "sub", "doc", rootElement(p("/")))
-      tree.rewrite { cursor => RewriteRules.forBlocks { 
+      tree.rewrite { cursor => Right(RewriteRules.forBlocks { 
         case Paragraph(Seq(Text("a",_)),_) => Replace(p(cursor.root.target.tree.path.toString)) 
-      }}.assertEquals(expected)
+      })}.assertEquals(expected)
     }
   }
   
@@ -105,9 +105,9 @@ class DocumentTreeAPISpec extends AnyFlatSpec
     new TreeModel {
       val tree     = treeWithSubtree(Root, "sub", "doc", rootElement(p("a")))
       val expected = treeWithSubtree(Root, "sub", "doc", rootElement(p("/sub")))
-      tree.rewrite { cursor => RewriteRules.forBlocks { 
+      tree.rewrite { cursor => Right(RewriteRules.forBlocks { 
         case Paragraph(Seq(Text("a",_)),_) => Replace(p(cursor.parent.target.path.toString)) 
-      }}.assertEquals(expected)
+      })}.assertEquals(expected)
     }
   }
 
@@ -214,11 +214,11 @@ class DocumentTreeAPISpec extends AnyFlatSpec
   it should "allow to rewrite the tree using a custom rule" in {
     new TreeModel {
       val tree = treeWithSubtree(Root, "sub", "doc", rootElement(p("a")))
-      val rewritten = tree rewrite { _ => RewriteRules.forSpans {
+      val rewritten = tree rewrite { _ => Right(RewriteRules.forSpans {
         case Text("a",_) => Replace(Text("x"))
-      }}
-      val target = rewritten.selectDocument("sub/doc")
-      target.get.content should be (RootElement(p("x"), p("b"), p("c")))
+      })}
+      val target = rewritten.map(_.selectDocument("sub/doc").map(_.content))
+      target should be (Right(Some(RootElement(p("x"), p("b"), p("c")))))
     }
   }
 

--- a/core/shared/src/test/scala/laika/ast/sample/DocumentTreeAssertions.scala
+++ b/core/shared/src/test/scala/laika/ast/sample/DocumentTreeAssertions.scala
@@ -17,11 +17,34 @@
 package laika.ast.sample
 
 import laika.ast.{Document, DocumentTree, DocumentTreeRoot, TemplateDocument}
+import laika.config.Config.ConfigResult
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 
 trait DocumentTreeAssertions extends Matchers {
 
+  implicit class DocumentTreeRootEitherOps (val root: ConfigResult[DocumentTreeRoot]) {
+
+    def assertEquals (expected: DocumentTreeRoot): Unit = {
+      root.fold(
+        err  => fail(s"rewriting failed: $err"), 
+        root => root.assertEquals(expected)
+      )
+    }
+    
+  }
+
+  implicit class DocumentTreeEitherOps (val root: ConfigResult[DocumentTree]) {
+
+    def assertEquals (expected: DocumentTree): Unit = {
+      root.fold(
+        err  => fail(s"rewriting failed: $err"),
+        root => root.assertEquals(expected)
+      )
+    }
+
+  }
+  
   implicit class DocumentTreeRootOps (val root: DocumentTreeRoot) {
 
     def assertEquals (expected: DocumentTreeRoot): Unit = {

--- a/core/shared/src/test/scala/laika/ast/sample/SampleTrees.scala
+++ b/core/shared/src/test/scala/laika/ast/sample/SampleTrees.scala
@@ -18,7 +18,7 @@ package laika.ast.sample
 
 import laika.ast.Path.Root
 import laika.ast._
-import laika.config.{Config, ConfigBuilder, LaikaKeys, Origin}
+import laika.config.{Config, ConfigBuilder, LaikaKeys, Origin, TreeConfigErrors}
 
 object SampleTrees {
 
@@ -188,7 +188,7 @@ class SampleTwoDocuments (protected val sampleRoot: SampleRoot) extends SampleRo
     tree = buildTree(0, 0, Config.empty),
     staticDocuments = sampleRoot.staticDocuments
   )
-  def buildCursor: RootCursor = RootCursor(build)
+  def buildCursor: Either[TreeConfigErrors, RootCursor] = RootCursor(build)
 }
 
 class SampleSixDocuments (protected val sampleRoot: SampleRoot) extends SampleRootOps { self =>
@@ -235,7 +235,7 @@ class SampleSixDocuments (protected val sampleRoot: SampleRoot) extends SampleRo
     )
   }
   
-  def buildCursor: RootCursor = RootCursor(build)
+  def buildCursor: Either[TreeConfigErrors, RootCursor] = RootCursor(build)
 }
 
 private[sample] case class SampleRoot (treeBuilders: IndexedSeq[SampleTree],

--- a/core/shared/src/test/scala/laika/bundle/BundleProvider.scala
+++ b/core/shared/src/test/scala/laika/bundle/BundleProvider.scala
@@ -16,6 +16,7 @@
 
 package laika.bundle
 
+import laika.ast.RewriteRules.RewriteRulesBuilder
 import laika.config.{Config, ConfigParser}
 import laika.ast._
 import laika.directive.{DirectiveRegistry, Templates}
@@ -91,13 +92,13 @@ object BundleProvider {
 
   def forSpanRewriteRule (rule: RewriteRule[Span]): ExtensionBundle = new TestExtensionBundle() {
 
-    override def rewriteRules: Seq[DocumentCursor => RewriteRules] = Seq(_ => laika.ast.RewriteRules.forSpans(rule))
+    override def rewriteRules: Seq[RewriteRulesBuilder] = Seq(_ => Right(laika.ast.RewriteRules.forSpans(rule)))
 
   }
 
   def forSpanRewriteRule (origin: BundleOrigin)(rule: RewriteRule[Span]): ExtensionBundle = new TestExtensionBundle(origin) {
 
-    override def rewriteRules: Seq[DocumentCursor => RewriteRules] = Seq(_ => laika.ast.RewriteRules.forSpans(rule))
+    override def rewriteRules: Seq[RewriteRulesBuilder] = Seq(_ => Right(laika.ast.RewriteRules.forSpans(rule)))
 
   }
 

--- a/core/shared/src/test/scala/laika/config/ConfigCodecSpec.scala
+++ b/core/shared/src/test/scala/laika/config/ConfigCodecSpec.scala
@@ -107,7 +107,7 @@ class ConfigCodecSpec extends AnyWordSpec with Matchers {
         """.stripMargin
       val res = decode[DocumentMetadata](input)
       res.isLeft shouldBe true
-      res.left.toOption.get.asInstanceOf[DecodingError].message should startWith("Invalid date format")
+      res.left.toOption.get.asInstanceOf[DecodingError].message should startWith("Error decoding 'laika.metadata.date': Invalid date format")
     }
 
   }

--- a/core/shared/src/test/scala/laika/config/OperationConfigSpec.scala
+++ b/core/shared/src/test/scala/laika/config/OperationConfigSpec.scala
@@ -154,8 +154,7 @@ class OperationConfigSpec extends AnyWordSpec with Matchers {
 
       val expected = Document(Root, RootElement(Literal("foo"), Literal("bar")))
 
-      val rewriteRule = config.rewriteRulesFor(doc)
-      doc.rewrite(rewriteRule) shouldBe expected
+      config.rewriteRulesFor(doc).map(doc.rewrite) shouldBe Right(expected)
     }
 
     "apply a rewrite rule from an app config and a rule from a markup extension successively" in new BundleSetup {
@@ -165,8 +164,7 @@ class OperationConfigSpec extends AnyWordSpec with Matchers {
       val doc =      Document(Root, RootElement(Literal("foo")))
       val expected = Document(Root, RootElement(Literal("foo!?")))
 
-      val rewriteRule = config.rewriteRulesFor(doc)
-      doc.rewrite(rewriteRule) shouldBe expected
+      config.rewriteRulesFor(doc).map(doc.rewrite) shouldBe Right(expected)
     }
 
     "apply a rewrite rule from an app config and a rule from a previously installed app config successively" in new BundleSetup {
@@ -179,8 +177,7 @@ class OperationConfigSpec extends AnyWordSpec with Matchers {
       val doc =      Document(Root, RootElement(Literal("foo")))
       val expected = Document(Root, RootElement(Literal("foo!?")))
 
-      val rewriteRule = config.rewriteRulesFor(doc)
-      doc.rewrite(rewriteRule) shouldBe expected
+      val rewriteRule = config.rewriteRulesFor(doc).map(doc.rewrite) shouldBe Right(expected)
     }
 
   }

--- a/core/shared/src/test/scala/laika/config/OperationConfigSpec.scala
+++ b/core/shared/src/test/scala/laika/config/OperationConfigSpec.scala
@@ -154,7 +154,7 @@ class OperationConfigSpec extends AnyWordSpec with Matchers {
 
       val expected = Document(Root, RootElement(Literal("foo"), Literal("bar")))
 
-      config.rewriteRulesFor(doc).map(doc.rewrite) shouldBe Right(expected)
+      config.rewriteRulesFor(doc).flatMap(doc.rewrite) shouldBe Right(expected)
     }
 
     "apply a rewrite rule from an app config and a rule from a markup extension successively" in new BundleSetup {
@@ -164,7 +164,7 @@ class OperationConfigSpec extends AnyWordSpec with Matchers {
       val doc =      Document(Root, RootElement(Literal("foo")))
       val expected = Document(Root, RootElement(Literal("foo!?")))
 
-      config.rewriteRulesFor(doc).map(doc.rewrite) shouldBe Right(expected)
+      config.rewriteRulesFor(doc).flatMap(doc.rewrite) shouldBe Right(expected)
     }
 
     "apply a rewrite rule from an app config and a rule from a previously installed app config successively" in new BundleSetup {
@@ -177,7 +177,7 @@ class OperationConfigSpec extends AnyWordSpec with Matchers {
       val doc =      Document(Root, RootElement(Literal("foo")))
       val expected = Document(Root, RootElement(Literal("foo!?")))
 
-      val rewriteRule = config.rewriteRulesFor(doc).map(doc.rewrite) shouldBe Right(expected)
+      config.rewriteRulesFor(doc).flatMap(doc.rewrite) shouldBe Right(expected)
     }
 
   }

--- a/core/shared/src/test/scala/laika/directive/BlockDirectiveAPISpec.scala
+++ b/core/shared/src/test/scala/laika/directive/BlockDirectiveAPISpec.scala
@@ -149,10 +149,10 @@ class BlockDirectiveAPISpec extends AnyFlatSpec
     lazy val defaultParser: Parser[RootElement] = RootParserProvider.forParsers(
       blockParsers = Seq(paragraphParser),
       markupExtensions = directiveSupport.markupExtensions
-    ).rootElement.map { root =>
-      TemplateRewriter.rewriteRules(DocumentCursor(
-        Document(Root, root, config = ConfigBuilder.empty.withValue("ref", "value").build)
-      )).rewriteBlock(root).asInstanceOf[RootElement]
+    ).rootElement.evalMap { root =>
+      DocumentCursor(Document(Root, root, config = ConfigBuilder.empty.withValue("ref", "value").build))
+        .map(c => TemplateRewriter.rewriteRules(c).rewriteBlock(root).asInstanceOf[RootElement])
+        .left.map(_.message)
     }
 
     def invalid (fragment: String, error: String): InvalidBlock = InvalidBlock(error, source(fragment, input))

--- a/core/shared/src/test/scala/laika/directive/SpanDirectiveAPISpec.scala
+++ b/core/shared/src/test/scala/laika/directive/SpanDirectiveAPISpec.scala
@@ -165,11 +165,11 @@ class SpanDirectiveAPISpec extends AnyFlatSpec
     
     lazy val defaultParser: Parser[Span] = RootParserProvider.forParsers(
       markupExtensions = directiveSupport.markupExtensions
-    ).standaloneSpanParser.map { spans =>
+    ).standaloneSpanParser.evalMap { spans =>
       val seq = SpanSequence(spans)
-      TemplateRewriter.rewriteRules(DocumentCursor(
-        Document(Root, RootElement(seq), config = ConfigBuilder.empty.withValue("ref","value").build)
-      )).rewriteSpan(seq)
+      DocumentCursor(Document(Root, RootElement(seq), config = ConfigBuilder.empty.withValue("ref", "value").build))
+        .map(c => TemplateRewriter.rewriteRules(c).rewriteSpan(seq))
+        .left.map(_.message)
     }
 
     def invalid (fragment: String, error: String): InvalidSpan = InvalidSpan(error, source(fragment, input))

--- a/core/shared/src/test/scala/laika/directive/TemplateDirectiveAPISpec.scala
+++ b/core/shared/src/test/scala/laika/directive/TemplateDirectiveAPISpec.scala
@@ -143,11 +143,11 @@ class TemplateDirectiveAPISpec extends AnyFlatSpec
 
     val templateParsers = new TemplateParsers(Map(directive.name -> directive))
     
-    val defaultParser: Parser[TemplateRoot] = templateParsers.templateSpans.map { spans =>
+    val defaultParser: Parser[TemplateRoot] = templateParsers.templateSpans.evalMap { spans =>
       val root = TemplateRoot(spans)
-      TemplateRewriter.rewriteRules(DocumentCursor(
-        Document(Root, RootElement(root), config = ConfigBuilder.empty.withValue("ref","value").build)
-      )).rewriteBlock(root).asInstanceOf[TemplateRoot]
+      DocumentCursor(Document(Root, RootElement(root), config = ConfigBuilder.empty.withValue("ref", "value").build))
+        .map(c => TemplateRewriter.rewriteRules(c).rewriteBlock(root).asInstanceOf[TemplateRoot])
+        .left.map(_.message)
     }
     
   }

--- a/core/shared/src/test/scala/laika/directive/std/HTMLHeadDirectiveSpec.scala
+++ b/core/shared/src/test/scala/laika/directive/std/HTMLHeadDirectiveSpec.scala
@@ -16,6 +16,7 @@
 
 package laika.directive.std
 
+import cats.syntax.all._
 import laika.api.builder.OperationConfig
 import laika.ast.Path.Root
 import laika.ast.RelativePath.CurrentTree
@@ -49,9 +50,11 @@ class HTMLHeadDirectiveSpec extends AnyFlatSpec
     
     def applyTemplate(root: TemplateRoot): Either[String, DocumentTreeRoot] = {
       val inputTree = buildTree(Some(templatePath.name, root.content))
-      val tree = inputTree.rewrite(OperationConfig.default.rewriteRulesFor(DocumentTreeRoot(inputTree)))
-      val treeRoot = DocumentTreeRoot(tree, staticDocuments = static)
-      TemplateRewriter.applyTemplates(treeRoot, ctx).left.map(_.message)
+      for {
+        tree     <- inputTree.rewrite(OperationConfig.default.rewriteRulesFor(DocumentTreeRoot(inputTree))).leftMap(_.message)
+        treeRoot =  DocumentTreeRoot(tree, staticDocuments = static)
+        result   <- TemplateRewriter.applyTemplates(treeRoot, ctx).leftMap(_.message)
+      } yield result
     }
     
     for {

--- a/core/shared/src/test/scala/laika/directive/std/NavigationDirectiveSpec.scala
+++ b/core/shared/src/test/scala/laika/directive/std/NavigationDirectiveSpec.scala
@@ -323,7 +323,7 @@ class NavigationDirectiveSpec extends AnyFlatSpec
     val template =
       s"""aaa $directive bbb $${cursor.currentDocument.content}""".stripMargin
 
-    val msg = "One or more errors processing directive 'navigationTree': One or more errors decoding array elements: not an integer: foo"
+    val msg = "One or more errors processing directive 'navigationTree': Error decoding 'entries': One or more errors decoding array elements: Error decoding 'depth': not an integer: foo"
     parseTemplateAndRewrite(template) shouldBe Right(error(msg, directive, template))
   }
 
@@ -338,7 +338,7 @@ class NavigationDirectiveSpec extends AnyFlatSpec
     val template =
       s"""aaa $directive bbb $${cursor.currentDocument.content}""".stripMargin
 
-    val msg = "One or more errors processing directive 'navigationTree': One or more errors decoding array elements: Not found: 'title'"
+    val msg = "One or more errors processing directive 'navigationTree': Error decoding 'entries': One or more errors decoding array elements: Not found: 'title'"
     parseTemplateAndRewrite(template) shouldBe Right(error(msg, directive, template))
   }
 

--- a/core/shared/src/test/scala/laika/directive/std/SelectDirectiveSpec.scala
+++ b/core/shared/src/test/scala/laika/directive/std/SelectDirectiveSpec.scala
@@ -19,7 +19,6 @@ package laika.directive.std
 import laika.api.MarkupParser
 import laika.ast.Path.Root
 import laika.ast._
-import laika.ast.sample.TestSourceBuilders
 import laika.ast.sample.{ParagraphCompanionShortcuts, TestSourceBuilders}
 import laika.config.ConfigBuilder
 import laika.format.Markdown
@@ -34,7 +33,7 @@ class SelectDirectiveSpec extends AnyFlatSpec
   with TestSourceBuilders {
 
 
-  val parser = MarkupParser
+  private val parser = MarkupParser
     .of(Markdown)
     .failOnMessages(MessageFilter.None)
     .withConfigValue(Selections(
@@ -150,8 +149,8 @@ class SelectDirectiveSpec extends AnyFlatSpec
     )
     val doc = Document(Root / "doc", RootElement(group))
     val tree = DocumentTreeRoot(DocumentTree(Root, Seq(doc), config = ConfigBuilder.empty.withValue(config).build))
-    val cursor = DocumentCursor(doc, TreeCursor(RootCursor(tree)), tree.config, TreePosition(Nil))
-    val rewritten = TemplateRewriter.applyTemplate(cursor, TemplateDocument(Root, TemplateRoot.fallback))
+    val cursor = RootCursor(tree).map(TreeCursor.apply).map(DocumentCursor(doc, _, tree.config, TreePosition(Nil)))
+    val rewritten = cursor.flatMap(c => TemplateRewriter.applyTemplate(c, TemplateDocument(Root, TemplateRoot.fallback)))
     rewritten.map(_.content) shouldBe Right(RootElement(BlockSequence(List(p("common"), p("33\n44")))))
   }
   

--- a/core/shared/src/test/scala/laika/directive/std/TemplateParserSetup.scala
+++ b/core/shared/src/test/scala/laika/directive/std/TemplateParserSetup.scala
@@ -40,11 +40,13 @@ trait TemplateParserSetup {
     
     def rewriteTemplate (tRoot: TemplateRoot, config: Config): Either[String, RootElement] = {
       val template = TemplateDocument(Path.Root / "theme" / "test.template.html", tRoot)
-      val cursor   = DocumentCursor(Document(Path.Root / "docs" / "doc1.md", RootElement.empty, config = config))
-      TemplateRewriter
-        .applyTemplate(cursor, template)
-        .map(_.content)
-        .left.map(_.message)
+      val doc = Document(Path.Root / "docs" / "doc1.md", RootElement.empty, config = config)
+      DocumentCursor(doc).flatMap { cursor =>
+        TemplateRewriter
+          .applyTemplate(cursor, template)
+          .map(_.content)
+      }
+      .left.map(_.message)
     }
     
     for {

--- a/core/shared/src/test/scala/laika/rewrite/LinkValidatorSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/LinkValidatorSpec.scala
@@ -47,8 +47,8 @@ class LinkValidatorSpec extends AnyFunSuite with Matchers {
       .docContent(doc2 _)
       .suffix("md")
       .buildCursor // TODO - buildCursor should be available on doc6
-      .allDocuments
-      .find(_.path == Root / "tree-2" / "doc-6.md")
+      .toOption
+      .flatMap(_.allDocuments.find(_.path == Root / "tree-2" / "doc-6.md"))
       .get
   }
   

--- a/core/shared/src/test/scala/laika/rewrite/PathTranslatorSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/PathTranslatorSpec.scala
@@ -48,6 +48,7 @@ class PathTranslatorSpec extends AnyFunSuite with Matchers {
       .docContent(doc2 _)
       .suffix("md")
       .buildCursor
+      .getOrElse(fail("unable to create cursor"))
   }
 
   val translatorConfig = TranslatorConfig.readFrom(rootCursor.config).getOrElse(TranslatorConfig.empty)

--- a/core/shared/src/test/scala/laika/rewrite/RewriteRulesSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/RewriteRulesSpec.scala
@@ -44,7 +44,9 @@ class RewriteRulesSpec extends AnyWordSpec
     val config = if (withTitles) disableInternalLinkValidation.withValue(LaikaKeys.firstHeaderAsTitle, true).build
                  else disableInternalLinkValidation
     val doc = Document(Path.Root / "doc", root, config = config)
-    OperationConfig.default.rewriteRulesFor(doc).map(doc.rewrite(_).content)
+    OperationConfig.default
+      .rewriteRulesFor(doc)
+      .flatMap(doc.rewrite(_).map(_.content))
   }
   
   val refPath: Path = Root / "doc"

--- a/core/shared/src/test/scala/laika/rewrite/SectionNumberSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/SectionNumberSpec.scala
@@ -19,6 +19,7 @@ package laika.rewrite
 import laika.api.builder.OperationConfig
 import laika.ast._
 import laika.ast.sample.{BuilderKey, DocumentTreeAssertions, SampleTrees}
+import laika.config.Config.ConfigResult
 import laika.config.ConfigParser
 import laika.parse.GeneratedSource
 import org.scalatest.flatspec.AnyFlatSpec
@@ -87,7 +88,7 @@ class SectionNumberSpec extends AnyFlatSpec
         .tree
     }
 
-    lazy val result: DocumentTree = {
+    lazy val result: ConfigResult[DocumentTree] = {
       val docTree = tree(sections)
       docTree.rewrite(OperationConfig.default.rewriteRulesFor(DocumentTreeRoot(docTree)))
     }

--- a/core/shared/src/test/scala/laika/rewrite/SectionNumberSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/SectionNumberSpec.scala
@@ -184,11 +184,4 @@ class SectionNumberSpec extends AnyFlatSpec
     }
   }
 
-  it should "insert an invalid element for invalid configuration" in {
-    new SectionsWithConfigError with InvalidConfig {
-      result.assertEquals(expected)
-    }
-  }
-
-
 }

--- a/core/shared/src/test/scala/laika/rewrite/SelectionConfigSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/SelectionConfigSpec.scala
@@ -17,6 +17,7 @@
 package laika.rewrite
 
 import cats.data.{NonEmptyChain, NonEmptyVector}
+import cats.syntax.all._
 import laika.ast.Path
 import laika.ast.Path.Root
 import laika.config.Config.ConfigResult
@@ -44,33 +45,42 @@ class SelectionConfigSpec extends AnyWordSpec with Matchers {
   ))
   val selectionFooSeparate = selectionFoo.copy(separateEbooks = true)
   val selectionBarSeparate = selectionBar.copy(separateEbooks = true)
+  
+  private val epubCoverImgKey = LaikaKeys.root.child("epub").child(LaikaKeys.coverImage.local)
 
-  def run (config: Config): NonEmptyVector[ConfigResult[Selections]] =
-    Selections.createCombinations(config).toNonEmptyVector.map(_._1.get[Selections])
+  def run (config: Config): ConfigResult[NonEmptyVector[Selections]] = Selections
+    .createCombinations(config)
+    .map(_.toNonEmptyVector.map(_._1.get[Selections]).sequence)
+    .flatten
 
-  def runAndGetCoverImage (config: Config): NonEmptyVector[ConfigResult[Path]] =
-    Selections.createCombinations(config).toNonEmptyVector.map(_._1.get[Path](LaikaKeys.root.child("epub").child(LaikaKeys.coverImage.local)))
+  def runAndGetCoverImage (config: Config): ConfigResult[NonEmptyVector[Path]] = Selections
+    .createCombinations(config)
+    .map(_.toNonEmptyVector.map(_._1.get[Path](epubCoverImgKey)).sequence)
+    .flatten
 
   "Selections.createCombinations" should {
 
     "succeed with an empty config" in {
-      Selections.createCombinations(Config.empty) shouldBe NonEmptyChain.one((Config.empty, Classifiers(Nil)))
+      val result = Selections.createCombinations(Config.empty).map { result =>
+        (result.length, result.head._1.get[Selections], result.head._2)
+      }
+      result shouldBe Right((1, Right(Selections.empty), Classifiers(Nil)))
     }
 
     "succeed with no choice groups in the config" in {
       val config = ConfigBuilder.empty.withValue(Selections.empty).build
-      val result = Selections.createCombinations(config)
-      result.length shouldBe 1
-      val decoded = result.head._1.get[Selections]
-      decoded shouldBe Right(Selections.empty)
+      val result = Selections.createCombinations(config).map { result =>
+        (result.length, result.head._1.get[Selections])
+      }
+      result shouldBe Right((1, Right(Selections.empty)))
     }
 
     "succeed with a single choice group without separation" in {
       val config = ConfigBuilder.empty.withValue(Selections(selectionFoo)).build
-      val result = Selections.createCombinations(config)
-      result.length shouldBe 1
-      val decoded = result.head._1.get[Selections]
-      decoded shouldBe Right(Selections(selectionFoo))
+      val result = Selections.createCombinations(config).map { result =>
+        (result.length, result.head._1.get[Selections])
+      }
+      result shouldBe Right((1, Right(Selections(selectionFoo))))
     }
 
     "succeed with a single choice group with separation" in {
@@ -88,9 +98,7 @@ class SelectionConfigSpec extends AnyWordSpec with Matchers {
           ChoiceConfig("foo-b", "foo-label-b", selected = true)
         ).withSeparateEbooks
       )
-      result.length shouldBe 2
-      result.get(0) shouldBe Some(Right(expectedGroup1))
-      result.get(1) shouldBe Some(Right(expectedGroup2))
+      result shouldBe Right(NonEmptyVector.of(expectedGroup1, expectedGroup2))
     }
 
     "succeed with a two choice groups with separation and one without" in {
@@ -105,12 +113,7 @@ class SelectionConfigSpec extends AnyWordSpec with Matchers {
       def groups (selectIn1: Int, selectIn2: Int): Selections = Selections(
         select(selectionFooSeparate, selectIn1), select(selectionBarSeparate, selectIn2), selectionBaz
       )
-
-      result.length shouldBe 4
-      result.get(0) shouldBe Some(Right(groups(0,0)))
-      result.get(1) shouldBe Some(Right(groups(0,1)))
-      result.get(2) shouldBe Some(Right(groups(1,0)))
-      result.get(3) shouldBe Some(Right(groups(1,1)))
+      result shouldBe Right(NonEmptyVector.of(groups(0,0), groups(0,1), groups(1,0), groups(1,1)))
     }
 
     "should use per-classifier cover image configuration" in {
@@ -120,9 +123,7 @@ class SelectionConfigSpec extends AnyWordSpec with Matchers {
         .withValue(LaikaKeys.coverImages, Seq(CoverImage(Root / "foo-a.png", "foo-a"), CoverImage(Root / "foo-b.png", "foo-b")))
         .build
       val result = runAndGetCoverImage(config)
-      result.length shouldBe 2
-      result.get(0) shouldBe Some(Right(Root / "foo-a.png"))
-      result.get(1) shouldBe Some(Right(Root / "foo-b.png"))
+      result shouldBe Right(NonEmptyVector.of(Root / "foo-a.png", Root / "foo-b.png"))
     }
 
     "should use the default cover image if none has been specified for a classifier" in {
@@ -132,9 +133,7 @@ class SelectionConfigSpec extends AnyWordSpec with Matchers {
         .withValue(LaikaKeys.coverImage, defaultPath)
         .build
       val result = runAndGetCoverImage(config)
-      result.length shouldBe 2
-      result.get(0) shouldBe Some(Right(defaultPath))
-      result.get(1) shouldBe Some(Right(defaultPath))
+      result shouldBe Right(NonEmptyVector.of(defaultPath, defaultPath))
     }
   }
 

--- a/core/shared/src/test/scala/laika/rst/bundle/RewriteRulesSpec.scala
+++ b/core/shared/src/test/scala/laika/rst/bundle/RewriteRulesSpec.scala
@@ -19,6 +19,7 @@ package laika.rst.bundle
 import laika.api.builder.OperationConfig
 import laika.ast._
 import laika.ast.sample.ParagraphCompanionShortcuts
+import laika.config.Config.ConfigResult
 import laika.format.ReStructuredText
 import laika.parse.GeneratedSource
 import laika.rst.ast.{CustomizedTextRole, InterpretedText, SubstitutionDefinition, SubstitutionReference}
@@ -30,10 +31,13 @@ class RewriteRulesSpec extends AnyFlatSpec
                   with ParagraphCompanionShortcuts {
 
   
-  def rewritten (root: RootElement): RootElement = {
+  def rewritten (root: RootElement): ConfigResult[RootElement] = {
     val doc = Document(Path.Root, root)
-    val rules = OperationConfig.default.withBundlesFor(ReStructuredText).rewriteRulesFor(doc)
-    doc.rewrite(rules).content
+    OperationConfig.default
+      .withBundlesFor(ReStructuredText)
+      .rewriteRulesFor(doc)
+      .map(doc.rewrite)
+      .map(_.content)
   }
   
   def invalidSpan (message: String): InvalidSpan = InvalidSpan(message, GeneratedSource)
@@ -41,7 +45,7 @@ class RewriteRulesSpec extends AnyFlatSpec
       
   "The rewrite rules for substitutions" should "replace a single reference with the target span" in {
     val rootElem = RootElement(p(SubstitutionReference("id", GeneratedSource)), SubstitutionDefinition("id", Text("subst")))
-    rewritten (rootElem) should be (RootElement(p("subst")))
+    rewritten (rootElem) should be (Right(RootElement(p("subst"))))
   }
   
   it should "replace multiple occurrences of the same reference with the same target span" in {
@@ -53,7 +57,7 @@ class RewriteRulesSpec extends AnyFlatSpec
       ), 
       SubstitutionDefinition("id", Text("subst"))
     )
-    rewritten (rootElem) should be (RootElement(p(Text("subst"),Text(" foo "),Text("subst"))))
+    rewritten (rootElem) should be (Right(RootElement(p(Text("subst"),Text(" foo "),Text("subst")))))
   }
   
   it should "replace a reference with an unknown substitution id with an invalid span" in {
@@ -61,13 +65,13 @@ class RewriteRulesSpec extends AnyFlatSpec
       p(SubstitutionReference("id1", GeneratedSource)), 
       SubstitutionDefinition("id2", Text("subst"))
     )
-    rewritten (rootElem) should be (RootElement(p(invalidSpan("unknown substitution id: id1"))))
+    rewritten (rootElem) should be (Right(RootElement(p(invalidSpan("unknown substitution id: id1")))))
   }
   
   
   "The rewrite rules for interpreted text roles" should "replace a single reference with the result of applying the role function" in {
     val rootElem = RootElement(p(InterpretedText("id", "foo", GeneratedSource)), CustomizedTextRole("id", s => Text(s":$s:")))
-    rewritten (rootElem) should be (RootElement(p(":foo:")))
+    rewritten (rootElem) should be (Right(RootElement(p(":foo:"))))
   }
   
   it should "replace multiple references with the result of applying corresponding role functions" in {
@@ -80,7 +84,7 @@ class RewriteRulesSpec extends AnyFlatSpec
       CustomizedTextRole("id1", s => Text(":"+s+":")),
       CustomizedTextRole("id2", s => Text(s".$s."))
     )
-    rewritten (rootElem) should be (RootElement(p(Text(":foo:"),Text(".bar."),Text(":baz:"))))
+    rewritten (rootElem) should be (Right(RootElement(p(Text(":foo:"),Text(".bar."),Text(":baz:")))))
   }
   
   it should "replace an unknown text role with an invalid span" in {
@@ -88,7 +92,7 @@ class RewriteRulesSpec extends AnyFlatSpec
       p(InterpretedText("id1", "foo", GeneratedSource)), 
       CustomizedTextRole("id2", s => Text(s".$s."))
     )
-    rewritten (rootElem) should be (RootElement(p(invalidSpan("unknown text role: id1"))))
+    rewritten (rootElem) should be (Right(RootElement(p(invalidSpan("unknown text role: id1")))))
   }
   
   

--- a/core/shared/src/test/scala/laika/rst/bundle/RewriteRulesSpec.scala
+++ b/core/shared/src/test/scala/laika/rst/bundle/RewriteRulesSpec.scala
@@ -36,7 +36,7 @@ class RewriteRulesSpec extends AnyFlatSpec
     OperationConfig.default
       .withBundlesFor(ReStructuredText)
       .rewriteRulesFor(doc)
-      .map(doc.rewrite)
+      .flatMap(doc.rewrite)
       .map(_.content)
   }
   

--- a/docs/src/04-customizing-laika/05-ast-rewriting.md
+++ b/docs/src/04-customizing-laika/05-ast-rewriting.md
@@ -94,18 +94,18 @@ Once again we are turning all `Emphasized` nodes in the text to `Strong` nodes f
 ```scala
 val doc: Document = ??? // obtained through the Parser API
 
-val newDoc = doc.rewrite {
+val newDoc = doc.rewrite(RewriteRules.forSpans {
   case Emphasized(content, opts) => Replace(Strong(content, opts))
-}
+})
 ```
 
 For a slightly more advanced example, let's assume you only want to replace `Emphasized` nodes inside headers. 
 To accomplish this you need to nest a rewrite operation inside another one:
 
 ```scala
-val newDoc = doc.rewrite {
-  case h: Header => Some(h.rewriteChildren {
+val newDoc = doc.rewrite(RewriteRules.forBlocks {
+  case h: Header => Replace(h.rewriteSpans {
     case Emphasized(content, opts) => Replace(Strong(content, opts))
   })
-}
+})
 ```

--- a/docs/src/07-reference/06-release-notes.md
+++ b/docs/src/07-reference/06-release-notes.md
@@ -23,6 +23,11 @@ Release Notes
   processed by some external tool, making it available during link validation.
 * PDF Support: upgrade to Apache FOP 2.6 (2.4 and 2.5 were both skipped as they had an issue with dependencies 
   in their POMs)
+* Error Handling for Rewrite Rules and Cursor API
+    * Change signatures of methods for registering rules in a bundle, rewriting a document or creating a cursor 
+      to include error handling (rule builders can now return an `Either[ConfigError, RewriteRule]`).
+    * Use these new hooks in internal rewrite rules to validate configuration values used by the rules early.
+    * Include key information in `DecodingError`.
 * Error Reporting: When a parser error originates in a template the error formatter now includes the path info
   for the template instead of making the error appear as if it came from the markup document
 

--- a/io/src/main/scala/laika/io/config/SiteConfig.scala
+++ b/io/src/main/scala/laika/io/config/SiteConfig.scala
@@ -18,6 +18,7 @@ package laika.io.config
 
 import laika.ast.Path
 import laika.ast.Path.Root
+import laika.config.Config.ConfigResult
 import laika.config.{Config, LaikaKeys}
 
 /** Configuration for special folders in Laika's site output.
@@ -31,12 +32,11 @@ object SiteConfig {
 
   /** The path within the virtual tree to place downloads (EPUB and PDF) in.
     */
-  def downloadPath (config: Config): Path =
-    config.get[Path](LaikaKeys.site.downloadPath).toOption.getOrElse(defaultDownloadPath)
+  def downloadPath (config: Config): ConfigResult[Path] =
+    config.get[Path](LaikaKeys.site.downloadPath, defaultDownloadPath)
 
   /** The path within the virtual tree where API documentation will be generated or copied into. 
     */
-  def apiPath (config: Config): Path =
-    config.get[Path](LaikaKeys.site.apiPath).toOption.getOrElse(defaultApiPath)
+  def apiPath (config: Config): ConfigResult[Path] = config.get[Path](LaikaKeys.site.apiPath, defaultApiPath)
 
 }

--- a/io/src/main/scala/laika/io/runtime/ParserRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/ParserRuntime.scala
@@ -108,8 +108,9 @@ object ParserRuntime {
           staticDocuments = inputs.binaryInputs.map(doc => StaticDocument(doc.path, doc.formats)) ++ inputs.providedPaths
         )
         val finalTree = rootToRewrite.rewrite(op.config.rewriteRulesFor(rootToRewrite))
-        InvalidDocuments.from(finalTree, op.config.failOnMessages)
-          .toLeft(ParsedTree(finalTree, inputs.binaryInputs))
+        InvalidDocuments
+          .from(finalTree, op.config.failOnMessages)
+          .map(ParsedTree(_, inputs.binaryInputs))
       }
       
       def loadIncludes(results: Vector[ParserResult]): F[IncludeMap] = {

--- a/io/src/test/scala/laika/io/TreeParserSpec.scala
+++ b/io/src/test/scala/laika/io/TreeParserSpec.scala
@@ -200,7 +200,7 @@ class TreeParserSpec extends IOWordSpec
       val invalidDocuments = inputs.map { case (path, markup) => 
         val msg = s"unresolved link id reference: link${markup.charAt(5)}"
         val invalidSpan = InvalidSpan(msg, source(markup, markup, path))
-        InvalidDocument(NonEmptyChain.one(invalidSpan), path)
+        InvalidDocument(path, invalidSpan)
       }
       val expectedError = InvalidDocuments(NonEmptyChain.fromChainUnsafe(Chain.fromSeq(invalidDocuments)))
       val expectedMessage =
@@ -260,7 +260,7 @@ class TreeParserSpec extends IOWordSpec
       val msg = "One or more errors processing directive 'foo': No template directive registered with name: foo"
       val invalidDocument = {
         val invalidSpan2 = InvalidSpan(msg, source("@:foo", Contents.brokenTemplate, DefaultTemplatePath.forHTML))
-        InvalidDocument(NonEmptyChain(invalidSpan2), docPath)
+        InvalidDocument(docPath, invalidSpan2)
       }
       val expectedError = InvalidDocuments(NonEmptyChain(invalidDocument))
       val expectedMessage =
@@ -270,6 +270,8 @@ class TreeParserSpec extends IOWordSpec
           |
           |  $${cursor.currentDocument.content} @:foo
           |                                    ^""".stripMargin
+      InvalidDocuments.format(expectedError.documents) shouldBe expectedMessage
+      
       parsedTree.map(root => 
         InvalidDocuments.from(root, MessageFilter.Error).map(_.documents.head)
       ).assertEquals(Some(invalidDocument))

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -262,7 +262,7 @@ class TreeRendererSpec extends IOWordSpec
         val invalidDocuments = input.allDocuments.map { doc =>
           val msg = s"unresolved link reference: link${doc.path.name.last}"
           val invalidSpan = InvalidBlock(msg, generatedSource(s"[link${doc.path.name.last}]"))
-          InvalidDocument(NonEmptyChain.one(invalidSpan), doc.path)
+          InvalidDocument(doc.path, invalidSpan)
         }
         renderer
           .use (_

--- a/io/src/test/scala/laika/theme/ThemeBundleSpec.scala
+++ b/io/src/test/scala/laika/theme/ThemeBundleSpec.scala
@@ -110,7 +110,7 @@ class ThemeBundleSpec extends IOWordSpec with Matchers {
 
       val expected = Document(Root, RootElement(Literal("foo"), Literal("bar")))
 
-      config.rewriteRulesFor(doc).map(doc.rewrite) shouldBe Right(expected)
+      config.rewriteRulesFor(doc).flatMap(doc.rewrite) shouldBe Right(expected)
     }
 
     "apply a rewrite rule from an app config and a rule from a markup extension successively" in new BundleSetup {
@@ -120,7 +120,7 @@ class ThemeBundleSpec extends IOWordSpec with Matchers {
       val doc =      Document(Root, RootElement(Literal("foo")))
       val expected = Document(Root, RootElement(Literal("foo!?")))
 
-      config.rewriteRulesFor(doc).map(doc.rewrite) shouldBe Right(expected)
+      config.rewriteRulesFor(doc).flatMap(doc.rewrite) shouldBe Right(expected)
     }
 
   }

--- a/io/src/test/scala/laika/theme/ThemeBundleSpec.scala
+++ b/io/src/test/scala/laika/theme/ThemeBundleSpec.scala
@@ -110,8 +110,7 @@ class ThemeBundleSpec extends IOWordSpec with Matchers {
 
       val expected = Document(Root, RootElement(Literal("foo"), Literal("bar")))
 
-      val rewriteRule = config.rewriteRulesFor(doc)
-      doc.rewrite(rewriteRule) shouldBe expected
+      config.rewriteRulesFor(doc).map(doc.rewrite) shouldBe Right(expected)
     }
 
     "apply a rewrite rule from an app config and a rule from a markup extension successively" in new BundleSetup {
@@ -121,8 +120,7 @@ class ThemeBundleSpec extends IOWordSpec with Matchers {
       val doc =      Document(Root, RootElement(Literal("foo")))
       val expected = Document(Root, RootElement(Literal("foo!?")))
 
-      val rewriteRule = config.rewriteRulesFor(doc)
-      doc.rewrite(rewriteRule) shouldBe expected
+      config.rewriteRulesFor(doc).map(doc.rewrite) shouldBe Right(expected)
     }
 
   }

--- a/pdf/src/test/scala/laika/render/FOConcatenationSpec.scala
+++ b/pdf/src/test/scala/laika/render/FOConcatenationSpec.scala
@@ -46,7 +46,7 @@ class FOConcatenationSpec extends AnyFlatSpec with Matchers with TestSourceBuild
   )
   
   "The FO concatenation" should "fail when there are invalid elements in the template result" in {
-    FOConcatenation(result, PDF.BookConfig(), OperationConfig.default) shouldBe Left(InvalidDocument(NonEmptyChain.one(invalidElement), Root / "merged.fo"))
+    FOConcatenation(result, PDF.BookConfig(), OperationConfig.default) shouldBe Left(InvalidDocument(Root / "merged.fo", invalidElement))
   }
   
   it should "succeed when there are errors in the template result, but the filter is None" in {

--- a/sbt/src/main/scala/laika/sbt/LaikaPlugin.scala
+++ b/sbt/src/main/scala/laika/sbt/LaikaPlugin.scala
@@ -154,8 +154,8 @@ object LaikaPlugin extends AutoPlugin {
     laikaDescribe           := Settings.describe.value,
 
     laikaIncludeAPI         := false,
-    laikaIncludeEPUB        := Settings.parserConfig.value.baseConfig.get[Boolean]("helium.site.includeEPUB").getOrElse(false),
-    laikaIncludePDF         := Settings.parserConfig.value.baseConfig.get[Boolean]("helium.site.includePDF").getOrElse(false),
+    laikaIncludeEPUB        := Settings.validated(Settings.parserConfig.value.baseConfig.get[Boolean]("helium.site.includeEPUB", false)),
+    laikaIncludePDF         := Settings.validated(Settings.parserConfig.value.baseConfig.get[Boolean]("helium.site.includePDF", false)),
 
     laikaSite               := Tasks.site.value,
     laikaGenerate           := Tasks.generate.evaluated,


### PR DESCRIPTION
* Change signatures of methods for registering rules in a bundle, rewriting a document or creating a cursor to include error handling (rule builders can now return an `Either[ConfigError, RewriteRule]`).
* Use these new hooks in internal rewrite rules to validate configuration values used by the rules early.
* Include key information in `DecodingError`.