### PR TITLE
fix: convert Windows line feed to Unix line feed in all parser inputs

### DIFF
--- a/core/shared/src/main/scala/laika/parse/SourceCursor.scala
+++ b/core/shared/src/main/scala/laika/parse/SourceCursor.scala
@@ -348,7 +348,7 @@ object BlockSource {
     val trimmedLines = lines.map { line =>
       if (line.input.endsWith("\n")) LineSource(line.input.dropRight(1), line.parent) else line
     }
-    val input = new InputString(trimmedLines.map(_.input).mkString_("\n"))
+    val input = InputString.safe(trimmedLines.map(_.input).mkString_("\n"))
     new BlockSource(input, trimmedLines, 0, lines.head.nestLevel)
   }
 
@@ -390,17 +390,17 @@ object SourceCursor {
 
   /** Builds a new instance for the specified input string.
     */
-  def apply (input: String): SourceCursor = new RootSource(new InputString(input), 0, 0)
+  def apply (input: String): SourceCursor = new RootSource(InputString(input), 0, 0)
 
   /** Builds a new instance for the specified input string and source path.
     */
-  def apply (input: String, path: Path): SourceCursor = new RootSource(new InputString(input, Some(path)), 0, 0)
+  def apply (input: String, path: Path): SourceCursor = new RootSource(InputString(input, Some(path)), 0, 0)
 
 }
 
 /** Represents the input string for a parsing operation.
   */
-private[parse] class InputString (val value: String, val path: Option[Path] = None, val isReverse: Boolean = false) {
+private[parse] class InputString private (val value: String, val path: Option[Path] = None, val isReverse: Boolean = false) {
 
   /** An index that contains all line starts, including first line, and eof.
     */
@@ -425,6 +425,10 @@ private[parse] class InputString (val value: String, val path: Option[Path] = No
 
 private[parse] object InputString {
   val empty: InputString = new InputString("")
+  def apply (value: String, path: Option[Path] = None, isReverse: Boolean = false): InputString =
+    new InputString(value.replace("\r\n", "\n"), path, isReverse)
+  def safe (value: String, path: Option[Path] = None, isReverse: Boolean = false): InputString =
+    new InputString(value, path, isReverse)
 }
 
 /**  Represents an offset into a source string. Its main purpose

--- a/core/shared/src/test/scala/laika/parse/SourceCursorSpec.scala
+++ b/core/shared/src/test/scala/laika/parse/SourceCursorSpec.scala
@@ -23,11 +23,11 @@ class RootCursorSpec extends FunSuite {
 
   private val cursor = SourceCursor("abc\ndef")
 
-  test("not be at the end of input after creation") {
+  test("not at the end of input after creation") {
     assertEquals(cursor.atEnd, false)
   }
 
-  test("be at the end of input after consuming all characters") {
+  test("at the end of input after consuming all characters") {
     assertEquals(cursor.consume(7).atEnd, true)
   }
 
@@ -94,6 +94,10 @@ class RootCursorSpec extends FunSuite {
   test("keep the path information") {
     assertEquals(SourceCursor("foo", Root / "bar").path, Some(Root / "bar"))
   }
+
+  test("convert Windows line feeds") {
+    assertEquals(SourceCursor("abc\r\ndef\r\nghi").input, "abc\ndef\nghi")
+  }
   
 }
 
@@ -102,7 +106,7 @@ class BlockCursorSpec extends FunSuite {
   import cats.data.NonEmptyChain
 
   private val cursor = {
-    val root = new RootSource(new InputString("000\nabc\ndef", Some(Root / "doc")), 4, 0)
+    val root = new RootSource(InputString("000\nabc\ndef", Some(Root / "doc")), 4, 0)
     val lines = NonEmptyChain(
       LineSource("abc", root),
       LineSource("def", root.consume(4))


### PR DESCRIPTION
Previously Windows line feeds were kept in place which caused several parsers to fail.