### PR TITLE
Helium theme: support dark mode for EPUB and HTML output

### DIFF
--- a/docs/src/03-preparing-content/03-theme-settings.md
+++ b/docs/src/03-preparing-content/03-theme-settings.md
@@ -212,7 +212,7 @@ the site and PDF output.
 Colors
 ------
 
-Helium let's you define two different color sets: The theme colors which are used for headlines, links, navigation
+Helium lets you define two different color sets: The theme colors which are used for headlines, links, navigation
 and backgrounds as well as the syntax coloring scheme to be used for all code blocks.
 
 ### Theme Colors
@@ -328,6 +328,31 @@ spans, the wheel colors are used for the more significant types of code spans.
 Amongst others these are substitution references, annotations (1st color), keywords, escape sequences (2nd),
 attribute names, declaration names (3rd), all types of literals (4th), type names, tag names (5th), 
 and several categories for other types of syntax, e.g. in text markup.
+
+
+### Dark Mode
+
+For EPUB and HTML output Laika also supports explicit configuration for dark mode.
+This requires e-book readers and browsers which support the CSS for dark mode 
+(the `color-scheme` attribute and the `prefers-color-scheme` media query).
+In supported software the color sets configured for Helium's dark mode become active
+whenever the user has switched on dark mode in the OS or in the reader software.
+
+The following example defines custom theme colors for dark mode in EPUB output:
+
+```scala
+Helium.defaults
+  .epub.darkMode.themeColors(
+    primary = hex("007c99"),
+    primaryDark = hex("931813"),
+    primaryLight = hex("095269"),
+    primaryMedium = Color.hex("a7d4de"),
+    primaryLight = Color.hex("ebf6f7"),
+    text = Color.hex("5f5f5f")
+  )
+```
+
+Similar configuration can be added for site output and syntax highlighting colors.
 
 
 Layout

--- a/docs/src/07-reference/06-release-notes.md
+++ b/docs/src/07-reference/06-release-notes.md
@@ -17,6 +17,10 @@ Release Notes
     * `@:path`: Validates and translates a path in a template to a path relative to the rendered document the template
       is applied to.
     * `@:attribute`: Renders an optional HTML or XML attribute.
+* Helium Theme:
+    * Add support for dark mode to the Configuration API for EPUB and HTML output, 
+      allowing to specify a complete second color set for theme colors and syntax highlighting that becomes
+      active when the user switches to dark mode in the OS or reader software. 
 * Versioning: new `renderUnversioned` flag, that can be set to false when rendering older versions 
   (e.g. from a maintenance branch) to ensure that unversioned files always come from the main branch (newest version).
 * Link Validation: new `addProvidedPath` method on `InputTreeBuilder` that adds a path representing a document which is 

--- a/io/src/main/scala/laika/helium/Helium.scala
+++ b/io/src/main/scala/laika/helium/Helium.scala
@@ -34,7 +34,7 @@ import laika.theme._
   * In the minimal example below we only specify some metadata for all formats as well as the navigation depth
   * for EPUB and PDF:
   *
-  * ```scala
+  * {{{
   * val theme = Helium.defaults
   * .all.metadata(
   * title = Some("Project Name"),
@@ -43,7 +43,7 @@ import laika.theme._
   * .epub.navigationDepth(4)
   * .pdf.navigationDepth(4)
   * .build
-  * ```
+  * }}}
   *
   * Laika also provides convenient constructors for some of the data types used frequently in its theme API.
   * You can import `laika.theme.Color._` for specifying colors with `hex("ffaaff")` or `rgb(255, 0, 0)` and 

--- a/io/src/main/scala/laika/helium/config/ColorSet.scala
+++ b/io/src/main/scala/laika/helium/config/ColorSet.scala
@@ -18,14 +18,16 @@ package laika.helium.config
 
 import laika.theme.config.Color
 
