### PR TITLE
Helium theme: more configuration options for top navigation bar

### DIFF
--- a/core/shared/src/main/scala/laika/ast/links.scala
+++ b/core/shared/src/main/scala/laika/ast/links.scala
@@ -200,12 +200,25 @@ case class Image (target: Target,
 }
 
 object Image {
+  
+  @deprecated("use ParsedTarget.forImage", "0.18.0")
   def create (url: String, source: SourceFragment, width: Option[Length] = None,
               height: Option[Length] = None, alt: Option[String] = None, title: Option[String] = None): Span =
-    Target.parseInternal(url) match {
-      case Right(external) => Image(external, width, height, alt, title)
-      case Left(internal)  => ImagePathReference(internal.path, source, width, height, alt, title)
-    }
+    ParsedTarget.forImage(url, source, width, height, alt, title)
+
+  /** Creates a new instance for the specified internal image.
+    * The path value represents a virtual path into the input tree of a transformation
+    * and may be absolute or relative.
+    */
+  def internal (path: PathBase, width: Option[Length] = None, height: Option[Length] = None,
+                alt: Option[String] = None, title: Option[String] = None): Image =
+    apply(InternalTarget(path), width, height, alt, title)
+
+  /** Creates a new instance for the specified external image URL.
+    */
+  def external (url: String, width: Option[Length] = None, height: Option[Length] = None,
+                alt: Option[String] = None, title: Option[String] = None): Image =
+    apply(ExternalTarget(url), width, height, alt, title)
 }
 
 /** Base trait for all supported icon types.
@@ -295,15 +308,32 @@ case class IconReference (key: String, source: SourceFragment, options: Options 
   lazy val unresolvedMessage: String = s"Unresolved icon reference with key '$key'"
 } 
 
-object ParsedLink {
-  /** Creates a new span that acts as a link reference based on the specified
-    * URL which will be parsed and interpreted as an internal or external target.
+object ParsedTarget {
+
+  /** Creates a new link span based on the specified URL which will be parsed and interpreted as an 
+    * internal or external target.
     */
-  def create (linkText: Seq[Span], url: String, source: SourceFragment, title: Option[String] = None): Span =
+  def forLink (linkText: Seq[Span], url: String, source: SourceFragment, title: Option[String] = None): Span =
     Target.parseInternal(url) match {
       case Right(external) => SpanLink(linkText, external, title)
       case Left(internal)  => LinkPathReference(linkText, internal.path, source, title)
     }
