### PR TITLE
Versioning: process existing versionInfo.json as index

### DIFF
--- a/docs/src/03-preparing-content/01-directory-structure.md
+++ b/docs/src/03-preparing-content/01-directory-structure.md
@@ -287,6 +287,8 @@ Versioned Documentation
 Laika supports versioned documentation, where the current inputs are interpreted as belonging to one version only.
 The Helium theme contains a version switcher in the top navigation bar.
 
+### Configuration
+
 Each directory and each individual document can be marked as either versioned or unversioned.
 All versioned document will be rendered to a sub-directory of the root that contains only content for this
 specific version.
@@ -347,7 +349,34 @@ When overriding for an individual document, you can do this with the standard HO
 enclosed between `{%` and `%}`.
 
 
-**Re-Rendering Older Versions**
+### Index for Smart Version Switcher
+
+The Helium theme contains a version switcher that is aware of the directory structure of all versions.
+This means that when switching to a different version that contains the same document (based on its path and
+filename) it will navigate to that document instead of the entry page of the other version.
+
+The index for this flexible switching can be built up in two different ways, depending on your use case:
+
+1) **Older versions rendered by other toolkits**: In this case you need to run a transformation once where
+   the version configuration for Laika is complete (including all the older versions rendered by other tools)
+   and the target directory of the transformation contains the rendered documents of the other versions.
+   The transformer will scan the target directory and index all sub-directories on the top level where
+   the directory name corresponds to the configured `pathSegment` of a version.
+   This index will be written to `/laika/versionInfo.json` in the output directory.
+   It needs to be part of the deployment, and can also be used as input for subsequent transformation (see below),
+   so that the directory scanning is only necessary once.
+   
+   In the future the scan operation may be provided by a dedicated, separate task in the plugin and API. 
+   
+2) **Using an existing `versionInfo.json` document**: 
+   This more convenient option is available when either step 1 above has been performed once, 
+   or the site has been rendered with Laika and version configuration from the beginning.
+   Just place a valid, existing `versionInfo.json` document into the `laika` directory of any of your
+   input directories.
+   It will use this index during a transformation while amending any new documents found for the current version.
+
+
+### Re-Rendering Older Versions
 
 When switching to a maintenance branch to fix something in the documentation for an older version,
 you might want to ensure that the build step excludes unversioned documents as you most likely would want

--- a/docs/src/07-reference/06-release-notes.md
+++ b/docs/src/07-reference/06-release-notes.md
@@ -33,11 +33,14 @@ Release Notes
     * Add new AST nodes for different kinds of icon sets: font icons, CSS icons (e.g. image sprites), inline SVG icons
       and SVG symbols (references).
     * New `@:icon` directive that allows to reference an icon by key in markup documents or templates.
-* Versioning: new `renderUnversioned` flag, that can be set to false when rendering older versions 
-  (e.g. from a maintenance branch) to ensure that unversioned files always come from the main branch (newest version).
+* Versioning: 
+     * New `renderUnversioned` flag, that can be set to false when rendering older versions 
+       (e.g. from a maintenance branch) to ensure that unversioned files always come from the main branch (newest version).
+     * Use existing `/laika/versionInfo.json` documents in the input directory as an alternative to scanning the
+       target directory for indexing the content of older versions.
 * Link Validation: new `addProvidedPath` method on `InputTreeBuilder` that adds a path representing a document which is 
   processed by some external tool, making it available during link validation.