-private[helium] case class ColorSet (primary: Color,
-                                     primaryDark: Color,
-                                     primaryMedium: Color,
-                                     primaryLight: Color,
-                                     secondary: Color,
-                                     text: Color,
+private[helium] case class ColorSet (theme: ThemeColors,
                                      messages: MessageColors,
                                      syntaxHighlighting: SyntaxColors)
+
+private[helium] case class ThemeColors (primary: Color,
+                                        primaryDark: Color,
+                                        primaryMedium: Color,
+                                        primaryLight: Color,
+                                        secondary: Color,
+                                        text: Color)
 
 private[helium] case class MessageColors (info: Color,
                                           infoLight: Color,

--- a/io/src/main/scala/laika/helium/config/HeliumDefaults.scala
+++ b/io/src/main/scala/laika/helium/config/HeliumDefaults.scala
@@ -102,6 +102,7 @@ private[helium] object HeliumDefaults {
       small = px(12)
     ),
     colors = colors(syntaxDarkScheme),
+    darkMode = None,
     htmlIncludes = HTMLIncludes(),
     landingPage = None,
     layout = WebLayout(
@@ -131,6 +132,7 @@ private[helium] object HeliumDefaults {
       small   = em(0.8)
     ),
     colors = colors(syntaxLightScheme),
+    darkMode = None,
     htmlIncludes = HTMLIncludes(),
     layout = EPUBLayout(
       defaultBlockSpacing = px(10),

--- a/io/src/main/scala/laika/helium/config/HeliumDefaults.scala
+++ b/io/src/main/scala/laika/helium/config/HeliumDefaults.scala
@@ -78,13 +78,17 @@ private[helium] object HeliumDefaults {
       Color.hex("9A6799"), Color.hex("9F4C46"), Color.hex("A0742D"), Color.hex("7D8D4C"), Color.hex("6498AE")
     )
   )
-  def colors (syntaxScheme: SyntaxColors): ColorSet = ColorSet(
+  private val themeColors = ThemeColors(
     primary = Color.hex("007c99"),
     secondary = Color.hex("931813"),
     primaryDark = Color.hex("095269"),
     primaryMedium = Color.hex("a7d4de"),
     primaryLight = Color.hex("ebf6f7"),
-    text = Color.hex("5f5f5f"),
+    text = Color.hex("5f5f5f")
+  )
+  
+  def colors (syntaxScheme: SyntaxColors): ColorSet = ColorSet(
+    theme = themeColors,
     messages = defaultMessageColors,
     syntaxHighlighting = syntaxScheme
   )

--- a/io/src/main/scala/laika/helium/config/settings.scala
+++ b/io/src/main/scala/laika/helium/config/settings.scala
@@ -34,6 +34,10 @@ private[helium] trait CommonSettings {
   def layout: CommonLayout
 }
 
+private[helium] trait DarkModeSupport extends CommonSettings {
+  def darkMode: Option[ColorSet]
+}
+  
 private[helium] case class SiteSettings (fontResources: Seq[FontDefinition],
                                          themeFonts: ThemeFonts,
                                          fontSizes: FontSizes,
@@ -44,7 +48,7 @@ private[helium] case class SiteSettings (fontResources: Seq[FontDefinition],
                                          layout: WebLayout,
                                          metadata: DocumentMetadata,
                                          versions: Option[Versions] = None,
-                                         baseURL: Option[String] = None) extends CommonSettings
+                                         baseURL: Option[String] = None) extends DarkModeSupport
 
 private[helium] case class PDFSettings (bookConfig: BookConfig,
                                         themeFonts: ThemeFonts,
@@ -62,7 +66,7 @@ private[helium] case class EPUBSettings (bookConfig: BookConfig,
                                          darkMode: Option[ColorSet],
                                          htmlIncludes: HTMLIncludes,
                                          layout: EPUBLayout,
-                                         coverImages: Seq[CoverImage]) extends CommonSettings {
+                                         coverImages: Seq[CoverImage]) extends DarkModeSupport {
   val metadata: DocumentMetadata = bookConfig.metadata
 }
 

--- a/io/src/main/scala/laika/helium/config/settings.scala
+++ b/io/src/main/scala/laika/helium/config/settings.scala
@@ -197,10 +197,10 @@ private[helium] trait ColorOps {
                    primaryMedium: Color,
                    primaryLight: Color,
                    secondary: Color,
-                   text: Color): Helium = withColors(currentColors.copy(
+                   text: Color): Helium = withColors(currentColors.copy(theme = ThemeColors(
     primary = primary, primaryDark = primaryDark, primaryMedium = primaryMedium, primaryLight = primaryLight,
     secondary = secondary, text = text
-  ))
+  )))
   def messageColors (info: Color,
                      infoLight: Color,
                      warning: Color,

--- a/io/src/main/scala/laika/helium/generate/CSSVarGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/CSSVarGenerator.scala
@@ -52,12 +52,12 @@ private[helium] object CSSVarGenerator {
   def generate (common: CommonSettings, additionalStyles: Seq[(String, String)]): String = {
     import common._
     (Seq(
-      "primary-color" -> colors.primary.displayValue,
-      "primary-light" -> colors.primaryLight.displayValue,
-      "primary-medium" -> colors.primaryMedium.displayValue,
-      "primary-dark" -> colors.primaryDark.displayValue,
-      "secondary-color" -> colors.secondary.displayValue,
-      "text-color" -> colors.text.displayValue,
+      "primary-color" -> colors.theme.primary.displayValue,
+      "primary-light" -> colors.theme.primaryLight.displayValue,
+      "primary-medium" -> colors.theme.primaryMedium.displayValue,
+      "primary-dark" -> colors.theme.primaryDark.displayValue,
+      "secondary-color" -> colors.theme.secondary.displayValue,
+      "text-color" -> colors.theme.text.displayValue,
       "messages-info" -> colors.messages.info.displayValue,
       "messages-info-light" -> colors.messages.infoLight.displayValue,
       "messages-warning" -> colors.messages.warning.displayValue,

--- a/io/src/main/scala/laika/helium/generate/FOStyles.scala
+++ b/io/src/main/scala/laika/helium/generate/FOStyles.scala
@@ -108,7 +108,7 @@ private[laika] class FOStyles (helium: Helium) {
     |  font-family: ${themeFonts.headlines};
     |  font-size: ${fontSizes.title.displayValue};
     |  font-weight: bold;
-    |  color: ${colors.primary.displayValue};
+    |  color: ${colors.theme.primary.displayValue};
     |  space-before: 0mm;
     |  space-after: 6mm;
     |}
@@ -228,7 +228,7 @@ private[laika] class FOStyles (helium: Helium) {
     |}
     |
     |FootnoteLink, CitationLink, SpanLink {
-    |  color: ${colors.secondary.displayValue};
+    |  color: ${colors.theme.secondary.displayValue};
     |}
     |
     |SpanLink {
@@ -237,12 +237,12 @@ private[laika] class FOStyles (helium: Helium) {
     |
     |NavigationItem SpanLink {
     |  font-weight: bold;
-    |  color: ${colors.primary.displayValue};
+    |  color: ${colors.theme.primary.displayValue};
     |}
     |
     |Paragraph.level2.nav SpanLink {
     |  font-weight: bold;
-    |  color: ${colors.secondary.displayValue};
+    |  color: ${colors.theme.secondary.displayValue};
     |}
     |
     |Emphasized {
@@ -319,7 +319,7 @@ private[laika] class FOStyles (helium: Helium) {
     |Paragraph.nav.level1 {
     |  font-size: 22pt; /* TODO - align with header font sizes */
     |  font-weight: bold;
-    |  color: ${colors.secondary.displayValue};
+    |  color: ${colors.theme.secondary.displayValue};
     |  margin-left: 0mm;
     |  text-align-last: center;
     |  text-transform: uppercase;
@@ -328,7 +328,7 @@ private[laika] class FOStyles (helium: Helium) {
     |
     |Paragraph.nav.level2 {
     |  font-size: 17pt;
-    |  color: ${colors.secondary.displayValue};
+    |  color: ${colors.theme.secondary.displayValue};
     |  margin-left: 4mm;
     |  space-before: 7mm;
     |}

--- a/io/src/test/scala/laika/helium/HeliumEPUBCSSSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumEPUBCSSSpec.scala
@@ -224,6 +224,33 @@ class HeliumEPUBCSSSpec extends IOFunSuite with InputBuilder with ResultExtracto
                               |--header4-font-size: 1.1em;
                               |--block-spacing: 10px;
                               |--line-height: 1.5;""".stripMargin
+  
+  private val darkModeColors = """color-scheme: light dark;
+                                 |}
+                                 |@media (prefers-color-scheme: dark) {
+                                 |:root {
+                                 |--primary-color: rgb(11,11,11);
+                                 |--primary-light: rgb(12,12,12);
+                                 |--primary-medium: rgb(14,14,14);
+                                 |--primary-dark: rgb(10,10,10);
+                                 |--secondary-color: rgb(112,112,112);
+                                 |--text-color: rgb(110,110,110);
+                                 |--messages-info: #00aaaa;
+                                 |--messages-info-light: #00aaab;
+                                 |--messages-warning: #00aaac;
+                                 |--messages-warning-light: #00aaad;
+                                 |--messages-error: #00aaae;
+                                 |--messages-error-light: #00aaaf;
+                                 |--syntax-base1: #200011;
+                                 |--syntax-base2: #200022;
+                                 |--syntax-base3: #200033;
+                                 |--syntax-base4: #200044;
+                                 |--syntax-base5: #200055;
+                                 |--syntax-wheel1: #210011;
+                                 |--syntax-wheel2: #210022;
+                                 |--syntax-wheel3: #210033;
+                                 |--syntax-wheel4: #210044;
+                                 |--syntax-wheel5: #210055;""".stripMargin
 
   test("custom colors - via 'epub' selector") {
     import laika.theme.config.Color._
@@ -255,6 +282,34 @@ class HeliumEPUBCSSSpec extends IOFunSuite with InputBuilder with ResultExtracto
         wheel = ColorQuintet(hex("110011"), hex("110022"), hex("110033"), hex("110044"), hex("110055"))
       )
     transformAndExtract(singleDoc, helium, ":root {", "}").assertEquals(customColors)
+  }
+
+  test("custom colors in dark mode") {
+    import laika.theme.config.Color._
+    val helium = Helium.defaults
+      .epub.themeColors(primary = rgb(1,1,1), primaryDark = rgb(0,0,0), primaryLight = rgb(2,2,2), primaryMedium = rgb(4,4,4),
+        secondary = rgb(212,212,212), text = rgb(10,10,10))
+      .epub.messageColors(
+        info = hex("aaaaaa"), infoLight = hex("aaaaab"),
+        warning = hex("aaaaac"), warningLight = hex("aaaaad"),
+        error = hex("aaaaae"), errorLight = hex("aaaaaf")
+      )
+      .epub.syntaxHighlightingColors(
+        base = ColorQuintet(hex("000011"), hex("000022"), hex("000033"), hex("000044"), hex("000055")),
+        wheel = ColorQuintet(hex("110011"), hex("110022"), hex("110033"), hex("110044"), hex("110055"))
+      )
+      .epub.darkMode.themeColors(primary = rgb(11,11,11), primaryDark = rgb(10,10,10), primaryLight = rgb(12,12,12), 
+        primaryMedium = rgb(14,14,14), secondary = rgb(112,112,112), text = rgb(110,110,110))
+      .epub.darkMode.messageColors(
+        info = hex("00aaaa"), infoLight = hex("00aaab"),
+        warning = hex("00aaac"), warningLight = hex("00aaad"),
+        error = hex("00aaae"), errorLight = hex("00aaaf")
+      )
+      .epub.darkMode.syntaxHighlightingColors(
+        base = ColorQuintet(hex("200011"), hex("200022"), hex("200033"), hex("200044"), hex("200055")),
+        wheel = ColorQuintet(hex("210011"), hex("210022"), hex("210033"), hex("210044"), hex("210055"))
+      )
+    transformAndExtract(singleDoc, helium, ":root {", "}\n}").assertEquals(customColors + "\n" + darkModeColors)
   }
 
   test("layout") {

--- a/io/src/test/scala/laika/io/helper/StringOps.scala
+++ b/io/src/test/scala/laika/io/helper/StringOps.scala
@@ -25,10 +25,11 @@ trait StringOps {
 
   implicit class TestStringOps (val str: String) {
     
-    def extract (start: String, end: String): Option[String] = for {
-      rest <- str.split(Pattern.quote(start)).drop(1).headOption
-      res  <- rest.split(Pattern.quote(end)).headOption
-    } yield res
+    def extract (start: String, end: String): Option[String] = {
+      val rest = str.split(Pattern.quote(start)).drop(1)
+      if (rest.isEmpty) None
+      else rest.mkString(start).split(Pattern.quote(end)).headOption
+    }
 
     def extractTag (tag: String): Option[String] = extract(s"<$tag>", s"</$tag>")
     


### PR DESCRIPTION
Adds support for dark mode to the Helium configuration API. The implementation requires e-book readers and browsers which support the new CSS for dark mode (the `color-scheme` attribute and the `prefers-color-scheme` media query). In supported software the color sets configured for Helium's dark mode become active whenever the user has switched to dark mode in the OS or in the reader software.