+
+  /** Creates a image span based on the specified URL which will be parsed and interpreted as an 
+    * internal or external target.
+    */
+  def forImage (url: String, source: SourceFragment, width: Option[Length] = None,
+                height: Option[Length] = None, alt: Option[String] = None, title: Option[String] = None): Span =
+    Target.parseInternal(url) match {
+      case Right(external) => Image(external, width, height, alt, title)
+      case Left(internal)  => ImagePathReference(internal.path, source, width, height, alt, title)
+    }
+}
+
+object ParsedLink {
+  @deprecated("use ParsedTarget.forLink", "0.18.0")
+  def create (linkText: Seq[Span], url: String, source: SourceFragment, title: Option[String] = None): Span =
+    ParsedTarget.forLink(linkText, url, source, title)
 }
 
 object LinkDefinition {

--- a/core/shared/src/main/scala/laika/markdown/InlineParsers.scala
+++ b/core/shared/src/main/scala/laika/markdown/InlineParsers.scala
@@ -137,7 +137,7 @@ object InlineParsers {
 
     ("[" ~> resource(recParsers)).withCursor.map { case (res, source) =>
       res.target match {
-        case TargetUrl(url, title) => ParsedLink.create(recParsers.recursiveSpans.parseAndRecover(res.text), url, source, title)
+        case TargetUrl(url, title) => ParsedTarget.forLink(recParsers.recursiveSpans.parseAndRecover(res.text), url, source, title)
         case TargetId(id)   => linkReference(res, id, source)
         case ImplicitTarget => linkReference(res, res.text.input, source)
       }
@@ -154,7 +154,7 @@ object InlineParsers {
 
     ("![" ~> resource(recParsers)).withCursor.map { case (res, source) =>
       res.target match {
-        case TargetUrl(url, title) => escape(res.text, source, text => Image.create(url, source, alt = Some(text), title = title))
+        case TargetUrl(url, title) => escape(res.text, source, text => ParsedTarget.forImage(url, source, alt = Some(text), title = title))
         case TargetId(id)   => escape(res.text, source, ImageIdReference(_, normalizeId(id), source))
         case ImplicitTarget => escape(res.text, source, ImageIdReference(_, normalizeId(res.text.input), source))
       }

--- a/core/shared/src/main/scala/laika/rst/InlineParsers.scala
+++ b/core/shared/src/main/scala/laika/rst/InlineParsers.scala
@@ -277,10 +277,10 @@ object InlineParsers {
     
     (markupStart("`", "`") ~> refName ~ opt(urlPart) ~ end).withCursor.map {
       case (name ~ Some(url) ~ true, src)   => SpanSequence(
-        ParsedLink.create(List(Text(ref(name.original, url))), url, src), 
+        ParsedTarget.forLink(List(Text(ref(name.original, url))), url, src), 
         LinkDefinition.create(ref(name.normalized, url), url)
       )
-      case (name ~ Some(url) ~ false, src)  => ParsedLink.create(List(Text(ref(name.original, url))), url, src)
+      case (name ~ Some(url) ~ false, src)  => ParsedTarget.forLink(List(Text(ref(name.original, url))), url, src)
       case (name ~ None ~ true, src)        => LinkIdReference(List(Text(name.original)), name.normalized, src) 
       case (name ~ None ~ false, src)       => LinkIdReference(List(Text(name.original)), "", src) 
     }

--- a/core/shared/src/main/scala/laika/rst/std/StandardDirectiveParsers.scala
+++ b/core/shared/src/main/scala/laika/rst/std/StandardDirectiveParsers.scala
@@ -102,7 +102,7 @@ object StandardDirectiveParsers {
         case (refName, src) => LinkIdReference(Nil, refName, src)
       }
     }
-    val uri = anyChars.withCursor.map { case (res, source) => ParsedLink.create(Nil, res, source) }
+    val uri = anyChars.withCursor.map { case (res, source) => ParsedTarget.forLink(Nil, res, source) }
     
     parseDirectivePart(phraseLinkRef | simpleLinkRef | uri, input)
   }

--- a/docs/src/03-preparing-content/03-theme-settings.md
+++ b/docs/src/03-preparing-content/03-theme-settings.md
@@ -446,32 +446,35 @@ There are several other navigation features which are supported independent of t
 like the option to centralize all definitions of external links.
 They are described in a dedicated [Navigation] chapter.
 
+
 ### Top Navigation Bar
 
-You can place a logo serving as home button into the middle of the top navigation bar,
-and a row of buttons or icons with links at the right corner.
+You can replace the home link in the middle of the bar and a row of buttons or icons with links at the right corner.
+The home link, unless overridden, points to `index.html` and uses the `HeliumIcon.home` icon.
+The navigation links on the right are empty by default.
 The left corner of the top bar is always reserved for the button to open or close the navigation.
 
 ```scala
 Helium.defaults.site
   .topNavigationBar(
-    logo = Some(Logo.internal(
-      path = Root / "image.png", 
-      alt = Some("Homepage"), 
-      title = Some("Home")
-    )),
-    links = Seq(
+    homeLink = IconLink.internal(Root / "README.md", HeliumIcon.hone),
+    navLinks = Seq(
       IconLink.internal(Root / "doc-2.md", HeliumIcon.download),
-      ButtonLink.external("http://somewhere.com/", "Text Link"),
+      TextLink.external("http://somewhere.com/", "Text Link"),
       ButtonLink.external("http://somewhere.com/", "Button Link")
-    ))
+    ),
+    highContrast = true
+  )
 ```
 
-The logo can be an external or internal link, in case of the latter, it is always a path from the perspective 
-of Laika's virtual root, not a file system path.
-For the links to the right navigation bar you can choose between an `IconLink` with optional text,
-a `ButtonLink` with an optional icon, or a plain text link.
-Internal targets are again within the virtual path and will be validated.
+All the properties shown above have default values, so you don't have to specify them all.
+The link to the homepage can be customized, by default it is pointing to `index.html` and using the Helium home icon.
+The links for the right navigation bar (`navLinks`, by default empty) can be an `IconLink` with optional text,
+a `ButtonLink` with an optional icon, or a plain `TextLink` or `ImageLink`.
+All links can be external or internal, in case of the latter, it is always a path from the perspective 
+of Laika's virtual root, not a file system path, and will be validated (dead links will cause the transformation to fail).
+Finally, the `highContrast` option indicates whether the background color should have a high contrast to the background
+of the page (darker in light mode and lighter in dark mode).
 
 With the default Helium settings the three link types from our code example render as shown below:
 

--- a/docs/src/07-reference/06-release-notes.md
+++ b/docs/src/07-reference/06-release-notes.md
@@ -21,10 +21,13 @@ Release Notes
     * Add support for dark mode to the Configuration API for EPUB and HTML output, 
       allowing to specify a complete second color set for theme colors and syntax highlighting that becomes
       active when the user switches to dark mode in the OS or reader software.
+    * Make the link of the home icon configurable.
+    * Add the page background color to the configurable theme colors.
+    * Add a "high-contrast" option for the top navigation bar (darker in light mode and lighter in dark mode).
 * Icon Support:
     * Add new AST nodes for different kinds of icon sets: font icons, CSS icons (e.g. image sprites), inline SVG icons
       and SVG symbols (references).
-    * Add new `@:icon` directive that allows to reference an icon by key in markup documents or templates.
+    * New `@:icon` directive that allows to reference an icon by key in markup documents or templates.
 * Versioning: new `renderUnversioned` flag, that can be set to false when rendering older versions 
   (e.g. from a maintenance branch) to ensure that unversioned files always come from the main branch (newest version).
 * Link Validation: new `addProvidedPath` method on `InputTreeBuilder` that adds a path representing a document which is 

--- a/io/src/main/resources/laika/helium/css/container.css
+++ b/io/src/main/resources/laika/helium/css/container.css
@@ -5,6 +5,7 @@
 body {
   font-family: var(--body-font);
   color: var(--text-color);
+  background-color: var(--bg-color);
   font-size: var(--body-font-size);
   line-height: var(--line-height);
   position: relative;

--- a/io/src/main/resources/laika/helium/css/nav.css
+++ b/io/src/main/resources/laika/helium/css/nav.css
@@ -8,7 +8,7 @@
 header {
   display: flex;
   justify-content: space-between;
-  background-color: var(--primary-light);
+  background-color: var(--top-bg);
   margin: 0;
   position: fixed;
   top: 0;
@@ -18,15 +18,15 @@ header {
   width: 100%;
   align-items: center;
   padding: 0 45px 0 20px;
-  border-bottom: 1px solid var(--primary-medium);
+  border-bottom: 1px solid var(--top-border);
 }
 header a {
-  color: var(--primary-color);
+  color: var(--top-color);
 }
 header a:hover {
   text-decoration: none;
   cursor: pointer;
-  color: var(--secondary-color)
+  color: var(--top-hover)
 }
 header img {
   height: 80%;
@@ -56,13 +56,13 @@ header .row a {
   display: inline-block;
   border-radius: 9px;
   padding: 0 7px;
-  background-color: var(--primary-color);
-  color: var(--primary-light);
+  background-color: var(--top-color);
+  color: var(--top-bg);
   font-size: 0.9em;
 }
 .button-link:hover {
-  background-color: var(--secondary-color);
-  color: var(--primary-light);
+  background-color: var(--top-hover);
+  color: var(--top-bg);
 }
 
 /* version dropdown ============================================== */

--- a/io/src/main/scala/laika/helium/config/ColorSet.scala
+++ b/io/src/main/scala/laika/helium/config/ColorSet.scala
@@ -27,7 +27,8 @@ private[helium] case class ThemeColors (primary: Color,
                                         primaryMedium: Color,
                                         primaryLight: Color,
                                         secondary: Color,
-                                        text: Color)
+                                        text: Color,
+                                        background: Color)
 
 private[helium] case class MessageColors (info: Color,
                                           infoLight: Color,

--- a/io/src/main/scala/laika/helium/config/HeliumDefaults.scala
+++ b/io/src/main/scala/laika/helium/config/HeliumDefaults.scala
@@ -84,7 +84,8 @@ private[helium] object HeliumDefaults {
     primaryDark = Color.hex("095269"),
     primaryMedium = Color.hex("a7d4de"),
     primaryLight = Color.hex("ebf6f7"),
-    text = Color.hex("5f5f5f")
+    text = Color.hex("5f5f5f"),
+    background = Color.hex("ffffff")
   )
   
   def colors (syntaxScheme: SyntaxColors): ColorSet = ColorSet(

--- a/io/src/main/scala/laika/helium/config/ThemeLink.scala
+++ b/io/src/main/scala/laika/helium/config/ThemeLink.scala
@@ -58,7 +58,7 @@ object IconLink {
     new IconLink(InternalTarget(path), icon, text, options) {}
 }
 
-/** A link consisting of text and an optional icon rendered in a rounded rectangle.
+/** A link consisting of text and an optional icon, by default rendered in a rounded rectangle.
   */
 sealed abstract case class ButtonLink (target: Target, text: String, icon: Option[Icon] = None, options: Options = NoOpt) extends ThemeLink {
   type Self = ButtonLink
@@ -92,48 +92,20 @@ object TextLink {
     new TextLink(InternalTarget(path), text, options) {}
 }
 
-/** A logo type that can be used in various Helium configuration options.
-  * The only required property is the target, which is either an external URL or an internal, relative path.
+/** A simple image link.
   */
-sealed abstract case class Logo(target: Target,
-                                width: Option[Length] = None,
-                                height: Option[Length] = None,
-                                alt: Option[String] = None,
-                                title: Option[String] = None,
-                                options: Options = NoOpt) extends ThemeLink {
-  type Self = Logo
-  protected def createLink (target: Target): Link = Image(target, width, height, alt, title)
-  def withOptions(newOptions: Options): Logo =
-    new Logo(target, width, height, alt, title, newOptions) {}
+sealed abstract case class ImageLink (target: Target, image: Image, options: Options = NoOpt) extends ThemeLink {
+  type Self = ImageLink
+  protected def createLink (target: Target): Link = SpanLink(Seq(image), target, options = HeliumStyles.imageLink + options)
+  def withOptions(newOptions: Options): ImageLink =
+    new ImageLink(target, image, newOptions) {}
 }
 
-object Logo {
-  
-  /** Creates a logo with an external image URL.
-    * The width and height are interpreted as the intrinsic size of the image and do not necessarily represent
-    * the actual display size which should be set via CSS. 
-    * You can assign classes to the options property for this purpose.
-    * The `alt` and `title` properties will be rendered as the corresponding attributes in HTML and ignored for PDF.
-   */
-  def external (url: String,
-                width: Option[Length] = None,
-                height: Option[Length] = None,
-                alt: Option[String] = None,
-                title: Option[String] = None,
-                options: Options = NoOpt): Logo = 
-    new Logo(ExternalTarget(url), width, height, alt, title, options) {}
-  
-  /** Creates a logo for an image that is part of the input resources of the transformation.
-    * The width and height are interpreted as the intrinsic size of the image and do not necessarily represent
-    * the actual display size which should be set via CSS. 
-    * You can assign classes to the options property for this purpose.
-    * The `alt` and `title` properties will be rendered as the corresponding attributes in HTML and ignored for PDF.
-    */
-  def internal (path: Path,
-                width: Option[Length] = None,
-                height: Option[Length] = None,
-                alt: Option[String] = None,
-                title: Option[String] = None,
-                options: Options = NoOpt): Logo =
-    new Logo(InternalTarget(path), width, height, alt, title, options) {}
+object ImageLink {
+  /** Creates a simple image link to an external target. */
+  def external (url: String, image: Image, options: Options = NoOpt): ImageLink = 
+    new ImageLink(ExternalTarget(url), image, options) {}
+  /** Creates a simple image link to an internal target. */
+  def internal (path: Path, image: Image, options: Options = NoOpt): ImageLink =
+    new ImageLink(InternalTarget(path), image, options) {}
 }

--- a/io/src/main/scala/laika/helium/config/layout.scala
+++ b/io/src/main/scala/laika/helium/config/layout.scala
@@ -17,7 +17,7 @@
 package laika.helium.config
 
 import laika.ast.Path.Root
-import laika.ast.{ExternalTarget, InternalTarget, Length, Options, Path, Styles, Target}
+import laika.ast.{ExternalTarget, Image, InternalTarget, Length, Options, Path, Styles, Target}
 
 private[helium] sealed trait CommonLayout {
   def defaultBlockSpacing: Length
@@ -59,7 +59,7 @@ private[helium] object TopNavigationBar {
 private[helium] case class DownloadPage (title: String, description: Option[String], downloadPath: Path = Root / "downloads", 
                                         includeEPUB: Boolean = true, includePDF: Boolean = true)
 
-private[helium] case class LandingPage (logo: Option[Logo] = None,
+private[helium] case class LandingPage (logo: Option[Image] = None,
                                         title: Option[String] = None,
                                         subtitle: Option[String] = None,
                                         latestReleases: Seq[ReleaseInfo] = Nil,

--- a/io/src/main/scala/laika/helium/config/layout.scala
+++ b/io/src/main/scala/laika/helium/config/layout.scala
@@ -50,7 +50,10 @@ private[helium] case class EPUBLayout (defaultBlockSpacing: Length,
 
 private[helium] case class TableOfContent (title: String, depth: Int)
 
-private[helium] case class TopNavigationBar (homeLink: ThemeLink, navLinks: Seq[ThemeLink], versionPrefix: String = "Version")
+private[helium] case class TopNavigationBar (homeLink: ThemeLink, 
+                                             navLinks: Seq[ThemeLink], 
+                                             highContrast: Boolean = false, 
+                                             versionPrefix: String = "Version")
 
 private[helium] object TopNavigationBar {
   val default: TopNavigationBar = TopNavigationBar(IconLink.internal(Root / "README", HeliumIcon.home), Nil)

--- a/io/src/main/scala/laika/helium/config/layout.scala
+++ b/io/src/main/scala/laika/helium/config/layout.scala
@@ -17,7 +17,7 @@
 package laika.helium.config
 
 import laika.ast.Path.Root
-import laika.ast.{ExternalTarget, Image, InternalTarget, Length, Options, Path, Styles, Target}
+import laika.ast.{ExternalTarget, Image, InternalTarget, Length, Options, Path, SpanLink, Styles, Target}
 
 private[helium] sealed trait CommonLayout {
   def defaultBlockSpacing: Length
@@ -50,10 +50,10 @@ private[helium] case class EPUBLayout (defaultBlockSpacing: Length,
 
 private[helium] case class TableOfContent (title: String, depth: Int)
 
-private[helium] case class TopNavigationBar (logo: Option[Logo], links: Seq[ThemeLink], versionPrefix: String = "Version")
+private[helium] case class TopNavigationBar (homeLink: ThemeLink, navLinks: Seq[ThemeLink], versionPrefix: String = "Version")
 
 private[helium] object TopNavigationBar {
-  val default: TopNavigationBar = TopNavigationBar(None, Nil) // TODO - use home icon instead of image if empty
+  val default: TopNavigationBar = TopNavigationBar(IconLink.internal(Root / "README", HeliumIcon.home), Nil)
 }
 
 private[helium] case class DownloadPage (title: String, description: Option[String], downloadPath: Path = Root / "downloads", 
@@ -138,6 +138,7 @@ private[helium] object HeliumStyles {
   val buttonLink: Options = Styles("button-link")
   val textLink: Options = Styles("text-link")
   val iconLink: Options = Styles("icon-link")
+  val imageLink: Options = Styles("image-link")
 }
 
 private[helium] case class ThemeFonts (body: String, headlines: String, code: String)

--- a/io/src/main/scala/laika/helium/config/settings.scala
+++ b/io/src/main/scala/laika/helium/config/settings.scala
@@ -116,13 +116,15 @@ private[helium] trait CommonConfigOps {
     *                     is readable when placed on a `primaryLight` background
     * @param secondary    this color is used for navigation headers and links
     * @param text         the color of the body text
+    * @param background   the background color of the pages
     */
   def themeColors (primary: Color,
                    primaryDark: Color,
                    primaryMedium: Color,
                    primaryLight: Color,
                    secondary: Color,
-                   text: Color): Helium
+                   text: Color,
+                   background: Color): Helium
 
   /** Configures the colors of runtime messages embedded in the rendered result.
     * Warnings and errors will only be rendered if you change the configuration to visual debugging,
@@ -201,9 +203,10 @@ private[helium] trait ColorOps {
                    primaryMedium: Color,
                    primaryLight: Color,
                    secondary: Color,
-                   text: Color): Helium = withColors(currentColors.copy(theme = ThemeColors(
+                   text: Color,
+                   background: Color): Helium = withColors(currentColors.copy(theme = ThemeColors(
     primary = primary, primaryDark = primaryDark, primaryMedium = primaryMedium, primaryLight = primaryLight,
-    secondary = secondary, text = text
+    secondary = secondary, text = text, background = background
   )))
   def messageColors (info: Color,
                      infoLight: Color,
@@ -272,9 +275,10 @@ private[helium] trait AllFormatsOps extends CommonConfigOps {
                    primaryMedium: Color,
                    primaryLight: Color,
                    secondary: Color,
-                   text: Color): Helium = formats.foldLeft(helium) {
+                   text: Color,
+                   background: Color): Helium = formats.foldLeft(helium) {
     case (helium, format) =>
-      format(helium).themeColors(primary, primaryDark, primaryMedium, primaryLight, secondary, text)
+      format(helium).themeColors(primary, primaryDark, primaryMedium, primaryLight, secondary, text, background)
   }
   def messageColors (info: Color,
                      infoLight: Color,
@@ -385,9 +389,11 @@ private[helium] trait SiteOps extends SingleConfigOps with CopyOps {
     * @param homeLink the link to the homepage, by default pointing to `index.html` and using the Helium home icon.
     * @param navLinks an optional set of links to be placed at the right side of the bar, supported link
     *                 types are `IconLink`, `ButtonLink`, `ImageLink` and a plain `TextLink`
+    * @param highContrast indicates whether the background color should have a high contrast to the background
+    *                     of the page (darker in light mode and lighter in dark mode).
     */
-  def topNavigationBar (homeLink: ThemeLink = TopNavigationBar.default.homeLink, navLinks: Seq[ThemeLink] = Nil): Helium = {
-    val newLayout = helium.siteSettings.layout.copy(topNavigationBar = TopNavigationBar(homeLink, navLinks))
+  def topNavigationBar (homeLink: ThemeLink = TopNavigationBar.default.homeLink, navLinks: Seq[ThemeLink] = Nil, highContrast: Boolean = false): Helium = {
+    val newLayout = helium.siteSettings.layout.copy(topNavigationBar = TopNavigationBar(homeLink, navLinks, highContrast))
     copyWith(helium.siteSettings.copy(layout = newLayout))
   }
 

--- a/io/src/main/scala/laika/helium/config/settings.scala
+++ b/io/src/main/scala/laika/helium/config/settings.scala
@@ -20,7 +20,7 @@ import java.time.Instant
 import java.util.Date
 
 import laika.ast.Path.Root
-import laika.ast.{DocumentMetadata, Length, Path}
+import laika.ast.{DocumentMetadata, Image, Length, Path}
 import laika.helium.Helium
 import laika.rewrite.Versions
 import laika.rewrite.nav.CoverImage
@@ -455,7 +455,7 @@ private[helium] trait SiteOps extends SingleConfigOps with CopyOps {
     * @param projectLinks        a set of project links to render at the bottom of the right side of the header
     * @param teasers             a set of teasers containing of headline and description to render below the header
     */
-  def landingPage (logo: Option[Logo] = None,
+  def landingPage (logo: Option[Image] = None,
                    title: Option[String] = None,
                    subtitle: Option[String] = None,
                    latestReleases: Seq[ReleaseInfo] = Nil,

--- a/io/src/main/scala/laika/helium/config/settings.scala
+++ b/io/src/main/scala/laika/helium/config/settings.scala
@@ -382,13 +382,12 @@ private[helium] trait SiteOps extends SingleConfigOps with CopyOps {
 
   /** Configures the top navigation bar of the main content pages.
     * 
-    * @param logo  an optional logo to be placed in the middle of the bar and linking to the landing page,
-    *              if omitted a default home icon will be used instead.
-    * @param links an optional set of links to be placed at the right side of the bar, supported link
-    *              types are `IconLink`, `ButtonLink` and a plain `TextLink`
+    * @param homeLink the link to the homepage, by default pointing to `index.html` and using the Helium home icon.
+    * @param navLinks an optional set of links to be placed at the right side of the bar, supported link
+    *                 types are `IconLink`, `ButtonLink`, `ImageLink` and a plain `TextLink`
     */
-  def topNavigationBar (logo: Option[Logo] = None, links: Seq[ThemeLink] = Nil): Helium = {
-    val newLayout = helium.siteSettings.layout.copy(topNavigationBar = TopNavigationBar(logo, links))
+  def topNavigationBar (homeLink: ThemeLink = TopNavigationBar.default.homeLink, navLinks: Seq[ThemeLink] = Nil): Helium = {
+    val newLayout = helium.siteSettings.layout.copy(topNavigationBar = TopNavigationBar(homeLink, navLinks))
     copyWith(helium.siteSettings.copy(layout = newLayout))
   }
 

--- a/io/src/main/scala/laika/helium/generate/ConfigGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/ConfigGenerator.scala
@@ -60,11 +60,9 @@ private[laika] object ConfigGenerator {
   }
 
   implicit val topNavBarEncoder: ConfigEncoder[TopNavigationBar] = ConfigEncoder[TopNavigationBar] { navBar =>
-    val logo = navBar.logo.getOrElse(HeliumIcon.home)
-    val homeLink = SpanLink.internal(Root / "README")(logo)
     ConfigEncoder.ObjectBuilder.empty
-      .withValue("home", homeLink)
-      .withValue("links", SpanSequence(navBar.links, HeliumStyles.row))
+      .withValue("home", navBar.homeLink)
+      .withValue("links", SpanSequence(navBar.navLinks, HeliumStyles.row))
       .withValue("versionPrefix", navBar.versionPrefix)
       .build
   }

--- a/io/src/test/scala/laika/helium/HeliumDownloadPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumDownloadPageSpec.scala
@@ -30,6 +30,7 @@ import laika.io.implicits._
 import laika.io.model.StringTreeOutput
 import laika.io.IOFunSuite
 import laika.render.HTMLFormatter
+import laika.rewrite.link.LinkConfig
 import laika.rewrite.nav.{ChoiceConfig, CoverImage, SelectionConfig, Selections}
 import laika.theme._
 
@@ -39,6 +40,7 @@ class HeliumDownloadPageSpec extends IOFunSuite with InputBuilder with ResultExt
   
   def transformer (theme: ThemeProvider, configure: ConfigureTransformer): Resource[IO, TreeTransformer[IO]] = {
     val builder = Transformer.from(Markdown).to(HTML)
+      .withConfigValue(LinkConfig(excludeFromValidation = Seq(Root)))
     configure(builder)  
       .parallel[IO]
       .withTheme(theme)
@@ -91,7 +93,7 @@ class HeliumDownloadPageSpec extends IOFunSuite with InputBuilder with ResultExt
                      |<i class="icofont-laika" title="Navigation">&#xefa2;</i>
                      |</a>
                      |</div>
-                     |<a href="index.html"><i class="icofont-laika" title="Home">&#xef47;</i></a>
+                     |<a class="icon-link" href="index.html"><i class="icofont-laika" title="Home">&#xef47;</i></a>
                      |<span class="row"></span>
                      |</header>
                      |<nav id="sidebar">

--- a/io/src/test/scala/laika/helium/HeliumEPUBCSSSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumEPUBCSSSpec.scala
@@ -64,6 +64,11 @@ class HeliumEPUBCSSSpec extends IOFunSuite with InputBuilder with ResultExtracto
                      |--primary-dark: #095269;
                      |--secondary-color: #931813;
                      |--text-color: #5f5f5f;
+                     |--bg-color: #ffffff;
+                     |--top-color: var(--primary);
+                     |--top-bg: var(--primaryLight);
+                     |--top-hover: var(--secondary);
+                     |--top-border: var(--primaryMedium);
                      |--messages-info: #007c99;
                      |--messages-info-light: #ebf6f7;
                      |--messages-warning: #b1a400;
@@ -145,6 +150,11 @@ class HeliumEPUBCSSSpec extends IOFunSuite with InputBuilder with ResultExtracto
                               |--primary-dark: #095269;
                               |--secondary-color: #931813;
                               |--text-color: #5f5f5f;
+                              |--bg-color: #ffffff;
+                              |--top-color: var(--primary);
+                              |--top-bg: var(--primaryLight);
+                              |--top-hover: var(--secondary);
+                              |--top-border: var(--primaryMedium);
                               |--messages-info: #007c99;
                               |--messages-info-light: #ebf6f7;
                               |--messages-warning: #b1a400;
@@ -196,6 +206,11 @@ class HeliumEPUBCSSSpec extends IOFunSuite with InputBuilder with ResultExtracto
                               |--primary-dark: rgb(0,0,0);
                               |--secondary-color: rgb(212,212,212);
                               |--text-color: rgb(10,10,10);
+                              |--bg-color: rgb(11,11,11);
+                              |--top-color: var(--primary);
+                              |--top-bg: var(--primaryLight);
+                              |--top-hover: var(--secondary);
+                              |--top-border: var(--primaryMedium);
                               |--messages-info: #aaaaaa;
                               |--messages-info-light: #aaaaab;
                               |--messages-warning: #aaaaac;
@@ -235,6 +250,11 @@ class HeliumEPUBCSSSpec extends IOFunSuite with InputBuilder with ResultExtracto
                                  |--primary-dark: rgb(10,10,10);
                                  |--secondary-color: rgb(112,112,112);
                                  |--text-color: rgb(110,110,110);
+                                 |--bg-color: rgb(111,111,111);
+                                 |--top-color: var(--primary);
+                                 |--top-bg: var(--primaryLight);
+                                 |--top-hover: var(--secondary);
+                                 |--top-border: var(--primaryMedium);
                                  |--messages-info: #00aaaa;
                                  |--messages-info-light: #00aaab;
                                  |--messages-warning: #00aaac;
@@ -256,7 +276,7 @@ class HeliumEPUBCSSSpec extends IOFunSuite with InputBuilder with ResultExtracto
     import laika.theme.config.Color._
     val helium = Helium.defaults
       .epub.themeColors(primary = rgb(1,1,1), primaryDark = rgb(0,0,0), primaryLight = rgb(2,2,2), primaryMedium = rgb(4,4,4),
-        secondary = rgb(212,212,212), text = rgb(10,10,10))
+        secondary = rgb(212,212,212), text = rgb(10,10,10), background = rgb(11,11,11))
       .epub.messageColors(info = hex("aaaaaa"), infoLight = hex("aaaaab"), 
         warning = hex("aaaaac"), warningLight = hex("aaaaad"),
         error = hex("aaaaae"), errorLight = hex("aaaaaf")
@@ -272,7 +292,7 @@ class HeliumEPUBCSSSpec extends IOFunSuite with InputBuilder with ResultExtracto
     import laika.theme.config.Color._
     val helium = Helium.defaults
       .all.themeColors(primary = rgb(1,1,1), primaryDark = rgb(0,0,0), primaryLight = rgb(2,2,2), primaryMedium = rgb(4,4,4),
-        secondary = rgb(212,212,212), text = rgb(10,10,10))
+        secondary = rgb(212,212,212), text = rgb(10,10,10), background = rgb(11,11,11))
       .all.messageColors(info = hex("aaaaaa"), infoLight = hex("aaaaab"),
         warning = hex("aaaaac"), warningLight = hex("aaaaad"),
         error = hex("aaaaae"), errorLight = hex("aaaaaf")
@@ -288,7 +308,7 @@ class HeliumEPUBCSSSpec extends IOFunSuite with InputBuilder with ResultExtracto
     import laika.theme.config.Color._
     val helium = Helium.defaults
       .epub.themeColors(primary = rgb(1,1,1), primaryDark = rgb(0,0,0), primaryLight = rgb(2,2,2), primaryMedium = rgb(4,4,4),
-        secondary = rgb(212,212,212), text = rgb(10,10,10))
+        secondary = rgb(212,212,212), text = rgb(10,10,10), background = rgb(11,11,11))
       .epub.messageColors(
         info = hex("aaaaaa"), infoLight = hex("aaaaab"),
         warning = hex("aaaaac"), warningLight = hex("aaaaad"),
@@ -299,7 +319,7 @@ class HeliumEPUBCSSSpec extends IOFunSuite with InputBuilder with ResultExtracto
         wheel = ColorQuintet(hex("110011"), hex("110022"), hex("110033"), hex("110044"), hex("110055"))
       )
       .epub.darkMode.themeColors(primary = rgb(11,11,11), primaryDark = rgb(10,10,10), primaryLight = rgb(12,12,12), 
-        primaryMedium = rgb(14,14,14), secondary = rgb(112,112,112), text = rgb(110,110,110))
+        primaryMedium = rgb(14,14,14), secondary = rgb(112,112,112), text = rgb(110,110,110), background = rgb(111,111,111))
       .epub.darkMode.messageColors(
         info = hex("00aaaa"), infoLight = hex("00aaab"),
         warning = hex("00aaac"), warningLight = hex("00aaad"),
@@ -319,6 +339,11 @@ class HeliumEPUBCSSSpec extends IOFunSuite with InputBuilder with ResultExtracto
                      |--primary-dark: #095269;
                      |--secondary-color: #931813;
                      |--text-color: #5f5f5f;
+                     |--bg-color: #ffffff;
+                     |--top-color: var(--primary);
+                     |--top-bg: var(--primaryLight);
+                     |--top-hover: var(--secondary);
+                     |--top-border: var(--primaryMedium);
                      |--messages-info: #007c99;
                      |--messages-info-light: #ebf6f7;
                      |--messages-warning: #b1a400;

--- a/io/src/test/scala/laika/helium/HeliumFORendererSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumFORendererSpec.scala
@@ -205,7 +205,8 @@ class HeliumFORendererSpec extends IOFunSuite with InputBuilder with ResultExtra
       primaryMedium = Color.hex("000011"),
       primaryLight = Color.hex("000022"),
       secondary = Color.hex("330033"),
-      text = Color.hex("990099")
+      text = Color.hex("990099"),
+      background = Color.hex("eeeeee")
     )
     val expected = """<fo:block font-family="Lato" font-size="10pt" line-height="1.5" space-after="3mm" text-align="justify">Text with a <fo:basic-link color="#330033" external-destination="http://foo.bar" font-weight="bold">link</fo:basic-link>.</fo:block>"""
     transformAndExtract(inputs, helium, "<fo:flow flow-name=\"xsl-region-body\">", "</fo:flow>")

--- a/io/src/test/scala/laika/helium/HeliumHTMLHeadSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumHTMLHeadSpec.scala
@@ -28,6 +28,7 @@ import laika.io.api.{TreeParser, TreeRenderer, TreeTransformer}
 import laika.io.helper.{InputBuilder, ResultExtractor, StringOps}
 import laika.io.implicits._
 import laika.io.model.StringTreeOutput
+import laika.rewrite.link.LinkConfig
 import laika.rewrite.{Version, Versions}
 import laika.theme._
 import laika.theme.config.{Font, FontDefinition, FontStyle, FontWeight}
@@ -36,6 +37,7 @@ class HeliumHTMLHeadSpec extends IOFunSuite with InputBuilder with ResultExtract
 
   val parser: Resource[IO, TreeParser[IO]] = MarkupParser
     .of(Markdown)
+    .withConfigValue(LinkConfig(excludeFromValidation = Seq(Root)))
     .parallel[IO]
     .build
 

--- a/io/src/test/scala/laika/helium/HeliumHTMLNavSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumHTMLNavSpec.scala
@@ -18,7 +18,7 @@ package laika.helium
 
 import cats.effect.{IO, Resource}
 import laika.api.Transformer
-import laika.ast.Path
+import laika.ast.{Image, Path}
 import laika.ast.Path.Root
 import laika.format.{HTML, Markdown}
 import laika.helium.config._
@@ -27,6 +27,7 @@ import laika.io.api.TreeTransformer
 import laika.io.helper.{InputBuilder, ResultExtractor, StringOps}
 import laika.io.implicits._
 import laika.io.model.StringTreeOutput
+import laika.rewrite.link.LinkConfig
 import laika.rewrite.{Version, Versions}
 import laika.theme._
 
@@ -35,6 +36,7 @@ class HeliumHTMLNavSpec extends IOFunSuite with InputBuilder with ResultExtracto
   def transformer (theme: ThemeProvider): Resource[IO, TreeTransformer[IO]] = Transformer
     .from(Markdown)
     .to(HTML)
+    .withConfigValue(LinkConfig(excludeFromValidation = Seq(Root)))
     .parallel[IO]
     .withTheme(theme)
     .build
@@ -133,7 +135,7 @@ class HeliumHTMLNavSpec extends IOFunSuite with InputBuilder with ResultExtracto
         |<i class="icofont-laika" title="Navigation">&#xefa2;</i>
         |</a>
         |</div>
-        |<a href="index.html"><i class="icofont-laika" title="Home">&#xef47;</i></a>
+        |<a class="icon-link" href="index.html"><i class="icofont-laika" title="Home">&#xef47;</i></a>
         |<span class="row"></span>""".stripMargin
     transformAndExtract(inputs, Helium.defaults.site.landingPage(), "<header id=\"top-bar\">", "</header>").assertEquals(expected)
   }
@@ -145,13 +147,13 @@ class HeliumHTMLNavSpec extends IOFunSuite with InputBuilder with ResultExtracto
         |<i class="icofont-laika" title="Navigation">&#xefa2;</i>
         |</a>
         |</div>
-        |<a href="index.html"><img src="home.png" alt="Homepage" title="Home"></a>
+        |<a class="image-link" href="index.html"><img src="home.png" alt="Homepage" title="Home"></a>
         |<span class="row"><a class="icon-link" href="doc-2.html"><i class="icofont-laika" title="Demo">&#xeeea;</i></a><a class="button-link" href="http://somewhere.com/">Somewhere</a></span>""".stripMargin
     val imagePath = Root / "home.png"
     val helium = Helium.defaults.site.landingPage()
       .site.topNavigationBar(
-        logo = Some(Logo.internal(imagePath, alt = Some("Homepage"), title = Some("Home"))), 
-        links = Seq(
+        homeLink = ImageLink.internal(Root / "README", Image.internal(imagePath, alt = Some("Homepage"), title = Some("Home"))), 
+        navLinks = Seq(
           IconLink.internal(Root / "doc-2.md", HeliumIcon.demo),
           ButtonLink.external("http://somewhere.com/", "Somewhere")
         ))
@@ -185,7 +187,7 @@ class HeliumHTMLNavSpec extends IOFunSuite with InputBuilder with ResultExtracto
         |</nav>
         |</div>
         |</div>
-        |<a href="index.html"><i class="icofont-laika" title="Home">&#xef47;</i></a>
+        |<a class="icon-link" href="index.html"><i class="icofont-laika" title="Home">&#xef47;</i></a>
         |<span class="row"></span>""".stripMargin
     transformAndExtract(inputs, helium, "<header id=\"top-bar\">", "</header>").assertEquals(expected)
   }

--- a/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
@@ -29,6 +29,7 @@ import laika.io.api.TreeTransformer
 import laika.io.helper.{InputBuilder, ResultExtractor, StringOps}
 import laika.io.implicits._
 import laika.io.model.StringTreeOutput
+import laika.rewrite.link.LinkConfig
 import laika.theme._
 
 class HeliumLandingPageSpec extends IOFunSuite with InputBuilder with ResultExtractor with StringOps {
@@ -36,6 +37,7 @@ class HeliumLandingPageSpec extends IOFunSuite with InputBuilder with ResultExtr
   def transformer (theme: ThemeProvider): Resource[IO, TreeTransformer[IO]] = Transformer
     .from(Markdown)
     .to(HTML)
+    .withConfigValue(LinkConfig(excludeFromValidation = Seq(Root)))
     .parallel[IO]
     .withTheme(theme)
     .build

--- a/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
@@ -20,7 +20,7 @@ import java.util.Locale
 
 import cats.effect.{IO, Resource}
 import laika.api.Transformer
-import laika.ast.Path
+import laika.ast.{Image, Path}
 import laika.ast.Path.Root
 import laika.format.{HTML, Markdown}
 import laika.helium.config._
@@ -116,7 +116,7 @@ class HeliumLandingPageSpec extends IOFunSuite with InputBuilder with ResultExtr
                      |</body>""".stripMargin
     val imagePath = Root / "home.png"
     val helium = Helium.defaults.site.landingPage(
-      logo = Some(Logo.internal(imagePath, alt = Some("Project Logo"))),
+      logo = Some(Image.internal(imagePath, alt = Some("Project Logo"))),
       title = Some("My Project"),
       subtitle = Some("Awesome Hyperbole Overkill"),
       latestReleases = Seq(
@@ -173,7 +173,7 @@ class HeliumLandingPageSpec extends IOFunSuite with InputBuilder with ResultExtr
                      |</body>""".stripMargin
     val imagePath = Root / "home.png"
     val helium = Helium.defaults.site.landingPage(
-      logo = Some(Logo.internal(imagePath, alt = Some("Project Logo"))),
+      logo = Some(Image.internal(imagePath, alt = Some("Project Logo"))),
       subtitle = Some("Awesome Hyperbole Overkill"),
       latestReleases = Seq(
         ReleaseInfo("Latest Release", "2.3.5")

--- a/io/src/test/scala/laika/helium/HeliumRenderOverridesSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumRenderOverridesSpec.scala
@@ -19,7 +19,7 @@ package laika.helium
 import cats.effect.{IO, Resource}
 import laika.api.Transformer
 import laika.api.builder.TransformerBuilder
-import laika.ast.{IconGlyph, Icon, Path}
+import laika.ast.{Icon, IconGlyph, Path}
 import laika.ast.Path.Root
 import laika.format.{HTML, Markdown}
 import laika.helium.config.{AnchorPlacement, HeliumIcon}
@@ -29,6 +29,7 @@ import laika.io.helper.{InputBuilder, ResultExtractor, StringOps}
 import laika.io.implicits._
 import laika.io.model.StringTreeOutput
 import laika.render.HTMLFormatter
+import laika.rewrite.link.LinkConfig
 import laika.rewrite.nav.{ChoiceConfig, SelectionConfig, Selections}
 import laika.theme._
 
@@ -38,6 +39,7 @@ class HeliumRenderOverridesSpec extends IOFunSuite with InputBuilder with Result
   
   def transformer (theme: ThemeProvider, configure: ConfigureTransformer): Resource[IO, TreeTransformer[IO]] = {
     val builder = Transformer.from(Markdown).to(HTML)
+      .withConfigValue(LinkConfig(excludeFromValidation = Seq(Root)))
     configure(builder)  
       .parallel[IO]
       .withTheme(theme)

--- a/io/src/test/scala/laika/helium/HeliumSiteCSSSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumSiteCSSSpec.scala
@@ -59,6 +59,11 @@ class HeliumSiteCSSSpec extends IOFunSuite with InputBuilder with ResultExtracto
                      |--primary-dark: #095269;
                      |--secondary-color: #931813;
                      |--text-color: #5f5f5f;
+                     |--bg-color: #ffffff;
+                     |--top-color: var(--primary);
+                     |--top-bg: var(--primaryLight);
+                     |--top-hover: var(--secondary);
+                     |--top-border: var(--primaryMedium);
                      |--messages-info: #007c99;
                      |--messages-info-light: #ebf6f7;
                      |--messages-warning: #b1a400;
@@ -98,6 +103,11 @@ class HeliumSiteCSSSpec extends IOFunSuite with InputBuilder with ResultExtracto
                               |--primary-dark: #095269;
                               |--secondary-color: #931813;
                               |--text-color: #5f5f5f;
+                              |--bg-color: #ffffff;
+                              |--top-color: var(--primary);
+                              |--top-bg: var(--primaryLight);
+                              |--top-hover: var(--secondary);
+                              |--top-border: var(--primaryMedium);
                               |--messages-info: #007c99;
                               |--messages-info-light: #ebf6f7;
                               |--messages-warning: #b1a400;
@@ -151,6 +161,11 @@ class HeliumSiteCSSSpec extends IOFunSuite with InputBuilder with ResultExtracto
                               |--primary-dark: rgb(0,0,0);
                               |--secondary-color: rgb(212,212,212);
                               |--text-color: rgb(10,10,10);
+                              |--bg-color: rgb(11,11,11);
+                              |--top-color: var(--primary);
+                              |--top-bg: var(--primaryLight);
+                              |--top-hover: var(--secondary);
+                              |--top-border: var(--primaryMedium);
                               |--messages-info: #aaaaaa;
                               |--messages-info-light: #aaaaab;
                               |--messages-warning: #aaaaac;
@@ -186,7 +201,7 @@ class HeliumSiteCSSSpec extends IOFunSuite with InputBuilder with ResultExtracto
     import laika.theme.config.Color._
     val helium = Helium.defaults
       .site.themeColors(primary = rgb(1,1,1), primaryDark = rgb(0,0,0), primaryLight = rgb(2,2,2), primaryMedium = rgb(4,4,4),
-        secondary = rgb(212,212,212), text = rgb(10,10,10))
+        secondary = rgb(212,212,212), text = rgb(10,10,10), background = rgb(11,11,11))
       .site.messageColors(info = hex("aaaaaa"), infoLight = hex("aaaaab"), 
         warning = hex("aaaaac"), warningLight = hex("aaaaad"),
         error = hex("aaaaae"), errorLight = hex("aaaaaf")
@@ -202,7 +217,7 @@ class HeliumSiteCSSSpec extends IOFunSuite with InputBuilder with ResultExtracto
     import laika.theme.config.Color._
     val helium = Helium.defaults
       .all.themeColors(primary = rgb(1,1,1), primaryDark = rgb(0,0,0), primaryLight = rgb(2,2,2), primaryMedium = rgb(4,4,4),
-        secondary = rgb(212,212,212), text = rgb(10,10,10))
+        secondary = rgb(212,212,212), text = rgb(10,10,10), background = rgb(11,11,11))
       .all.messageColors(info = hex("aaaaaa"), infoLight = hex("aaaaab"),
         warning = hex("aaaaac"), warningLight = hex("aaaaad"),
         error = hex("aaaaae"), errorLight = hex("aaaaaf")
@@ -220,6 +235,11 @@ class HeliumSiteCSSSpec extends IOFunSuite with InputBuilder with ResultExtracto
                                |--primary-dark: #095269;
                                |--secondary-color: #931813;
                                |--text-color: #5f5f5f;
+                               |--bg-color: #ffffff;
+                               |--top-color: var(--primary);
+                               |--top-bg: var(--primaryLight);
+                               |--top-hover: var(--secondary);
+                               |--top-border: var(--primaryMedium);
                                |--messages-info: #007c99;
                                |--messages-info-light: #ebf6f7;
                                |--messages-warning: #b1a400;

--- a/io/src/test/scala/laika/helium/HeliumSiteCSSSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumSiteCSSSpec.scala
@@ -28,6 +28,7 @@ import laika.io.api.TreeTransformer
 import laika.io.helper.{InputBuilder, ResultExtractor, StringOps}
 import laika.io.implicits._
 import laika.io.model.StringTreeOutput
+import laika.rewrite.link.LinkConfig
 import laika.theme.ThemeProvider
 
 class HeliumSiteCSSSpec extends IOFunSuite with InputBuilder with ResultExtractor with StringOps {
@@ -35,6 +36,7 @@ class HeliumSiteCSSSpec extends IOFunSuite with InputBuilder with ResultExtracto
   def transformer (theme: ThemeProvider): Resource[IO, TreeTransformer[IO]] = Transformer
     .from(Markdown)
     .to(HTML)
+    .withConfigValue(LinkConfig(excludeFromValidation = Seq(Root)))
     .parallel[IO]
     .withTheme(theme)
     .build

--- a/io/src/test/scala/laika/helium/HeliumTocPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumTocPageSpec.scala
@@ -55,7 +55,7 @@ class HeliumTocPageSpec extends IOFunSuite with InputBuilder with ResultExtracto
   }
     
   test("no table of content page configured") {
-    transformAndExtract(twoDocs, Helium.defaults, "", "")
+    transformAndExtract(twoDocs, Helium.defaults.site.landingPage(), "", "")
       .assertFailsWithMessage("Missing document under test")
   }
   
@@ -80,7 +80,7 @@ class HeliumTocPageSpec extends IOFunSuite with InputBuilder with ResultExtracto
                      |<i class="icofont-laika" title="Navigation">&#xefa2;</i>
                      |</a>
                      |</div>
-                     |<a href="index.html"><i class="icofont-laika" title="Home">&#xef47;</i></a>
+                     |<a class="icon-link" href="index.html"><i class="icofont-laika" title="Home">&#xef47;</i></a>
                      |<span class="row"></span>
                      |</header>
                      |<nav id="sidebar">


### PR DESCRIPTION
* Makes the link of the home icon configurable (fixes #172).
* Add a "high-contrast" option for the top navigation bar (darker in light mode and lighter in dark mode).
* Add the page's background color to the configurable theme colors.