-* PDF Support: upgrade to Apache FOP 2.6 (2.4 and 2.5 were both skipped as they had an issue with dependencies 
+* PDF Support: upgrade to Apache FOP 2.6 (2.4 and 2.5 were both skipped as they had an issue with non-public dependencies 
   in their POMs).
 * EPUB Renderer: add support for JavaScript execution in EPUB documents
     * Scripting in EPUB requires a flag to be set for each scripted document in OPF metadata.
@@ -55,7 +58,9 @@ Release Notes
 * AST: add `codeOptions` property to `CodeBlock` element for potential tool integrations
 * sbt plugin: The `Laika/clean` task now preserves some directories that will not be re-generated
   (e.g. api documentation, download directory and older versions in versioned documentation).
-* Bugfix: the HTML renderer did not apply versions to image URLs in case of versioned documentation
+* Bugfixes
+    * The HTML renderer did not apply versions to image URLs in case of versioned documentation
+    * In-memory string input sources could not be read more than once
 
 
 0.17.1 (Mar 19, 2021)

--- a/io/src/main/scala/laika/io/runtime/InputRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/InputRuntime.scala
@@ -60,12 +60,12 @@ object InputRuntime {
     Resource.fromAutoCloseable(Sync[F].delay(new BufferedInputStream(new FileInputStream(file))))
 
   def textFileResource[F[_]: Sync] (file: File, codec: Codec): Resource[F, Reader] =
-    readerResource(Resource.fromAutoCloseable(Sync[F].delay(new FileInputStream(file))), codec)
-  
-  def textStreamResource[F[_]: Sync] (inputStream: F[InputStream], codec: Codec, autoClose: Boolean): Resource[F, Reader] =
-    readerResource(if (autoClose) Resource.fromAutoCloseable(inputStream) else Resource.eval(inputStream), codec)
+    textStreamResource(Resource.fromAutoCloseable(Sync[F].delay(new FileInputStream(file))), codec)
 
-  private def readerResource[F[_]: Sync](resource: Resource[F, InputStream], codec: Codec): Resource[F, Reader] =
+  def textStreamResource[F[_]: Sync] (inputStream: F[InputStream], codec: Codec, autoClose: Boolean): Resource[F, Reader] =
+    textStreamResource(if (autoClose) Resource.fromAutoCloseable(inputStream) else Resource.eval(inputStream), codec)
+
+  def textStreamResource[F[_]: Sync](resource: Resource[F, InputStream], codec: Codec): Resource[F, Reader] =
     resource.map(in => new BufferedReader(new InputStreamReader(in, codec.charSet)))
   
 }

--- a/io/src/main/scala/laika/io/runtime/VersionInfoGenerator.scala
+++ b/io/src/main/scala/laika/io/runtime/VersionInfoGenerator.scala
@@ -16,10 +16,12 @@
 
 package laika.io.runtime
 
+import laika.ast.Path
+import laika.ast.Path.Root
 import laika.io.runtime.VersionedLinkTargets.VersionedDocument
 import laika.rewrite.Versions
 
-private[runtime] object VersionInfoGenerator {
+private[io] object VersionInfoGenerator {
   
   private val template = 
     """{
@@ -41,6 +43,8 @@ private[runtime] object VersionInfoGenerator {
     linkTargets.sortBy(_.path.toString).map { doc =>
       s"""    { "path": "${doc.path.toString}", "versions": ["${doc.versions.sorted.mkString("\",\"")}"] }"""
     }.mkString(",\n").trim
+    
+  val path: Path = Root / "laika" / "versionInfo.json"
 
   def generate (versions: Versions, linkTargets: Seq[VersionedDocument]): String = template
     .replace("$VERSIONS", generateVersions(versions))

--- a/io/src/main/scala/laika/io/runtime/VersionedLinkTargets.scala
+++ b/io/src/main/scala/laika/io/runtime/VersionedLinkTargets.scala
@@ -23,21 +23,26 @@ import laika.collection.TransitionalCollectionOps._
 import laika.ast.DocumentType.{Ignored, Static}
 import laika.ast.Path.Root
 import laika.ast.{DocumentType, Path, SegmentedPath}
+import laika.config.Config.ConfigResult
+import laika.config.{Config, ConfigDecoder, ConfigException, ConfigParser}
 import laika.io.model.{BinaryInput, DirectoryInput, DirectoryOutput}
-import laika.rewrite.Versions
+import laika.rewrite.{Version, Versions}
+
+import java.io.File
+import scala.io.Codec
 
 private[runtime] object VersionedLinkTargets {
 
-  def scanExistingVersions[F[_]: Sync] (versions: Versions, output: DirectoryOutput): F[Map[String, Seq[Path]]] = {
+  private def scanTargetDirectory[F[_]: Sync] (versions: Versions, output: DirectoryOutput): F[Map[String, Seq[Path]]] = {
     val existingVersions = (versions.newerVersions ++ versions.olderVersions).map(_.pathSegment).toSet
     val excluded = versions.excludeFromScanning.flatMap { exclude =>
       existingVersions.toSeq.map(v => Root / v / exclude.relative)
     }.toSet
-    
+
     def included (path: Path, segments: NonEmptyChain[String]): Boolean = {
       path.suffix.contains("html") &&
-        existingVersions.contains(segments.head) && 
-        segments.size > 1 && 
+        existingVersions.contains(segments.head) &&
+        segments.size > 1 &&
         !excluded.exists(ex => path.isSubPath(ex))
     }
     val docTypeMather: Path => DocumentType = {
@@ -47,12 +52,45 @@ private[runtime] object VersionedLinkTargets {
     val input = DirectoryInput(Seq(output.directory), output.codec, docTypeMather)
     DirectoryScanner.scanDirectories(input).map { tree =>
       tree.binaryInputs
-        .collect { case BinaryInput(path: SegmentedPath, _, _, _) => 
-          (path.segments.head, SegmentedPath(NonEmptyChain.fromChainUnsafe(path.segments.tail), path.suffix, None)) 
+        .collect { case BinaryInput(path: SegmentedPath, _, _, _) if path.depth > 1 =>
+          (path.segments.head, SegmentedPath(NonEmptyChain.fromChainUnsafe(path.segments.tail), path.suffix, None))
+        }
+        .groupBy(_._1)
+        .mapValuesStrict(_.map(_._2))
+    }
+  }
+
+  implicit private val versionInfoDecoder: ConfigDecoder[(Path, Seq[String])] = ConfigDecoder.config.flatMap { config =>
+    for {
+      path      <- config.get[Path]("path")
+      versions  <- config.get[Seq[String]]("versions")
+    } yield {
+      (path, versions)
+    }
+  }
+  
+  private def loadVersionInfo[F[_]: Sync] (existing: BinaryInput[F]): F[Map[String, Seq[Path]]] = {
+    def asSync[T](res: ConfigResult[T]): F[T] = Sync[F].fromEither(res.leftMap(ConfigException.apply))
+    
+    InputRuntime
+      .textStreamResource(existing.input, Codec.UTF8)
+      .use(InputRuntime.readAll(_, 8096))
+      .flatMap(json => asSync(ConfigParser.parse(json).resolve()))
+      .flatMap(config => asSync(config.get[Seq[(Path, Seq[String])]]("linkTargets")))
+      .map { _
+        .flatMap { case (path, versions) =>
+          versions.map((_, path))
         }
         .groupBy(_._1)
         .mapValuesStrict(_.map(_._2))
       }
+  }
+  
+  def gatherTargets[F[_]: Sync] (versions: Versions, output: Option[DirectoryOutput], staticDocs: Seq[BinaryInput[F]]): F[Map[String, Seq[Path]]] =
+    (staticDocs.find(_.path == VersionInfoGenerator.path), output) match {
+      case (Some(info), _) => loadVersionInfo(info)
+      case (_, Some(dir))  => scanTargetDirectory(versions, dir)
+      case _               => Sync[F].pure(Map.empty)
     }
 
   def groupLinkTargets (versions: Versions,


### PR DESCRIPTION
This serves as a more convenient alternative to providing all documents of older versions in the output directory for scanning.
The latter is now only required once in cases where older versions exist that had been generated by other tools.