### PR TITLE
Preview

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,9 +74,13 @@ val http4s     = Seq(
                    "org.http4s"           %% "http4s-dsl"          % "0.21.20",
                    "org.http4s"           %% "http4s-blaze-server" % "0.21.20"
                  )
+val http4sM    = Seq(
+                    "org.http4s"          %% "http4s-dsl"          % "1.0.0-M21",
+                    "org.http4s"          %% "http4s-blaze-server" % "1.0.0-M21"
+                 )
 
 lazy val root = project.in(file("."))
-  .aggregate(core.js, core.jvm, pdf, io, plugin)
+  .aggregate(core.js, core.jvm, pdf, io, preview, plugin)
   .settings(basicSettings)
   .settings(noPublishSettings)
   .enablePlugins(ScalaUnidocPlugin)
@@ -135,9 +139,18 @@ lazy val pdf = project.in(file("pdf"))
     name := "laika-pdf",
     libraryDependencies ++= Seq(fop, scalatest)
   )
-  
-lazy val plugin = project.in(file("sbt"))
+
+lazy val preview = project.in(file("preview"))
   .dependsOn(core.jvm, io, pdf)
+  .settings(moduleSettings)
+  .settings(publishSettings)
+  .settings(
+    name := "laika-preview",
+    libraryDependencies ++= (http4sM :+ scalatest)
+  )
+
+lazy val plugin = project.in(file("sbt"))
+  .dependsOn(core.jvm, io, pdf, preview)
   .enablePlugins(SbtPlugin)
   .settings(basicSettings)
   .settings(publishSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -141,7 +141,7 @@ lazy val pdf = project.in(file("pdf"))
   )
 
 lazy val preview = project.in(file("preview"))
-  .dependsOn(core.jvm, io, pdf)
+  .dependsOn(core.jvm, io % "compile->compile;test->test", pdf)
   .settings(moduleSettings)
   .settings(publishSettings)
   .settings(

--- a/core/shared/src/main/scala/laika/collection/TransitionalCollectionOps.scala
+++ b/core/shared/src/main/scala/laika/collection/TransitionalCollectionOps.scala
@@ -16,6 +16,8 @@
 
 package laika.collection
 
+import scala.collection.{AbstractIterator, Iterator}
+
 /** Temporary extension methods for cross-building to Scala 2.12 and 2.13.
   *
   * @author Jens Halm
@@ -48,6 +50,14 @@ object TransitionalCollectionOps {
     private val cIter = cs.iterator
     def hasNext = aIter.hasNext && bIter.hasNext && cIter.hasNext
     def next() = (aIter.next(), bIter.next(), cIter.next())
+  }
+
+  /** Simple utility to avoid having either a dependency to scala-compat or a warning with 2.13.
+    * There are very few places within Laika where we need to deal with a Java collection.
+    */
+  case class JIteratorWrapper[A](underlying: java.util.Iterator[A]) extends AbstractIterator[A] with Iterator[A] {
+    def hasNext: Boolean = underlying.hasNext
+    def next(): A = underlying.next
   }
 
 }

--- a/core/shared/src/main/scala/laika/config/LaikaKeys.scala
+++ b/core/shared/src/main/scala/laika/config/LaikaKeys.scala
@@ -69,5 +69,10 @@ object LaikaKeys {
     val downloadPath: Key = root.child(Key("site","apiPath"))
     val metadata: Key = root.child(Key("site", "metadata"))
   }
+  object preview {
+    private val base = root.child("preview")
+    val enabled: Key = base.child("enabled")
+    val pollInterval: Key = base.child("pollInterval")
+  }
   
 }

--- a/docs/src/02-running-laika/01-sbt-plugin.md
+++ b/docs/src/02-running-laika/01-sbt-plugin.md
@@ -145,6 +145,22 @@ Finally if you only work with a single format there are also shortcut tasks for 
 `laikaHTML`, `laikaEPUB`, `laikaPDF` and `laikaAST`.
 
 
+Using the Preview Server
+------------------------
+
+Laika contains a preview server that can be used to browse generated sites.
+Simply run the `laikaPreview` task and navigate to `localhost:4242` in the browser.
+For overriding the default configuration for the preview server, see [laikaPreviewConfig setting] below.
+
+The page will auto-refresh whenever changes to any input document are detected.
+The default poll interval is 3 seconds.
+If you are using an IDE with auto-save you might need to tweak its preferences
+for seeing changes while editing the Markdown sources. 
+IntelliJ, for example, only auto-saves when you run or compile an application or when you switch to a
+different application in the OS. 
+You can either use `cmd-S` to manually force saving or change the preferences to auto-save in fixed time intervals. 
+
+
 Plugin Settings
 ---------------
 
@@ -333,6 +349,22 @@ Finally there are three boolean flags that only affect the laikaSite task.
 - `laikaIncludeEPUB` - default `false` - see [Including EPUB and PDF].
 
 - `laikaIncludePDF` - default `false` - see [Including EPUB and PDF].
+
+
+### laikaPreviewConfig setting
+
+You can override the defaults by for the `laikaPreview` task if necessary:
+
+```scala
+laikaPreviewConfig :=
+  LaikaPreviewConfig.defaults
+    .withPort(8080)
+    .withPollInterval(5.seconds)
+    .verbose
+```
+
+By default, the port is 4242, the poll interval is 3 seconds.
+With the `verbose` options the console will log all pages served.
 
 
 ### Inspecting Laika's Configuration

--- a/docs/src/02-running-laika/02-library-api.md
+++ b/docs/src/02-running-laika/02-library-api.md
@@ -86,7 +86,7 @@ the `laika-io` module expands on the core API to add this functionality:
 @:image(../img/io-api-0_18.png) {
   alt = Anatomy of the IO API
   intrinsicWidth = 602
-  intrinsicHeight = 433
+  intrinsicHeight = 408
 }
 
 The blue elements of the API are identical to the pure transformer.
