### PR TITLE
Link Resolver: allow duplicate ids, but prevent references to them

### DIFF
--- a/core/shared/src/main/scala/laika/rewrite/link/DocumentTargets.scala
+++ b/core/shared/src/main/scala/laika/rewrite/link/DocumentTargets.scala
@@ -132,7 +132,7 @@ case class DocumentTargets (document: Document, slugBuilder: String => String) {
       case (sel: UniqueSelector, target :: Nil) =>
         (sel, target)
       case (sel: UniqueSelector, duplicates) =>
-        (sel, TargetResolver.forDuplicateSelector(sel, document.path, duplicates))
+        (sel, TargetResolver.forDuplicateSelector(sel, document.path, duplicates, isDocScope = true))
       case (selector, list) =>
         (selector, TargetSequenceResolver(list, selector))
     }

--- a/core/shared/src/main/scala/laika/rewrite/link/TreeTargets.scala
+++ b/core/shared/src/main/scala/laika/rewrite/link/TreeTargets.scala
@@ -55,7 +55,7 @@ class TreeTargets (root: DocumentTreeRoot, slugBuilder: String => String) {
     (targets ++ static).groupBy(_._1).collect {
       case (key, Seq((_, target))) => (key, target)
       case ((path, selector: UniqueSelector), dupTargets) => 
-        ((path, selector), TargetResolver.forDuplicateSelector(selector, path, dupTargets.map(_._2)))
+        ((path, selector), TargetResolver.forDuplicateSelector(selector, path, dupTargets.map(_._2), isDocScope = false))
     }
   }
 

--- a/core/shared/src/test/scala/laika/rewrite/RewriteRulesSpec.scala
+++ b/core/shared/src/test/scala/laika/rewrite/RewriteRulesSpec.scala
@@ -564,13 +564,13 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
     runRootWithoutTitles(rootElem, expected)
   }
 
-
-  test("duplicate ids - remove the id from all elements with duplicate ids") {
-    val target1a = Citation("name", List(p("citation 1")))
-    val target1b = Citation("name", List(p("citation 2")))
-    val msg = "More than one link target with id 'name' in path /doc"
-    val rootElem = RootElement(target1a, target1b)
-    val expected = RootElement(invalidBlock(msg, target1a), invalidBlock(msg, target1b))
+  test("duplicate ids - append auto-increment numbers") {
+    val header = Header(1, "Header")
+    val rootElem = RootElement(header, header)
+    val expected = RootElement(
+      Title("Header").withOptions(Id("header-1") + Styles("title")),
+      Section(header.withOptions(Id("header-2") + Styles("section")), Nil)
+    )
     runRoot(rootElem, expected)
   }
 
@@ -585,7 +585,7 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
   test("duplicate ids - replace ambiguous references to duplicate ids with invalid spans") {
     val target1a = LinkDefinition("name", ExternalTarget("http://foo/1"))
     val target1b = LinkDefinition("name", ExternalTarget("http://foo/2"))
-    val msg = "More than one link definition with id 'name' in path /doc"
+    val msg = "Ambiguous reference: more than one link definition with id 'name' in path /doc"
     val rootElem = RootElement(p(linkIdRef()), target1a, target1b)
     val expected = RootElement(p(invalidSpan(msg, "<<name>>")))
     runRoot(rootElem, expected)
@@ -593,10 +593,14 @@ class RewriteRulesSpec extends FunSuite with ParagraphCompanionShortcuts with Te
 
   test("duplicate ids - replace ambiguous references for a link alias pointing to duplicate ids with invalid spans") {
     val target = InternalLinkTarget(Id("ref"))
-    val targetMsg = "More than one link target with id 'ref' in path /doc"
+    val targetMsg = "Ambiguous reference: more than one link target with id 'ref' in path /doc"
     val invalidTarget = invalidBlock(targetMsg, InternalLinkTarget())
     val rootElem = RootElement(p(pathRef()), LinkAlias("name", "ref"), target, target)
-    val expected = RootElement(p(invalidSpan(targetMsg, "[<name>]")), invalidTarget, invalidTarget)
+    val expected = RootElement(
+      p(invalidSpan(targetMsg, "[<name>]")),
+      InternalLinkTarget(Id("ref-1")),
+      InternalLinkTarget(Id("ref-2"))
+    )
     runRoot(rootElem, expected)
   }
 


### PR DESCRIPTION
The restriction of preventing duplicate section headers had already been raised some time ago in #153. Unfortunately I did not realize back then that there is an obvious approach that is less restrictive, but still prevents ambiguous internal links.

With this PR, duplicate section headers are allowed, **as long as** no internal link points to it.
In case of valid duplication (nothing pointing to it), Laika now appends auto-increment ids to the section ids like other tools do.