### PR TITLE
Do not fail describe operation in case of non-existing input directory

### DIFF
--- a/io/src/main/scala/laika/io/descriptor/ParserDescriptor.scala
+++ b/io/src/main/scala/laika/io/descriptor/ParserDescriptor.scala
@@ -51,14 +51,16 @@ case class ParserDescriptor (parsers: NonEmptyList[String],
 object ParserDescriptor {
   
   def create[F[_]: Sync] (op: TreeParser.Op[F]): F[ParserDescriptor] = 
-    TreeInputDescriptor.create(op.input.build(op.config.docTypeMatcher)).map { inputDesc =>
-    apply(
-      op.parsers.map(_.format.description),
-      op.config.bundles.filter(op.config.bundleFilter).map(ExtensionBundleDescriptor.apply),
-      inputDesc,
-      op.config.bundleFilter.strict,
-      op.config.bundleFilter.acceptRawContent
-    )
-  } 
+    TreeInputDescriptor
+      .create(op.input.withFileFilter(f => !f.exists).build(op.config.docTypeMatcher))
+      .map { inputDesc =>
+        apply(
+          op.parsers.map(_.format.description),
+          op.config.bundles.filter(op.config.bundleFilter).map(ExtensionBundleDescriptor.apply),
+          inputDesc,
+          op.config.bundleFilter.strict,
+          op.config.bundleFilter.acceptRawContent
+        )
+      }
   
 }


### PR DESCRIPTION
Previously the directory scanner ran prematurely which causes issues in the sbt plugin when used in a scenario where Laika's inputs are the output of another tool, e.g. mdoc, which might not exist before the first run of that tool.