@@ -619,3 +619,50 @@ These other settings are available independent from the theme in use:
 
 - [Inspecting Laika's Configuration]: Run the `describe` method on the IO-based transformers, parsers and renderers 
   to get a formatted summary of the active configuration, installed extension bundles and lists of input and output files.
+
+
+Using the Preview Server
+------------------------
+
+Laika contains a preview server that can be used to browse generated sites. 
+This includes auto-refreshing whenever changes to any input document are detected. 
+It is the basis of the `laikaPreview` task of the sbt plugin, 
+but can alternatively be launched via the library API:
+
+```scala
+val parser = MarkupParser
+  .of(Markdown)
+  .using(GitHubFlavor)
+  .parallel[IO]
+  .build
+
+val inputs = InputTree[IO]
+  .addDirectory("/path/to/your/inputs")
+
+ServerBuilder[IO](parser, inputs)
+  .build
+  .use(_ => IO.never)
+```
+
+The above example creates a server based on its default configuration.
+Open `localhost:4242` for the landing page of your site.
+You can override the defaults by passing a `ServerConfig` instance explicitly:
+
+```scala
+val config =
+  ServerConfig.defaults
+    .withPort(8080)
+    .withPollInterval(5.seconds)
+    .withEPUBDownloads
+    .withPDFDownloads
+    .verbose
+
+ServerBuilder[IO](parser, inputs)
+  .withConfig(config)
+  .build
+  .use(_ => IO.never)
+```
+
+By default, the port is 4242, the poll interval is 3 seconds, and EPUB or PDF downloads will not be included
+in the generated site.
+

--- a/docs/src/07-reference/06-release-notes.md
+++ b/docs/src/07-reference/06-release-notes.md
@@ -13,6 +13,11 @@ Release Notes
     * PDF support: remove the old callback hacks for integration with the blocking, synchronous `ResourceResolver` API
       of Apache FOP by using the new `Dispatcher` from CE3 instead.
 * Support for Scala 3.0
+* New Preview Server
+    * The new `laikaPreview` task of the sbt plugin can be used to browse generated sites.
+    * Includes auto-refreshing when input sources change.
+    * Can also be launched via the library API, using `laika.preview.ServerBuilder`.
+    * Introduces a new published module `laika-preview` that the sbt plugin depends on.
 * New Directives:
     * `@:path`: Validates and translates a path in a template to a path relative to the rendered document the template
       is applied to.

--- a/io/src/main/resources/laika/helium/js/preview.js
+++ b/io/src/main/resources/laika/helium/js/preview.js
@@ -1,0 +1,23 @@
+
+function refresh(targets) {
+  targets.forEach( target => {
+    sessionStorage.setItem('scrollpos-' + target.id, target.scrollTop.toString());
+  });
+  window.location.reload();
+}
+
+function restoreScrollPos(targets) {
+  targets.forEach( target => {
+    let scrollPos = sessionStorage.getItem('scrollpos-' + target.id);
+    if (scrollPos) target.scrollTop = parseInt(scrollPos);
+    sessionStorage.removeItem('scrollpos-' + target.id);
+  });
+}
+
+function initPreview (targetIds, pollInterval) {
+  document.addEventListener('DOMContentLoaded', () => {
+    let targets = targetIds.map(id => document.getElementById(id));
+    restoreScrollPos(targets);
+    setTimeout(() => refresh(targets), pollInterval);
+  });
+}

--- a/io/src/main/resources/laika/helium/js/versions.js
+++ b/io/src/main/resources/laika/helium/js/versions.js
@@ -38,7 +38,7 @@ function populateMenu (data, localRootPrefix, currentPath, currentVersion) {
 }
 
 function loadVersions (localRootPrefix, currentPath, currentVersion) {
-  const url = localRootPrefix + "/laika/versionInfo.json";
+  const url = localRootPrefix + "laika/versionInfo.json";
   const req = new XMLHttpRequest();
   req.open("GET", url);
   req.responseType = "json";

--- a/io/src/main/resources/laika/helium/templates/default.template.html
+++ b/io/src/main/resources/laika/helium/templates/default.template.html
@@ -21,6 +21,7 @@
     @:linkCSS { paths = ${helium.site.includeCSS} }
     @:linkJS { paths = ${helium.site.includeJS} }
     @:heliumInitVersions
+    @:heliumInitPreview
     <script> /* for avoiding page load transitions */ </script>
   </head>
 

--- a/io/src/main/resources/laika/helium/templates/default.template.html
+++ b/io/src/main/resources/laika/helium/templates/default.template.html
@@ -21,7 +21,7 @@
     @:linkCSS { paths = ${helium.site.includeCSS} }
     @:linkJS { paths = ${helium.site.includeJS} }
     @:heliumInitVersions
-    @:heliumInitPreview
+    @:heliumInitPreview(container)
     <script> /* for avoiding page load transitions */ </script>
   </head>
 

--- a/io/src/main/scala/laika/format/EPUB.scala
+++ b/io/src/main/scala/laika/format/EPUB.scala
@@ -59,6 +59,8 @@ import laika.theme.Theme
  */
 case object EPUB extends TwoPhaseRenderFormat[HTMLFormatter, BinaryPostProcessorBuilder] {
 
+  override val description: String = "EPUB"
+  
   /** A render format for XHTML output as used by EPUB output.
     *
     * This format is usually not used directly with Laika's `Render` or `Transform` APIs.

--- a/io/src/main/scala/laika/helium/builder/HeliumInputBuilder.scala
+++ b/io/src/main/scala/laika/helium/builder/HeliumInputBuilder.scala
@@ -54,6 +54,7 @@ private[helium] object HeliumInputBuilder {
       .addClasspathResource("laika/helium/templates/landing.template.html", Root / "landing.template.html")
       .addClasspathResource("laika/helium/templates/default.template.fo", DefaultTemplatePath.forFO)
       .addClasspathResource("laika/helium/js/theme.js", heliumPath / "laika-helium.js")
+      .addClasspathResource("laika/helium/js/preview.js", heliumPath / "laika-preview.js")
       .addClasspathResource("laika/helium/css/landing.css", heliumPath / "landing.page.css")
       .addClasspathResource("laika/helium/fonts/icofont/icofont.min.css", heliumPath / "icofont.min.css")
       .addClasspathResource("laika/helium/fonts/icofont/fonts/icofont.woff", heliumPath / "fonts" / "icofont.woff")

--- a/io/src/main/scala/laika/helium/builder/HeliumThemeBuilder.scala
+++ b/io/src/main/scala/laika/helium/builder/HeliumThemeBuilder.scala
@@ -34,7 +34,7 @@ private[helium] class HeliumThemeBuilder (helium: Helium) extends ThemeProvider 
     override val description: String = "Directives for theme 'Helium'"
     val spanDirectives: Seq[Spans.Directive] = Nil
     val blockDirectives: Seq[Blocks.Directive] = Nil
-    val templateDirectives: Seq[Templates.Directive] = Seq(InitVersionsDirective.definition)
+    val templateDirectives: Seq[Templates.Directive] = HeliumDirectives.all
     val linkDirectives: Seq[Links.Directive] = Nil
   }
   

--- a/io/src/main/scala/laika/io/api/TreeParser.scala
+++ b/io/src/main/scala/laika/io/api/TreeParser.scala
@@ -33,7 +33,7 @@ import laika.parse.markup.DocumentParser.{ParserError, DocumentInput}
   *
   * @author Jens Halm
   */
-class TreeParser[F[_]: Sync: Batch] (parsers: NonEmptyList[MarkupParser], theme: Theme[F]) extends InputOps[F] {
+class TreeParser[F[_]: Sync: Batch] (parsers: NonEmptyList[MarkupParser], val theme: Theme[F]) extends InputOps[F] {
 
   type Result = TreeParser.Op[F]
 

--- a/io/src/main/scala/laika/io/api/TreeParser.scala
+++ b/io/src/main/scala/laika/io/api/TreeParser.scala
@@ -45,6 +45,11 @@ class TreeParser[F[_]: Sync: Batch] (parsers: NonEmptyList[MarkupParser], theme:
     .map(_.config)
     .reduceLeft[OperationConfig](_ merge _)
     .withBundles(theme.extensions)
+  
+  private[laika] def modifyConfig (f: OperationConfig => OperationConfig): TreeParser[F] = {
+    val modifiedParsers = parsers.map(p => new MarkupParser(p.format, f(p.config)))
+    new TreeParser(modifiedParsers, theme)
+  }
 
   def fromInput (input: InputTreeBuilder[F]): TreeParser.Op[F] = TreeParser.Op(parsers, theme, input)
 

--- a/io/src/main/scala/laika/io/api/TreeRenderer.scala
+++ b/io/src/main/scala/laika/io/api/TreeRenderer.scala
@@ -20,10 +20,11 @@ import cats.effect.{Resource, Sync}
 import laika.api.Renderer
 import laika.api.builder.OperationConfig
 import laika.ast.DocumentTreeRoot
+import laika.io.api.BinaryTreeRenderer.Builder
 import laika.io.descriptor.RendererDescriptor
 import laika.io.model.{BinaryInput, RenderedTreeRoot, TreeOutput}
 import laika.io.ops.TextOutputOps
-import laika.io.runtime.{RendererRuntime, Batch}
+import laika.io.runtime.{Batch, RendererRuntime}
 import laika.theme.{Theme, ThemeProvider}
 
 /** Renderer for a tree of output documents.
@@ -45,15 +46,19 @@ object TreeRenderer {
 
   /** Builder step that allows to specify the execution context for blocking IO and CPU-bound tasks.
     */
-  case class Builder[F[_]: Sync: Batch] (renderer: Renderer, theme: ThemeProvider) {
+  class Builder[F[_]: Sync: Batch] (renderer: Renderer, theme: Resource[F, Theme[F]]) {
 
     /** Applies the specified theme to this renderer, overriding any previously specified themes.
       */
-    def withTheme (theme: ThemeProvider): Builder[F] = copy(theme = theme)
+    def withTheme (theme: ThemeProvider): Builder[F] = new Builder(renderer, theme.build)
 
+    /** Applies the specified theme to this renderer, overriding any previously specified themes.
+      */
+    def withTheme (theme: Theme[F]): Builder[F] = new Builder(renderer, Resource.pure[F, Theme[F]](theme))
+    
     /** Final builder step that creates a parallel renderer.
       */
-    def build: Resource[F, TreeRenderer[F]] = theme.build.map(new TreeRenderer[F](renderer, _))
+    def build: Resource[F, TreeRenderer[F]] = theme.map(new TreeRenderer[F](renderer, _))
 
   }
 

--- a/io/src/main/scala/laika/io/implicits.scala
+++ b/io/src/main/scala/laika/io/implicits.scala
@@ -77,7 +77,7 @@ object implicits {
   implicit class ImplicitTextRendererOps (val builder: RendererBuilder[_]) extends SyncIOBuilderOps[TreeRenderer.Builder] {
 
     protected def build[F[_]: Sync: Batch]: TreeRenderer.Builder[F] =
-      new TreeRenderer.Builder[F](builder.build, Helium.defaults.build)
+      new TreeRenderer.Builder[F](builder.build, Helium.defaults.build.build)
   }
 
   implicit class ImplicitTextTransformerOps (val builder: TransformerBuilder[_]) extends SyncIOBuilderOps[TreeTransformer.Builder] {
@@ -92,7 +92,7 @@ object implicits {
   implicit class ImplicitBinaryRendererOps (val builder: TwoPhaseRendererBuilder[_, BinaryPostProcessorBuilder]) extends AsyncIOBuilderOps[BinaryTreeRenderer.Builder] {
 
     protected def build[F[_]: Async: Batch]: BinaryTreeRenderer.Builder[F] = {
-      new BinaryTreeRenderer.Builder[F](builder.twoPhaseFormat, builder.config, Helium.defaults.build)
+      new BinaryTreeRenderer.Builder[F](builder.twoPhaseFormat, builder.config, Helium.defaults.build.build)
     }
   }
 

--- a/io/src/main/scala/laika/io/model/Input.scala
+++ b/io/src/main/scala/laika/io/model/Input.scala
@@ -46,7 +46,7 @@ case class BinaryInput[F[_]: Sync] (path: Path,
 object BinaryInput {
   
   def fromString[F[_]: Sync] (path: Path, input: String, targetFormats: TargetFormats = TargetFormats.All): BinaryInput[F] = {
-    val resource = Resource.pure[F, InputStream](new ByteArrayInputStream(input.getBytes(Codec.UTF8.charSet)))
+    val resource = Resource.eval[F, InputStream](Sync[F].delay(new ByteArrayInputStream(input.getBytes(Codec.UTF8.charSet))))
     BinaryInput(path, resource, targetFormats)
   }
 

--- a/io/src/main/scala/laika/io/runtime/DirectoryScanner.scala
+++ b/io/src/main/scala/laika/io/runtime/DirectoryScanner.scala
@@ -18,13 +18,12 @@ package laika.io.runtime
 
 import java.nio.file.{Files, Path => JPath}
 
-import cats.effect.{Sync, Resource}
+import cats.effect.{Resource, Sync}
 import cats.implicits._
 import laika.ast.DocumentType.Static
 import laika.ast.{Path, TextDocumentType}
+import laika.collection.TransitionalCollectionOps.JIteratorWrapper
 import laika.io.model._
-
-import scala.collection.{AbstractIterator, Iterator}
 
 /** Scans a directory in the file system and transforms it into a generic InputCollection
   * that can serve as input for parallel parsers or transformers.
@@ -69,13 +68,6 @@ object DirectoryScanner {
     }
 
     join(entries.map(toCollection))
-  }
-  
-  // copied from SDK source to avoid having either a dependency to scala-compat or a warning with 2.13
-  // this is literally the one place in the Laika source where we need to deal with a Java collection
-  case class JIteratorWrapper[A](underlying: java.util.Iterator[A]) extends AbstractIterator[A] with Iterator[A] {
-    def hasNext: Boolean = underlying.hasNext
-    def next(): A = underlying.next
   }
   
 }

--- a/io/src/test/scala/laika/io/IOSpec.scala
+++ b/io/src/test/scala/laika/io/IOSpec.scala
@@ -47,12 +47,18 @@ trait IOSpec extends Matchers {
       self.map(_.assertEquals(tree)).unsafeRunSync()
 
   }
+
+  implicit class AssertingIO[A] (private val self: IO[Assertion]) {
+    def run: Assertion = self.unsafeRunSync()
+  }
   
   implicit class Asserting[A](private val self: IO[A]) {
 
     def assertEquals(a: A): Assertion = self.map(_ shouldBe a).unsafeRunSync()
 
     def asserting(f: A => Assertion): Assertion = self.map(f).unsafeRunSync()
+    
+    def assertingIO(f: A => IO[Assertion]): Assertion = self.flatMap(f).unsafeRunSync()
 
     def assertFailsWith (t: Throwable): Assertion = self.attempt.map(_ shouldBe Left(t)).unsafeRunSync()
     

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -583,7 +583,7 @@ class TreeRendererSpec extends IOWordSpec
 
       def docHTML(num: Int): String = s"<p>Text $num</p>"
       
-      val expectedStatic = staticDocs.drop(2).map(_.path)
+      val expectedStatic = staticDocs.drop(2).map(in => Root / "0.4" / in.path.relative)
       val expectedRendered = renderedRoot(List(
         renderedTree(Root / "0.4", List(
           renderedTree(Root / "0.4" / "tree-1", List(

--- a/preview/src/main/scala/laika/preview/Cache.scala
+++ b/preview/src/main/scala/laika/preview/Cache.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package laika.preview
+
+import cats.effect.{Concurrent, Ref}
+import cats.syntax.all._
+import laika.preview.Cache.Result
+
+
+private[preview] class Cache[F[_]: Concurrent, V] (factory: F[V], ref: Ref[F, Result[V]]) {
+
+  def get: F[V] = ref.get.rethrow
+
+  def update: F[Unit] =
+    factory.attempt.flatMap { result =>
+      ref.set(result)
+    }
+  
+}
+
+private[preview] object Cache {
+
+  type Result[A] = Either[Throwable, A]
+
+  def create[F[_]: Concurrent, V] (factory: F[V]): F[Cache[F, V]] = factory.attempt.flatMap { result =>
+    Concurrent[F].ref(result).map { ref => new Cache[F, V](factory, ref) }
+  }
+
+}

--- a/preview/src/main/scala/laika/preview/RouteBuilder.scala
+++ b/preview/src/main/scala/laika/preview/RouteBuilder.scala
@@ -1,0 +1,44 @@
+package laika.preview
+
+import java.io.InputStream
+
+import cats.syntax.all._
+import cats.effect.{Async, Resource, Sync}
+import fs2.io.readInputStream
+import laika.{ast, config}
+import org.http4s.EntityEncoder.entityBodyEncoder
+import org.http4s.dsl.Http4sDsl
+import org.http4s.{EntityEncoder, Headers, HttpRoutes, MediaType}
+import org.http4s.headers.`Content-Type`
+
+class RouteBuilder[F[_]: Async](cache: Cache[F, Map[ast.Path, Either[Resource[F, InputStream], String]]]) extends Http4sDsl[F] {
+
+  implicit def inputStreamResourceEncoder[G[_]: Sync, IS <: InputStream]: EntityEncoder[G, Resource[G, IS]] =
+    entityBodyEncoder[G].contramap { (in: Resource[G, IS]) =>
+      fs2.Stream.resource(in).flatMap { stream =>
+        readInputStream[G](Sync[G].pure(stream), 4096, closeAfterUse = false)
+      }
+    }
+  
+  private def mediaTypeFor (suffix: String): Option[MediaType] =
+    MediaType.forExtension(suffix).orElse(MediaType.forExtension(suffix.split("\\.").last))
+  
+  def build: HttpRoutes[F] = HttpRoutes.of[F] {
+
+    case GET -> path =>
+      val laikaPath = laika.ast.Path.parse(path.toString)
+      cache.get.map(_.get(laikaPath.withoutFragment)).flatMap {
+        case Some(Right(content)) =>
+          Async[F].delay(println(s"serving path $laikaPath - transformed markup")) *>
+          Ok(content).map(_.withContentType(`Content-Type`(MediaType.text.html)))
+        case Some(Left(input)) =>
+          Async[F].delay(println(s"serving path $laikaPath - static input")) *> {
+            val mediaType = laikaPath.suffix.flatMap(mediaTypeFor).map(`Content-Type`(_))
+            Ok(input).map(_.withHeaders(Headers(mediaType)))
+          }
+        case None =>
+          Async[F].delay(println(s"serving path $laikaPath - not found")) *> NotFound()
+      }
+  }
+  
+}

--- a/preview/src/main/scala/laika/preview/RouteBuilder.scala
+++ b/preview/src/main/scala/laika/preview/RouteBuilder.scala
@@ -8,8 +8,8 @@ import fs2.io.readInputStream
 import laika.preview.ServerBuilder.Logger
 import org.http4s.EntityEncoder.entityBodyEncoder
 import org.http4s.dsl.Http4sDsl
-import org.http4s.{EntityEncoder, Headers, HttpRoutes, MediaType}
-import org.http4s.headers.`Content-Type`
+import org.http4s.{CacheDirective, EntityEncoder, Headers, HttpRoutes, MediaType}
+import org.http4s.headers.{`Cache-Control`, `Content-Type`}
 
 private [preview] class RouteBuilder[F[_]: Async](cache: Cache[F, SiteResults[F]], logger: Logger[F]) extends Http4sDsl[F] {
 
@@ -23,6 +23,8 @@ private [preview] class RouteBuilder[F[_]: Async](cache: Cache[F, SiteResults[F]
   private def mediaTypeFor (suffix: String): Option[MediaType] =
     MediaType.forExtension(suffix).orElse(MediaType.forExtension(suffix.split("\\.").last))
   
+  private val noCache = `Cache-Control`(CacheDirective.`no-store`)
+  
   def build: HttpRoutes[F] = HttpRoutes.of[F] {
 
     case GET -> path =>
@@ -30,11 +32,14 @@ private [preview] class RouteBuilder[F[_]: Async](cache: Cache[F, SiteResults[F]
       cache.get.map(_.get(laikaPath.withoutFragment)).flatMap {
         case Some(RenderedResult(content)) =>
           logger(s"serving path $laikaPath - transformed markup") *>
-          Ok(content).map(_.withContentType(`Content-Type`(MediaType.text.html)))
+          Ok(content).map(_
+            .withHeaders(noCache)
+            .withContentType(`Content-Type`(MediaType.text.html))
+          )
         case Some(StaticResult(input)) =>
           logger(s"serving path $laikaPath - static input") *> {
             val mediaType = laikaPath.suffix.flatMap(mediaTypeFor).map(`Content-Type`(_))
-            Ok(input).map(_.withHeaders(Headers(mediaType)))
+            Ok(input).map(_.withHeaders(Headers(mediaType, noCache)))
           }
         case None =>
           logger(s"serving path $laikaPath - not found") *> NotFound()

--- a/preview/src/main/scala/laika/preview/RouteBuilder.scala
+++ b/preview/src/main/scala/laika/preview/RouteBuilder.scala
@@ -11,7 +11,7 @@ import org.http4s.dsl.Http4sDsl
 import org.http4s.{EntityEncoder, Headers, HttpRoutes, MediaType}
 import org.http4s.headers.`Content-Type`
 
-class RouteBuilder[F[_]: Async](cache: Cache[F, SiteResults[F]], logger: Logger[F]) extends Http4sDsl[F] {
+private [preview] class RouteBuilder[F[_]: Async](cache: Cache[F, SiteResults[F]], logger: Logger[F]) extends Http4sDsl[F] {
 
   implicit def inputStreamResourceEncoder[G[_]: Sync, IS <: InputStream]: EntityEncoder[G, Resource[G, IS]] =
     entityBodyEncoder[G].contramap { (in: Resource[G, IS]) =>

--- a/preview/src/main/scala/laika/preview/RouteBuilder.scala
+++ b/preview/src/main/scala/laika/preview/RouteBuilder.scala
@@ -29,15 +29,15 @@ class RouteBuilder[F[_]: Async](cache: Cache[F, SiteResults[F]], logger: Logger[
       val laikaPath = laika.ast.Path.parse(path.toString)
       cache.get.map(_.get(laikaPath.withoutFragment)).flatMap {
         case Some(RenderedResult(content)) =>
-          Async[F].delay(println(s"serving path $laikaPath - transformed markup")) *>
+          logger(s"serving path $laikaPath - transformed markup") *>
           Ok(content).map(_.withContentType(`Content-Type`(MediaType.text.html)))
         case Some(StaticResult(input)) =>
-          Async[F].delay(println(s"serving path $laikaPath - static input")) *> {
+          logger(s"serving path $laikaPath - static input") *> {
             val mediaType = laikaPath.suffix.flatMap(mediaTypeFor).map(`Content-Type`(_))
             Ok(input).map(_.withHeaders(Headers(mediaType)))
           }
         case None =>
-          Async[F].delay(println(s"serving path $laikaPath - not found")) *> NotFound()
+          logger(s"serving path $laikaPath - not found") *> NotFound()
       }
   }
   

--- a/preview/src/main/scala/laika/preview/RouteBuilder.scala
+++ b/preview/src/main/scala/laika/preview/RouteBuilder.scala
@@ -5,13 +5,12 @@ import java.io.InputStream
 import cats.syntax.all._
 import cats.effect.{Async, Resource, Sync}
 import fs2.io.readInputStream
-import laika.{ast, config}
 import org.http4s.EntityEncoder.entityBodyEncoder
 import org.http4s.dsl.Http4sDsl
 import org.http4s.{EntityEncoder, Headers, HttpRoutes, MediaType}
 import org.http4s.headers.`Content-Type`
 
-class RouteBuilder[F[_]: Async](cache: Cache[F, Map[ast.Path, Either[Resource[F, InputStream], String]]]) extends Http4sDsl[F] {
+class RouteBuilder[F[_]: Async](cache: Cache[F, SiteResults[F]]) extends Http4sDsl[F] {
 
   implicit def inputStreamResourceEncoder[G[_]: Sync, IS <: InputStream]: EntityEncoder[G, Resource[G, IS]] =
     entityBodyEncoder[G].contramap { (in: Resource[G, IS]) =>
@@ -28,10 +27,10 @@ class RouteBuilder[F[_]: Async](cache: Cache[F, Map[ast.Path, Either[Resource[F,
     case GET -> path =>
       val laikaPath = laika.ast.Path.parse(path.toString)
       cache.get.map(_.get(laikaPath.withoutFragment)).flatMap {
-        case Some(Right(content)) =>
+        case Some(RenderedResult(content)) =>
           Async[F].delay(println(s"serving path $laikaPath - transformed markup")) *>
           Ok(content).map(_.withContentType(`Content-Type`(MediaType.text.html)))
-        case Some(Left(input)) =>
+        case Some(StaticResult(input)) =>
           Async[F].delay(println(s"serving path $laikaPath - static input")) *> {
             val mediaType = laikaPath.suffix.flatMap(mediaTypeFor).map(`Content-Type`(_))
             Ok(input).map(_.withHeaders(Headers(mediaType)))

--- a/preview/src/main/scala/laika/preview/RouteBuilder.scala
+++ b/preview/src/main/scala/laika/preview/RouteBuilder.scala
@@ -5,12 +5,13 @@ import java.io.InputStream
 import cats.syntax.all._
 import cats.effect.{Async, Resource, Sync}
 import fs2.io.readInputStream
+import laika.preview.ServerBuilder.Logger
 import org.http4s.EntityEncoder.entityBodyEncoder
 import org.http4s.dsl.Http4sDsl
 import org.http4s.{EntityEncoder, Headers, HttpRoutes, MediaType}
 import org.http4s.headers.`Content-Type`
 
-class RouteBuilder[F[_]: Async](cache: Cache[F, SiteResults[F]]) extends Http4sDsl[F] {
+class RouteBuilder[F[_]: Async](cache: Cache[F, SiteResults[F]], logger: Logger[F]) extends Http4sDsl[F] {
 
   implicit def inputStreamResourceEncoder[G[_]: Sync, IS <: InputStream]: EntityEncoder[G, Resource[G, IS]] =
     entityBodyEncoder[G].contramap { (in: Resource[G, IS]) =>

--- a/preview/src/main/scala/laika/preview/ServerBuilder.scala
+++ b/preview/src/main/scala/laika/preview/ServerBuilder.scala
@@ -2,38 +2,98 @@ package laika.preview
 
 import cats.syntax.all._
 import cats.effect._
+import laika.api.Renderer
+import laika.api.builder.OperationConfig
+import laika.format.HTML
+import laika.helium.Helium
+import laika.io.implicits._
+import laika.io.api.{TreeParser, TreeRenderer}
+import laika.io.model.{InputTreeBuilder, StringTreeOutput}
+import laika.theme.ThemeProvider
 import org.http4s._
 import org.http4s.dsl.Http4sDsl
+import org.http4s.headers.`Content-Type`
 import org.http4s.implicits._
 import org.http4s.server.{Router, Server}
 import org.http4s.server.blaze.BlazeServerBuilder
 
-class ServerBuilder[F[_]: Async] extends Http4sDsl[F] {
+class ServerBuilder[F[_]: Async] (parser: Resource[F, TreeParser[F]], 
+                                  inputs: InputTreeBuilder[F],
+                                  theme: ThemeProvider,
+                                  port: Int) extends Http4sDsl[F] {
 
+  
   def build: Resource[F, Server] = {
     
-    Resource.eval(Async[F].executionContext).flatMap { ctx =>
+    def htmlRenderer (config: OperationConfig): Resource[F, TreeRenderer[F]] = Renderer
+      .of(HTML)
+      .withConfig(config)
+      .parallel[F]
+      .withTheme(theme)
+      .build
+    
+    (for {
+      ctx <- Resource.eval(Async[F].executionContext)
+      p   <- parser
+      r   <- htmlRenderer(p.config)
+    } yield (ctx, p, r)).flatMap { case (ctx, parser, htmlRenderer) =>
+
+      val tree = {
+//        val apiPath = validated(SiteConfig.apiPath(baseConfig))
+//        val inputs = generateAPI.value.foldLeft(laikaInputs.value.delegate) {
+//          (inputs, path) => inputs.addProvidedPath(apiPath / path)
+//        }
+        parser.fromInput(inputs).parse
+      }
       
-      val helloWorldService = HttpRoutes.of[F] {
-        case GET -> Root / "hello" / name => Ok(s"Hello, $name.")
+      // TODO - if we do not copy the static documents, we must still apply the filter + path translation from RendererRuntime
+      
+      val docMap = tree.flatMap { tree =>
+        htmlRenderer
+          .from(tree.root)
+          .toOutput(StringTreeOutput)
+          .render
+          .map { root =>
+            root.allDocuments.map { doc =>
+              (doc.path, doc.content)
+            }
+            .toMap // TODO - map root
+          }
+      }
+      
+      def getDocument (path: String): F[String] = docMap.map { docs =>
+        docs.getOrElse(laika.ast.Path.parse(path), "Not Found")
+      } 
+      
+      val routes = HttpRoutes.of[F] {
+        
+        case GET -> path => 
+          // MediaType.forExtension() / Headers
+          getDocument(path.toString)
+            .flatMap(content => Ok(content).map(_.withContentType(`Content-Type`(MediaType.text.html))))
       }
     
-      val httpApp = Router("/" -> helloWorldService).orNotFound
+      val httpApp = Router("/" -> routes).orNotFound
       
-      val serverBuilder = 
-        BlazeServerBuilder[F](ctx)
-          .bindHttp(4242, "localhost")
-          .withHttpApp(httpApp)
-
-      serverBuilder.resource
-  
+      BlazeServerBuilder[F](ctx)
+        .bindHttp(port, "localhost")
+        .withHttpApp(httpApp)
+        .resource
     }
   }
+
+  private def copy (newTheme: ThemeProvider = theme,
+                    newPort: Int = port): ServerBuilder[F] = 
+    new ServerBuilder[F](parser, inputs, newTheme, newPort)
+
+  def withTheme (theme: ThemeProvider): ServerBuilder[F] = copy(newTheme = theme)
+  def withPort (port: Int): ServerBuilder[F] = copy(newPort = port)
   
 }
 
 object ServerBuilder {
   
-  def apply[F[_]: Async](): ServerBuilder[F] = new ServerBuilder[F]
+  def apply[F[_]: Async](parser: Resource[F, TreeParser[F]], inputs: InputTreeBuilder[F]): ServerBuilder[F] = 
+    new ServerBuilder[F](parser, inputs, Helium.defaults.build, 4242)
   
 }

--- a/preview/src/main/scala/laika/preview/ServerBuilder.scala
+++ b/preview/src/main/scala/laika/preview/ServerBuilder.scala
@@ -1,0 +1,39 @@
+package laika.preview
+
+import cats.syntax.all._
+import cats.effect._
+import org.http4s._
+import org.http4s.dsl.Http4sDsl
+import org.http4s.implicits._
+import org.http4s.server.{Router, Server}
+import org.http4s.server.blaze.BlazeServerBuilder
+
+class ServerBuilder[F[_]: Async] extends Http4sDsl[F] {
+
+  def build: Resource[F, Server] = {
+    
+    Resource.eval(Async[F].executionContext).flatMap { ctx =>
+      
+      val helloWorldService = HttpRoutes.of[F] {
+        case GET -> Root / "hello" / name => Ok(s"Hello, $name.")
+      }
+    
+      val httpApp = Router("/" -> helloWorldService).orNotFound
+      
+      val serverBuilder = 
+        BlazeServerBuilder[F](ctx)
+          .bindHttp(4242, "localhost")
+          .withHttpApp(httpApp)
+
+      serverBuilder.resource
+  
+    }
+  }
+  
+}
+
+object ServerBuilder {
+  
+  def apply[F[_]: Async](): ServerBuilder[F] = new ServerBuilder[F]
+  
+}

--- a/preview/src/main/scala/laika/preview/ServerBuilder.scala
+++ b/preview/src/main/scala/laika/preview/ServerBuilder.scala
@@ -78,7 +78,7 @@ class ServerBuilder[F[_]: Async] (parser: Resource[F, TreeParser[F]],
     List(PDF).filter(_ => config.includePDF)
 
   private[preview] def buildRoutes: Resource[F, HttpApp[F]] = for {
-    transf <- SiteTransformer.create(parser, inputs, binaryRenderFormats, staticFiles, config.artifactBasename)
+    transf <- SiteTransformer.create(parser, inputs, binaryRenderFormats, staticFiles, config.pollInterval, config.artifactBasename)
     cache  <- Resource.eval(Cache.create(transf.transform))
     _      <- createSourceChangeWatcher(cache, transf.parser.config.docTypeMatcher)
   } yield createApp(cache)

--- a/preview/src/main/scala/laika/preview/ServerBuilder.scala
+++ b/preview/src/main/scala/laika/preview/ServerBuilder.scala
@@ -16,11 +16,8 @@
 
 package laika.preview
 
-import java.io.{File, InputStream}
-
 import cats.syntax.all._
 import cats.effect._
-import fs2.io.readInputStream
 import laika.api.Renderer
 import laika.api.builder.OperationConfig
 import laika.format.HTML
@@ -29,10 +26,8 @@ import laika.io.implicits._
 import laika.io.api.{TreeParser, TreeRenderer}
 import laika.io.model.{InputTreeBuilder, StringTreeOutput}
 import laika.theme.ThemeProvider
-import org.http4s.EntityEncoder.entityBodyEncoder
 import org.http4s._
 import org.http4s.dsl.Http4sDsl
-import org.http4s.headers.`Content-Type`
 import org.http4s.implicits._
 import org.http4s.server.{Router, Server}
 import org.http4s.server.blaze.BlazeServerBuilder
@@ -48,17 +43,7 @@ class ServerBuilder[F[_]: Async] (parser: Resource[F, TreeParser[F]],
                                   port: Int,
                                   pollInterval: FiniteDuration) extends Http4sDsl[F] {
 
-  implicit def inputStreamResourceEncoder[G[_]: Sync, IS <: InputStream]: EntityEncoder[G, Resource[G, IS]] =
-    entityBodyEncoder[G].contramap { (in: Resource[G, IS]) =>
-      fs2.Stream.resource(in).flatMap { stream =>
-        readInputStream[G](Sync[G].pure(stream), 4096, closeAfterUse = false)
-      }
-    }
-
   def build: Resource[F, Server] = {
-    
-    def mediaTypeFor (suffix: String): Option[MediaType] =
-      MediaType.forExtension(suffix).orElse(MediaType.forExtension(suffix.split("\\.").last))
     
     def htmlRenderer (config: OperationConfig): Resource[F, TreeRenderer[F]] = Renderer
       .of(HTML)
@@ -108,25 +93,7 @@ class ServerBuilder[F[_]: Async] (parser: Resource[F, TreeParser[F]],
           parser.config.docTypeMatcher
         ).flatMap { _ =>
 
-          val routes = HttpRoutes.of[F] {
-
-            case GET -> path =>
-              val laikaPath = laika.ast.Path.parse(path.toString)
-              cache.get.map(_.get(laikaPath.withoutFragment)).flatMap {
-                case Some(Right(content)) =>
-                  println(s"serving path $laikaPath - transformed markup")
-                  Ok(content).map(_.withContentType(`Content-Type`(MediaType.text.html)))
-                case Some(Left(input)) =>
-                  println(s"serving path $laikaPath - static input")
-                  val mediaType = laikaPath.suffix.flatMap(mediaTypeFor).map(`Content-Type`(_))
-                  Ok(input).map(_.withHeaders(Headers(mediaType)))
-                case None =>
-                  println(s"serving path $laikaPath - not found")
-                  NotFound()
-              }
-          }
-
-          val httpApp = Router("/" -> routes).orNotFound
+          val httpApp = Router("/" -> new RouteBuilder[F](cache).build).orNotFound
 
           BlazeServerBuilder[F](ctx)
             .bindHttp(port, "localhost")

--- a/preview/src/main/scala/laika/preview/ServerBuilder.scala
+++ b/preview/src/main/scala/laika/preview/ServerBuilder.scala
@@ -54,6 +54,9 @@ class ServerBuilder[F[_]: Async] (parser: Resource[F, TreeParser[F]],
 
   def build: Resource[F, Server] = {
     
+    def mediaTypeFor (suffix: String): Option[MediaType] =
+      MediaType.forExtension(suffix).orElse(MediaType.forExtension(suffix.split("\\.").last))
+    
     def htmlRenderer (config: OperationConfig): Resource[F, TreeRenderer[F]] = Renderer
       .of(HTML)
       .withConfig(config)
@@ -104,7 +107,7 @@ class ServerBuilder[F[_]: Async] (parser: Resource[F, TreeParser[F]],
                 Ok(content).map(_.withContentType(`Content-Type`(MediaType.text.html)))
               case Some(Left(input)) =>
                 println(s"serving path $laikaPath - static input")
-                val mediaType = laikaPath.suffix.flatMap(ext => MediaType.forExtension(ext).map(`Content-Type`(_)))
+                val mediaType = laikaPath.suffix.flatMap(mediaTypeFor).map(`Content-Type`(_))
                 Ok(input).map(_.withHeaders(Headers(mediaType)))
               case None => 
                 println(s"serving path $laikaPath - not found")

--- a/preview/src/main/scala/laika/preview/SiteTransformer.scala
+++ b/preview/src/main/scala/laika/preview/SiteTransformer.scala
@@ -34,14 +34,14 @@ import laika.io.model.{InputTreeBuilder, ParsedTree, StringTreeOutput}
 import laika.rewrite.nav.Selections
 import laika.theme.ThemeProvider
 
-class SiteTransformer[F[_]: Async] (val parser: TreeParser[F], 
-                                    htmlRenderer: TreeRenderer[F],
-                                    binaryRenderers: Seq[(BinaryTreeRenderer[F], String)],
-                                    inputs: InputTreeBuilder[F],
-                                    staticFiles: Map[Path, SiteResult[F]],
-                                    artifactBasename: String) {
+private [preview] class SiteTransformer[F[_]: Async] (val parser: TreeParser[F], 
+                                                      htmlRenderer: TreeRenderer[F],
+                                                      binaryRenderers: Seq[(BinaryTreeRenderer[F], String)],
+                                                      inputs: InputTreeBuilder[F],
+                                                      staticFiles: Map[Path, SiteResult[F]],
+                                                      artifactBasename: String) {
 
-  private val parse = {
+  val parse = {
     val allInputs = staticFiles.foldLeft(inputs) {
       case (inputs, (path, _)) => inputs.addProvidedPath(path)
     }
@@ -108,7 +108,7 @@ class SiteTransformer[F[_]: Async] (val parser: TreeParser[F],
   
 }
 
-object SiteTransformer {
+private [preview] object SiteTransformer {
 
   def htmlRenderer[F[_]: Async] (config: OperationConfig, 
                                  theme: ThemeProvider): Resource[F, TreeRenderer[F]] = 

--- a/preview/src/main/scala/laika/preview/SiteTransformer.scala
+++ b/preview/src/main/scala/laika/preview/SiteTransformer.scala
@@ -16,65 +16,140 @@
 
 package laika.preview
 
-import java.io.InputStream
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream}
 
 import cats.syntax.all._
 import cats.effect.{Async, Resource}
 import laika.api.Renderer
 import laika.api.builder.OperationConfig
-import laika.ast.Path
-import laika.format.HTML
-import laika.io.api.{TreeParser, TreeRenderer}
+import laika.ast.{DocumentTreeRoot, Path}
+import laika.config.Config.ConfigResult
+import laika.config.{ConfigException, LaikaKeys}
+import laika.factory.{BinaryPostProcessorBuilder, TwoPhaseRenderFormat}
+import laika.format.{EPUB, HTML, PDF}
+import laika.io.api.{BinaryTreeRenderer, TreeParser, TreeRenderer}
+import laika.io.config.SiteConfig
 import laika.io.implicits._
-import laika.io.model.{InputTreeBuilder, StringTreeOutput}
+import laika.io.model.{InputTreeBuilder, ParsedTree, StringTreeOutput}
+import laika.rewrite.nav.Selections
 import laika.theme.ThemeProvider
 
-class SiteTransformer[F[_]: Async] (val parser: TreeParser[F], htmlRenderer: TreeRenderer[F], inputs: InputTreeBuilder[F]) {
+class SiteTransformer[F[_]: Async] (val parser: TreeParser[F], 
+                                    htmlRenderer: TreeRenderer[F],
+                                    epubRenderer: BinaryTreeRenderer[F],
+                                    pdfRenderer: BinaryTreeRenderer[F],
+                                    inputs: InputTreeBuilder[F],
+                                    artifactBasename: String) {
 
-  private val tree = {
+  private val parse = {
     //        val apiPath = validated(SiteConfig.apiPath(baseConfig))
     //        val inputs = generateAPI.value.foldLeft(laikaInputs.value.delegate) {
     //          (inputs, path) => inputs.addProvidedPath(apiPath / path)
     //        }
     parser.fromInput(inputs).parse
   }
+  
+  def renderBinary (renderer: BinaryTreeRenderer[F], root: DocumentTreeRoot): Resource[F, InputStream] = {
+    val renderResult = for {
+      out <- Async[F].delay(new ByteArrayOutputStream)
+      _   <- renderer.from(root).toStream(Async[F].pure(out)).render
+    } yield out.toByteArray
+    
+    Resource
+      .eval(renderResult)
+      .flatMap(bytes => Resource.eval(Async[F].delay(new ByteArrayInputStream(bytes))))
+  }
+  
+  def transformBinaries (root: DocumentTreeRoot): ConfigResult[Map[Path, SiteResult[F]]] = {
+    for {
+      roots            <- Selections.createCombinations(root)
+      downloadPath     <- SiteConfig.downloadPath(root.config)
+      artifactBaseName <- root.config.get[String](LaikaKeys.artifactBaseName, artifactBasename)
+    } yield {
+      val combinations = 
+        roots.map(r => (r._1, r._2, epubRenderer, ".epub")) ++
+        roots.map(r => (r._1, r._2, pdfRenderer, ".pdf"))
+      combinations.map { case (root, classifiers, renderer, suffix) =>
+        val classifier = if (classifiers.value.isEmpty) "" else "-" + classifiers.value.mkString("-")
+        val docName = artifactBaseName + classifier + suffix
+        val path = downloadPath / docName
+        (path, StaticResult(renderBinary(renderer, root)))
+      }.toList.toMap
+    }
+  }
 
-  val transform: F[Map[Path, Either[Resource[F, InputStream], String]]] = tree.flatMap { tree =>
+  def transformHTML (tree: ParsedTree[F]): F[Map[Path, SiteResult[F]]] = {
     htmlRenderer
       .from(tree.root)
       .copying(tree.staticDocuments)
       .toOutput(StringTreeOutput)
       .render
       .map { root =>
-        (root.allDocuments.map { doc =>
-          (doc.path, Right(doc.content))
-        } ++
-          root.staticDocuments.map { doc =>
-            (doc.path, Left(doc.input))
-          })
-          .toMap // TODO - map root
+        val map = root.allDocuments.map { doc =>
+          (doc.path, RenderedResult[F](doc.content))
+        }.toMap ++
+        root.staticDocuments.map { doc =>
+          (doc.path, StaticResult(doc.input))
+        }.toMap
+        val roots = map.flatMap { case (path, result) =>
+          if (path.name == "index.html") Some((path.parent, result)) else None 
+        }
+        map ++ roots
       }
+  }
+
+  val transform: F[SiteResults[F]] = for { 
+    tree     <- parse
+    rendered <- transformHTML(tree)
+    ebooks   <- Async[F].fromEither(transformBinaries(tree.root).leftMap(ConfigException.apply))
+  } yield {
+    new SiteResults(rendered ++ ebooks)
   }
   
 }
 
 object SiteTransformer {
 
-  def htmlRenderer[F[_]: Async] (config: OperationConfig, theme: ThemeProvider): Resource[F, TreeRenderer[F]] = Renderer
-    .of(HTML)
-    .withConfig(config)
-    .parallel[F]
-    .withTheme(theme)
-    .build
+  def htmlRenderer[F[_]: Async] (config: OperationConfig, 
+                                 theme: ThemeProvider): Resource[F, TreeRenderer[F]] = 
+    Renderer
+      .of(HTML)
+      .withConfig(config)
+      .parallel[F]
+      .withTheme(theme)
+      .build
   
+  def binaryRenderer[F[_]: Async, FMT] (format: TwoPhaseRenderFormat[FMT, BinaryPostProcessorBuilder],
+                                        config: OperationConfig,
+                                        theme: ThemeProvider): Resource[F, BinaryTreeRenderer[F]] = 
+    Renderer
+      .of(format)
+      .withConfig(config)
+      .parallel[F]
+      .withTheme(theme)
+      .build
+
   def create[F[_]: Async](parser: Resource[F, TreeParser[F]],
                           inputs: InputTreeBuilder[F],
-                          theme: ThemeProvider): Resource[F, SiteTransformer[F]] = {
+                          theme: ThemeProvider,
+                          artifactBasename: String): Resource[F, SiteTransformer[F]] = {
     for {
-      p   <- parser
-      r   <- htmlRenderer(p.config, theme)
-    } yield new SiteTransformer[F](p,r, inputs)
+      p      <- parser
+      html   <- htmlRenderer(p.config, theme)
+      epub   <- binaryRenderer(EPUB, p.config, theme)
+      pdf    <- binaryRenderer(PDF, p.config, theme)
+    } yield new SiteTransformer[F](p, html, epub, pdf, inputs, artifactBasename)
     
   }
   
 }
+
+class SiteResults[F[_]: Async] (map: Map[Path, SiteResult[F]]) {
+  
+  def get (path: Path): Option[SiteResult[F]] = map.get(path)
+  
+}
+
+sealed abstract class SiteResult[F[_]: Async] extends Product with Serializable
+case class RenderedResult[F[_]: Async] (content: String) extends SiteResult[F]
+case class StaticResult[F[_]: Async] (content: Resource[F, InputStream]) extends SiteResult[F]

--- a/preview/src/main/scala/laika/preview/SiteTransformer.scala
+++ b/preview/src/main/scala/laika/preview/SiteTransformer.scala
@@ -32,7 +32,7 @@ import laika.io.config.SiteConfig
 import laika.io.implicits._
 import laika.io.model.{InputTreeBuilder, ParsedTree, StringTreeOutput}
 import laika.rewrite.nav.Selections
-import laika.theme.ThemeProvider
+import laika.theme.Theme
 
 private [preview] class SiteTransformer[F[_]: Async] (val parser: TreeParser[F], 
                                                       htmlRenderer: TreeRenderer[F],
@@ -71,7 +71,7 @@ private [preview] class SiteTransformer[F[_]: Async] (val parser: TreeParser[F],
       } yield (root, renderer)
       combinations.map { case ((root, classifiers), (renderer, suffix)) =>
         val classifier = if (classifiers.value.isEmpty) "" else "-" + classifiers.value.mkString("-")
-        val docName = artifactBaseName + classifier + suffix
+        val docName = artifactBaseName + classifier + "." + suffix
         val path = downloadPath / docName
         (path, StaticResult(renderBinary(renderer, root)))
       }.toMap
@@ -111,7 +111,7 @@ private [preview] class SiteTransformer[F[_]: Async] (val parser: TreeParser[F],
 private [preview] object SiteTransformer {
 
   def htmlRenderer[F[_]: Async] (config: OperationConfig, 
-                                 theme: ThemeProvider): Resource[F, TreeRenderer[F]] = 
+                                 theme: Theme[F]): Resource[F, TreeRenderer[F]] = 
     Renderer
       .of(HTML)
       .withConfig(config)
@@ -122,7 +122,7 @@ private [preview] object SiteTransformer {
   
   def binaryRenderer[F[_]: Async, FMT] (format: TwoPhaseRenderFormat[FMT, BinaryPostProcessorBuilder],
                                         config: OperationConfig,
-                                        theme: ThemeProvider): Resource[F, BinaryTreeRenderer[F]] = 
+                                        theme: Theme[F]): Resource[F, BinaryTreeRenderer[F]] = {
     Renderer
       .of(format)
       .withConfig(config)
@@ -130,10 +130,10 @@ private [preview] object SiteTransformer {
       .parallel[F]
       .withTheme(theme)
       .build
+  }
 
   def create[F[_]: Async](parser: Resource[F, TreeParser[F]],
                           inputs: InputTreeBuilder[F],
-                          theme: ThemeProvider,
                           renderFormats: List[TwoPhaseRenderFormat[_, BinaryPostProcessorBuilder]],
                           staticFiles: Option[StaticFileScanner],
                           artifactBasename: String): Resource[F, SiteTransformer[F]] = {
@@ -147,8 +147,8 @@ private [preview] object SiteTransformer {
     
     for {
       p      <- parser
-      html   <- htmlRenderer(p.config, theme)
-      bin    <- renderFormats.map(f => binaryRenderer(f, p.config, theme).map((_, f.interimFormat.fileSuffix))).sequence
+      html   <- htmlRenderer(p.config, p.theme)
+      bin    <- renderFormats.map(f => binaryRenderer(f, p.config, p.theme).map((_, f.description.toLowerCase))).sequence
       static <- collectFiles(p.config)
     } yield new SiteTransformer[F](ignoreErrors(p), html, bin, inputs, static, artifactBasename)
     
@@ -159,6 +159,8 @@ private [preview] object SiteTransformer {
 class SiteResults[F[_]: Async] (map: Map[Path, SiteResult[F]]) {
   
   def get (path: Path): Option[SiteResult[F]] = map.get(path)
+  
+  def list: List[Path] = map.keySet.toList.sortBy(_.toString)
   
 }
 

--- a/preview/src/main/scala/laika/preview/SiteTransformer.scala
+++ b/preview/src/main/scala/laika/preview/SiteTransformer.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package laika.preview
+
+import java.io.InputStream
+
+import cats.syntax.all._
+import cats.effect.{Async, Resource}
+import laika.api.Renderer
+import laika.api.builder.OperationConfig
+import laika.ast.Path
+import laika.format.HTML
+import laika.io.api.{TreeParser, TreeRenderer}
+import laika.io.implicits._
+import laika.io.model.{InputTreeBuilder, StringTreeOutput}
+import laika.theme.ThemeProvider
+
+class SiteTransformer[F[_]: Async] (val parser: TreeParser[F], htmlRenderer: TreeRenderer[F], inputs: InputTreeBuilder[F]) {
+
+  private val tree = {
+    //        val apiPath = validated(SiteConfig.apiPath(baseConfig))
+    //        val inputs = generateAPI.value.foldLeft(laikaInputs.value.delegate) {
+    //          (inputs, path) => inputs.addProvidedPath(apiPath / path)
+    //        }
+    parser.fromInput(inputs).parse
+  }
+
+  val transform: F[Map[Path, Either[Resource[F, InputStream], String]]] = tree.flatMap { tree =>
+    htmlRenderer
+      .from(tree.root)
+      .copying(tree.staticDocuments)
+      .toOutput(StringTreeOutput)
+      .render
+      .map { root =>
+        (root.allDocuments.map { doc =>
+          (doc.path, Right(doc.content))
+        } ++
+          root.staticDocuments.map { doc =>
+            (doc.path, Left(doc.input))
+          })
+          .toMap // TODO - map root
+      }
+  }
+  
+}
+
+object SiteTransformer {
+
+  def htmlRenderer[F[_]: Async] (config: OperationConfig, theme: ThemeProvider): Resource[F, TreeRenderer[F]] = Renderer
+    .of(HTML)
+    .withConfig(config)
+    .parallel[F]
+    .withTheme(theme)
+    .build
+  
+  def create[F[_]: Async](parser: Resource[F, TreeParser[F]],
+                          inputs: InputTreeBuilder[F],
+                          theme: ThemeProvider): Resource[F, SiteTransformer[F]] = {
+    for {
+      p   <- parser
+      r   <- htmlRenderer(p.config, theme)
+    } yield new SiteTransformer[F](p,r, inputs)
+    
+  }
+  
+}

--- a/preview/src/main/scala/laika/preview/SourceChangeWatcher.scala
+++ b/preview/src/main/scala/laika/preview/SourceChangeWatcher.scala
@@ -157,7 +157,8 @@ object SourceChangeWatcher {
                            pollInterval: FiniteDuration,
                            fileFilter: File => Boolean,
                            docTypeMatcher: Path => DocumentType): Resource[F, Unit] = {
-    Resource
+    if (inputs.isEmpty) Resource.unit
+    else Resource
       .make(Async[F].delay(FileSystems.getDefault.newWatchService))(service => Async[F].delay(service.close()))
       .evalMap(s => Async[F].ref(Map.empty[JPath, ObservedTarget]).map((s,_)))
       .flatMap { case (service, targetMap) =>

--- a/preview/src/main/scala/laika/preview/SourceChangeWatcher.scala
+++ b/preview/src/main/scala/laika/preview/SourceChangeWatcher.scala
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package laika.preview
+
+import java.io.File
+import java.nio.file.{FileSystems, Files, WatchEvent, WatchService, Path => JPath}
+import java.nio.file.StandardWatchEventKinds._
+
+import laika.ast.{DocumentType, Path}
+import cats.syntax.all._
+
+import scala.concurrent.duration._
+import cats.effect.{Async, Ref, Resource, Temporal}
+import laika.ast.DocumentType.Static
+import laika.collection.TransitionalCollectionOps.{JIteratorWrapper, TransitionalMapOps}
+import laika.io.runtime.DirectoryScanner
+import laika.preview.SourceChangeWatcher.{ObservedDirectory, ObservedFiles, ObservedTarget}
+
+import scala.annotation.tailrec
+
+class SourceChangeWatcher[F[_]: Async] (service: WatchService,
+                                        targetMap: Ref[F, Map[JPath, ObservedTarget]],
+                                        inputs: List[File],
+                                        update: F[Unit],
+                                        fileFilter: File => Boolean,
+                                        docTypeMatcher: Path => DocumentType) {
+  
+  private def scanDirectory (dir: JPath): F[List[JPath]] = DirectoryScanner.scanDirectory[F, List[JPath]](dir) {
+    _.toList
+      .map { childPath =>
+        if (Files.isDirectory(childPath) && !fileFilter(childPath.toFile)) scanDirectory(childPath)
+        else Async[F].pure(List.empty[JPath])
+      }
+      .sequence.map(_.flatten :+ dir)
+  }
+  
+  def registerRoot (file: JPath, children: List[JPath] = Nil): F[List[ObservedTarget]] = {
+    
+    def registerDirectory (dir: JPath, children: List[JPath] = Nil): F[ObservedTarget] = {
+      val target = 
+        if (children.isEmpty) ObservedDirectory(dir, fileFilter, docTypeMatcher)
+        else ObservedFiles(dir, children.toSet, docTypeMatcher)
+      Async[F]
+        .delay(dir.register(service, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY))
+        .as(target)
+    }
+    
+    if (children.isEmpty) scanDirectory(file).flatMap(_.map(registerDirectory(_)).sequence)
+    else registerDirectory(file, children).map(List(_))
+  }
+  
+  private def updateTargetMap (targets: List[List[ObservedTarget]]): F[Unit] = {
+    val initTargetMap = targets.flatten.map(t => (t.parent, t)).toMap
+    targetMap.update(_ ++ initTargetMap)
+  }
+  
+  val init: F[Unit] = {
+    
+    val groupedInputs = inputs.map { input =>
+      if (input.isDirectory) (input.toPath, None)
+      else (input.toPath.getParent, Some(input.toPath))
+    }
+      .groupBy(_._1)
+      .mapValuesStrict(_.flatMap(_._2))
+
+    groupedInputs
+      .map {
+        case (parent, children) => registerRoot(parent, children)
+      }
+      .toList
+      .sequence
+      .flatMap(updateTargetMap)
+  }
+
+  @tailrec
+  private def collectEvents (acc: List[WatchEvent[_]]): List[WatchEvent[_]] = {
+    val key = service.poll()
+    if (key == null) acc
+    else {
+      val events = JIteratorWrapper(key.pollEvents().iterator()).toList
+      key.reset()
+      collectEvents(acc ++ events)
+    }
+  }
+  
+  val poll: F[Unit] = {
+    val events = Async[F].delay(collectEvents(Nil))
+    (events, targetMap.get).mapN { case (events, targets) =>
+      val (needsUpdate, newDirectories) = events.foldLeft((false, List.empty[JPath])) { case ((needsUpdate, newDirectories), event) =>
+        val targetKind = event.context() match {
+          case p: JPath if !fileFilter(p.toFile) => targets.get(p.getParent).flatMap { t =>
+            if (Files.isDirectory(p)) Some(Left(p))
+            else t.docTypeFor(p) match {
+              case DocumentType.Ignored  => None
+              case other                 => Some(Right(other)) 
+            }
+          }
+          case _ => None
+        }
+        (event.kind, targetKind) match {
+          case (ENTRY_CREATE, Some(Left(path)))       => (true,        newDirectories :+ path)
+          case (ENTRY_MODIFY, Some(Right(_: Static))) => (needsUpdate, newDirectories)
+          case (ENTRY_CREATE | ENTRY_DELETE, Some(_)) => (true,        newDirectories)
+          case _                                      => (needsUpdate, newDirectories)
+        }
+      }
+      val updateF = if (needsUpdate) update else Async[F].unit
+      val registrations = newDirectories
+        .map(registerRoot(_))
+        .sequence
+        .flatMap(updateTargetMap)
+      
+      updateF <* registrations
+    }
+  }
+  
+}
+
+object SourceChangeWatcher {
+
+  sealed trait ObservedTarget {
+    def parent: JPath
+    def docTypeMatcher: Path => DocumentType
+    def filter (child: JPath): Boolean
+    def docTypeFor (child: JPath): DocumentType =
+      if (filter(child)) docTypeMatcher(Path.parse(child.toString))
+      else DocumentType.Ignored
+  }
+  case class ObservedDirectory (parent: JPath, fileFilter: File => Boolean, docTypeMatcher: Path => DocumentType) extends ObservedTarget {
+    def filter (child: JPath): Boolean = !fileFilter(child.toFile)
+  }
+  case class ObservedFiles (parent: JPath, children: Set[JPath], docTypeMatcher: Path => DocumentType) extends ObservedTarget {
+    def filter (child: JPath): Boolean = children.contains(child)
+  }
+
+  def scheduledTaskResource[F[_]: Temporal] (task: F[Unit], interval: FiniteDuration): Resource[F, Unit] = {
+    val bg = fs2.Stream.fixedRate[F](interval).evalMap(_ => task)
+    fs2.Stream.emit(()).concurrently(bg).compile.resource.lastOrError
+  }
+  
+  def create[F[_]: Async] (inputs: List[File], 
+                           update: F[Unit], 
+                           pollInterval: FiniteDuration,
+                           fileFilter: File => Boolean,
+                           docTypeMatcher: Path => DocumentType): Resource[F, Unit] = {
+    Resource
+      .make(Async[F].delay(FileSystems.getDefault.newWatchService))(service => Async[F].delay(service.close()))
+      .evalMap(s => Async[F].ref(Map.empty[JPath, ObservedTarget]).map((s,_)))
+      .flatMap { case (service, targetMap) =>
+        val watcher = new SourceChangeWatcher[F](service, targetMap, inputs, update, fileFilter, docTypeMatcher)
+        scheduledTaskResource(watcher.poll, pollInterval)
+      }
+  }
+  
+}

--- a/preview/src/main/scala/laika/preview/SourceChangeWatcher.scala
+++ b/preview/src/main/scala/laika/preview/SourceChangeWatcher.scala
@@ -32,12 +32,12 @@ import laika.preview.SourceChangeWatcher.{ObservedDirectory, ObservedFiles, Obse
 
 import scala.annotation.tailrec
 
-class SourceChangeWatcher[F[_]: Async] (service: WatchService,
-                                        targetMap: Ref[F, Map[JPath, ObservedTarget]],
-                                        inputs: List[File],
-                                        update: F[Unit],
-                                        fileFilter: File => Boolean,
-                                        docTypeMatcher: Path => DocumentType) {
+private [preview] class SourceChangeWatcher[F[_]: Async] (service: WatchService,
+                                                          targetMap: Ref[F, Map[JPath, ObservedTarget]],
+                                                          inputs: List[File],
+                                                          update: F[Unit],
+                                                          fileFilter: File => Boolean,
+                                                          docTypeMatcher: Path => DocumentType) {
   
   private def scanDirectory (dir: JPath): F[List[JPath]] = DirectoryScanner.scanDirectory[F, List[JPath]](dir) {
     _.toList
@@ -130,7 +130,7 @@ class SourceChangeWatcher[F[_]: Async] (service: WatchService,
   
 }
 
-object SourceChangeWatcher {
+private [preview] object SourceChangeWatcher {
 
   sealed trait ObservedTarget {
     def parent: JPath

--- a/preview/src/main/scala/laika/preview/StaticFileScanner.scala
+++ b/preview/src/main/scala/laika/preview/StaticFileScanner.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package laika.preview
+
+import java.io.File
+import java.nio.file.{Files, Path => JPath}
+
+import cats.syntax.all._
+import cats.effect.Async
+import laika.api.builder.OperationConfig
+import laika.ast.Path
+import laika.ast.Path.Root
+import laika.config.ConfigException
+import laika.io.config.SiteConfig
+import laika.io.model.BinaryInput
+import laika.io.runtime.DirectoryScanner
+import laika.rewrite.{Version, Versions}
+
+class StaticFileScanner (target: File, includeAPI: Boolean) {
+
+  def collectStaticFiles[F[_]: Async] (config: OperationConfig): F[Map[Path, SiteResult[F]]] = {
+
+    def collect (filePath: JPath, vPath: Path = Root): F[List[(Path, SiteResult[F])]] = {
+      DirectoryScanner.scanDirectory(filePath) { paths =>
+        paths.toList
+          .map { path =>
+            val vChild = vPath / path.getFileName.toString
+            def result: (Path, SiteResult[F]) = (vChild, StaticResult(BinaryInput.fromFile(vPath, path.toFile).input))
+            if (Files.isDirectory(path)) collect(path, vChild)
+            else Async[F].pure(List(result))
+          }
+          .sequence
+          .map(_.flatten)
+      }
+    }
+
+    def otherVersions (versions: Option[Versions]): F[List[(Path, SiteResult[F])]] = {
+      versions
+        .fold(List.empty[Version])(v => (v.olderVersions ++ v.newerVersions).toList)
+        .map { v =>
+          collect(new File(target, v.pathSegment).toPath, Root / v.pathSegment)
+        }
+        .sequence
+        .map(_.flatten)
+    }
+    
+    def apiFiles (apiPath: Path, versions: Option[Versions]): F[List[(Path, SiteResult[F])]] = {
+      val vSegment = versions.fold[Path](Root)(v => Root / v.currentVersion.pathSegment)
+      val fullApiPath = (vSegment / apiPath.relative)
+      if (!includeAPI) Async[F].pure(Nil)
+      else collect(new File(target, fullApiPath.relative.toString).toPath, fullApiPath)
+    }
+
+    for {
+      apiPath  <- Async[F].fromEither(SiteConfig.apiPath(config.baseConfig).leftMap(ConfigException.apply))
+      versions <- Async[F].fromEither(config.baseConfig.getOpt[Versions].leftMap(ConfigException.apply))
+      apiFiles <- apiFiles(apiPath, versions)
+      vFiles   <- otherVersions(versions)
+    } yield (apiFiles ++ vFiles).toMap
+  }
+  
+}

--- a/preview/src/main/scala/laika/preview/StaticFileScanner.scala
+++ b/preview/src/main/scala/laika/preview/StaticFileScanner.scala
@@ -30,7 +30,7 @@ import laika.io.model.BinaryInput
 import laika.io.runtime.DirectoryScanner
 import laika.rewrite.{Version, Versions}
 
-class StaticFileScanner (target: File, includeAPI: Boolean) {
+private [preview] class StaticFileScanner (target: File, includeAPI: Boolean) {
 
   def collectStaticFiles[F[_]: Async] (config: OperationConfig): F[Map[Path, SiteResult[F]]] = {
 

--- a/preview/src/test/scala/laika/preview/PreviewRouteSpec.scala
+++ b/preview/src/test/scala/laika/preview/PreviewRouteSpec.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package laika.preview
+
+import cats.effect.IO
+import laika.api.MarkupParser
+import laika.ast.Path.Root
+import laika.format.Markdown
+import laika.io.IOFunSuite
+import laika.io.helper.InputBuilder
+import laika.io.implicits._
+import laika.theme.Theme
+import org.http4s.headers.`Content-Type`
+import org.http4s.implicits._
+import org.http4s.{MediaType, Method, Request, Response, Status}
+import org.scalatest.Assertion
+
+class PreviewRouteSpec extends IOFunSuite with InputBuilder {
+  
+  def stringBody (expected: String)(response: Response[IO]): IO[Assertion] =
+    response.as[String].map(_ shouldBe expected)
+
+  def nonEmptyBody (response: Response[IO]): IO[Assertion] =
+    response.body.compile.last.map(_.nonEmpty shouldBe true)
+
+  def check[A](actual:         IO[Response[IO]],
+               expectedStatus: Status): IO[Assertion] =
+    check(actual, expectedStatus, None, _ => IO.pure(succeed))
+  
+  def check[A](actual:            IO[Response[IO]],
+               expectedStatus:    Status,
+               expectedMediaType: Option[MediaType],
+               bodyCheck:         Response[IO] => IO[Assertion]): IO[Assertion] = 
+    actual.flatMap { response =>
+      response.status shouldBe expectedStatus
+      expectedMediaType.foreach { mt =>
+        response.headers.get[`Content-Type`] shouldBe Some(`Content-Type`(mt))
+      }
+      bodyCheck(response)
+    }
+
+  val defaultParser = MarkupParser
+    .of(Markdown)
+    .parallel[IO]
+    .withTheme(Theme.empty)
+    .build
+  
+  test("serve a rendered document") {
+    
+    val inputs = build(Seq((Root / "doc.md") -> "foo"))
+    
+    ServerBuilder(defaultParser, inputs).buildRoutes.use { app =>
+      val req = Request[IO](method = Method.GET, uri = uri"/doc.html" )
+      val res = app.run(req)
+      check (res, Status.Ok, Some(MediaType.text.html), stringBody("<p>foo</p>"))
+    }.run
+    
+  }
+
+  test("serve a rendered index document") {
+
+    val inputs = build(Seq((Root / "dir" / "README.md") -> "foo"))
+
+    ServerBuilder(defaultParser, inputs).buildRoutes.use { app =>
+      val req = Request[IO](method = Method.GET, uri = uri"/dir" )
+      val res = app.run(req)
+      check (res, Status.Ok, Some(MediaType.text.html), stringBody("<p>foo</p>"))
+    }.run
+
+  }
+
+  test("serve a static document") {
+
+    val inputs = build(Seq(
+      (Root / "doc.md") -> "foo",
+      (Root / "dir" / "image.jpg") -> "img"
+    ))
+
+    ServerBuilder(defaultParser, inputs).buildRoutes.use { app =>
+      val req = Request[IO](method = Method.GET, uri = uri"/dir/image.jpg" )
+      val res = app.run(req)
+      check (res, Status.Ok, Some(MediaType.image.jpeg), stringBody("img"))
+    }.run
+
+  }
+
+  test("serve a generated EPUB document") {
+
+    val inputs = build(Seq(
+      (Root / "doc.md") -> "foo",
+      (Root / "dir" / "image.jpg") -> "img"
+    ))
+
+    ServerBuilder(defaultParser, inputs)
+      .withConfig(ServerConfig.defaults.withEPUBDownloads.verbose)
+      .buildRoutes
+      .use { app =>
+        val req = Request[IO](method = Method.GET, uri = uri"/downloads/docs.epub" )
+        val res = app.run(req)
+        check (res, Status.Ok, Some(MediaType.application.`epub+zip`), nonEmptyBody)
+      }
+      .run
+  }
+
+  test("return 404 for unknown target path") {
+
+    val inputs = build(Seq(
+      (Root / "doc.md") -> "foo",
+      (Root / "dir" / "image.jpg") -> "img"
+    ))
+
+    ServerBuilder(defaultParser, inputs).buildRoutes.use { app =>
+      val req = Request[IO](method = Method.GET, uri = uri"/dir/styles.css" )
+      val res = app.run(req)
+      check (res, Status.NotFound)
+    }.run
+
+  }
+  // static file scanner
+  
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,6 +9,6 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 
-addSbtPlugin("org.planet42" % "laika-sbt" % "0.17.1")
+addSbtPlugin("org.planet42" % "laika-sbt" % "0.18.0-SNAPSHOT")
 
 addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,6 +9,6 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 
-addSbtPlugin("org.planet42" % "laika-sbt" % "0.18.0-SNAPSHOT")
+addSbtPlugin("org.planet42" % "laika-sbt" % "0.17.1")
 
 addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.3")

--- a/sbt/src/main/scala/laika/sbt/LaikaPlugin.scala
+++ b/sbt/src/main/scala/laika/sbt/LaikaPlugin.scala
@@ -132,7 +132,10 @@ object LaikaPlugin extends AutoPlugin {
 
     val laikaPreview      = taskKey[Unit]("Launches an HTTP server for the generated site and e-books")
     
+    val laikaPreviewConfig = taskKey[LaikaPreviewConfig]("Configuration options for the preview server")
+    
     val laikaPackageSite  = taskKey[File]("Create a zip file of the site")
+    
     
     val LaikaConfig = laika.sbt.LaikaConfig
     
@@ -154,6 +157,7 @@ object LaikaPlugin extends AutoPlugin {
 
     laikaExtensions         := Nil,
     laikaConfig             := LaikaConfig(),
+    laikaPreviewConfig      := LaikaPreviewConfig.defaults,
     laikaTheme              := Helium.defaults.build,
     laikaDescribe           := Settings.describe.value,
 

--- a/sbt/src/main/scala/laika/sbt/LaikaPlugin.scala
+++ b/sbt/src/main/scala/laika/sbt/LaikaPlugin.scala
@@ -76,6 +76,8 @@ import sbt._
   *
   * - `laikaSite`: combines the html generator with optionally also rendering a PDF document from the same input and
   *   creating scaladoc documentation and copying both over to the target directory.
+  *   
+  * - `laikaPreview`: launches an HTTP server for the generated site and e-books, auto-refreshing when inputs change.
   *
   * - `laikaPackageSite`: packages the generated html site and (optionally) the included API documentation and
   *   PDF file into a zip archive.
@@ -128,6 +130,8 @@ object LaikaPlugin extends AutoPlugin {
     val laikaIncludePDF   = settingKey[Boolean]("Indicates whether PDF output should be copied to the site")
     
 
+    val laikaPreview      = taskKey[Unit]("Launches an HTTP server for the generated site and e-books")
+    
     val laikaPackageSite  = taskKey[File]("Create a zip file of the site")
     
     val LaikaConfig = laika.sbt.LaikaConfig
@@ -169,6 +173,7 @@ object LaikaPlugin extends AutoPlugin {
     laikaAST                := Tasks.generate.toTask(" ast").value,
     
     laikaPackageSite        := Tasks.packageSite.value,
+    laikaPreview            := Tasks.preview.value,
     Laika / clean           := Tasks.clean.value,
 
     laikaSite / mappings    := Def.sequential(Tasks.site, Tasks.mappings).value,

--- a/sbt/src/main/scala/laika/sbt/LaikaPreviewConfig.scala
+++ b/sbt/src/main/scala/laika/sbt/LaikaPreviewConfig.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package laika.sbt
+
+import laika.preview.ServerConfig
+
+import scala.concurrent.duration.FiniteDuration
+
+/** Plugin configuration options specific to the preview server.
+  *
+  * @param port the port the server should run on (default 4242)
+  * @param pollInterval the interval at which input file resources are polled for changes (default 3 seconds)
+  * @param isVerbose whether each served page and each detected file change should be logged (default false)
+  */
+class LaikaPreviewConfig (val port: Int,
+                          val pollInterval: FiniteDuration,
+                          val isVerbose: Boolean) {
+
+  private def copy (newPort: Int = port,
+                    newPollInterval: FiniteDuration = pollInterval,
+                    newVerbose: Boolean = isVerbose): LaikaPreviewConfig =
+    new LaikaPreviewConfig(newPort, newPollInterval, newVerbose)
+  
+  /** Specifies the port the server should run on (default 4242).
+    */
+  def withPort (port: Int): LaikaPreviewConfig = copy(newPort = port)
+
+  /** Specifies the interval at which input file resources are polled for changes (default 3 seconds).
+    */
+  def withPollInterval (interval: FiniteDuration): LaikaPreviewConfig = copy(newPollInterval = interval)
+
+  /** Indicates that each served page and each detected file change should be logged to the console.
+    */
+  def verbose: LaikaPreviewConfig = copy(newVerbose = true)
+
+}
+
+/** Companion for preview server configuration instances.
+  */
+object LaikaPreviewConfig {
+
+  /** A config instance populated with default values. */
+  val defaults = new LaikaPreviewConfig(ServerConfig.defaultPort, ServerConfig.defaultPollInterval, false)
+
+}

--- a/sbt/src/main/scala/laika/sbt/Tasks.scala
+++ b/sbt/src/main/scala/laika/sbt/Tasks.scala
@@ -191,10 +191,22 @@ object Tasks {
     * The server can be stopped with `ctrl-D`.
     */
   val preview: Initialize[Task[Unit]] = task {
-    val port = 4242
     
-    val (_, cancel) = ServerBuilder[IO]().build.allocated.unsafeRunSync()
+    // optional props
+    val encoding = laikaConfig.value.encoding
+    val projectName = name.value // as fallback for artifactBaseName
+    val apiDocs = generateAPI.value // for link validation
+    val port = 4242 // TODO - should be configurable
+    
+    val (_, cancel) = ServerBuilder[IO](Settings.parser.value, laikaInputs.value.delegate)
+      .withTheme(laikaTheme.value)
+      .withPort(port)
+      .build
+      .allocated
+      .unsafeRunSync()
+    
     streams.value.log.info(s"Preview server started on port $port. Press ctrl-D to exit.")
+    
     try {
       System.in.read
     }

--- a/sbt/src/main/scala/laika/sbt/Tasks.scala
+++ b/sbt/src/main/scala/laika/sbt/Tasks.scala
@@ -213,7 +213,6 @@ object Tasks {
       .withPollInterval(previewConfig.pollInterval)
     
     val (_, cancel) = ServerBuilder[IO](Settings.parser.value, laikaInputs.value.delegate)
-      .withTheme(laikaTheme.value)
       .withLogger(s => IO(logger.info(s)))
       .withConfig(configureEbooks(config))
       .build

--- a/sbt/src/main/scala/laika/sbt/Tasks.scala
+++ b/sbt/src/main/scala/laika/sbt/Tasks.scala
@@ -193,7 +193,6 @@ object Tasks {
     */
   val preview: Initialize[Task[Unit]] = task {
     
-    // TODO - laikaPreviewConfig
     val logger = streams.value.log
     logger.info("Initializing server...")
     
@@ -203,10 +202,15 @@ object Tasks {
     val configureEbooks = applyIf(laikaIncludeEPUB.value, _.withEPUBDownloads)
       .andThen(applyIf(laikaIncludePDF.value, _.withPDFDownloads))
     
-    val config = ServerConfig.defaults
+    val previewConfig = laikaPreviewConfig.value
+    val defaultConfig = if (previewConfig.isVerbose) ServerConfig.defaults.verbose else ServerConfig.defaults
+    
+    val config = defaultConfig
       .withArtifactBasename(name.value)
       .withApiFiles(generateAPI.value)
       .withTargetDirectory((laikaSite / target).value)
+      .withPort(previewConfig.port)
+      .withPollInterval(previewConfig.pollInterval)
     
     val (_, cancel) = ServerBuilder[IO](Settings.parser.value, laikaInputs.value.delegate)
       .withTheme(laikaTheme.value)


### PR DESCRIPTION
* The new `laikaPreview` task of the sbt plugin can be used to browse generated sites.
* Includes auto-refreshing when input sources change.
* Can also be launched via the library API, using `laika.preview.ServerBuilder`.
* Introduces a new published module `laika-preview` that the sbt plugin depends on.