### PR TITLE
fix: the sbt plugin logs the wrong "port" val

### DIFF
--- a/sbt/src/main/scala/laika/sbt/Tasks.scala
+++ b/sbt/src/main/scala/laika/sbt/Tasks.scala
@@ -218,8 +218,8 @@ object Tasks {
       .allocated
       .unsafeRunSync()
 
-    logger.info(s"Preview server started on port $port. Press ctrl-D to exit.")
-    
+    logger.info(s"Preview server started on port ${previewConfig.port}. Press ctrl-D to exit.")
+
     try {
       System.in.read
     }


### PR DESCRIPTION
in the scope, comcast.ip4s.port is imported and that's what is logged.

it shows has:

```
sbt:blog-sbt> blog/laikaPreview
[info] Delete API dir
[info] Initializing server...
[info] Preview server started on port com.comcast.ip4s.Literals$port$@b128704. Press ctrl-D to exit.
```

instead we should log the previewConfig port (default 4242).