### PR TITLE
add prevDoc and nextDoc template directives

### DIFF
--- a/core/shared/src/main/scala/laika/directive/std/StandardDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/StandardDirectives.scala
@@ -118,6 +118,23 @@ object StandardDirectives extends DirectiveRegistry {
     }
   }
 
+  lazy val prevDoc: Templates.Directive = Templates.create("prevDoc"){
+    import Templates.dsl._
+    cursor.map { cursor =>
+      cursor.previousDocument.fold[TemplateSpan](TemplateElement(Deleted(Nil))) {
+        d => TemplateElement(SpanLink(d.target.title.getOrElse(SpanSequence(Text(d.path.toString)+:Nil)) +:Nil,InternalTarget(PathBase.parse(d.path.toString))))
+      }
+    }
+  }
+  lazy val nextDoc: Templates.Directive = Templates.create("nextDoc"){
+    import Templates.dsl._
+    cursor.map { cursor =>
+      cursor.nextDocument.fold[TemplateSpan](TemplateElement(Deleted(Nil))) {
+        d => TemplateElement(SpanLink(d.target.title.getOrElse(SpanSequence(Text(d.path.toString)+:Nil)) +:Nil,InternalTarget(PathBase.parse(d.path.toString))))
+      }
+    }
+  }
+
   lazy val path: Templates.Directive = Templates.eval("path") {
     import Templates.dsl._
     
@@ -276,6 +293,8 @@ object StandardDirectives extends DirectiveRegistry {
     HTMLHeadDirectives.linkJS,
     iconTemplate,
     path,
+    prevDoc,
+    nextDoc,
     attr
   )
 


### PR DESCRIPTION
rel #137

cursor.previousDocument.(absolutePath|relativePath) is not useful when
it comes to adding links to prev/next documents because it returns
not resolved path(e.g. path/to/index.html) but unresolved path(e.g. path/to/README.md)

Besides, it is not possible to eval values in `path` directive.  

I tried path directive with Substitution Variables, but it results in error.

```
@:path(cursor.previousDocument.absolutePath) 
@:path(${cursor.previousDocument.absolutePath}) 
```

`prevDoc` and `nextDoc` ,for example, enables something like this.

<img width="682" alt="image" src="https://user-images.githubusercontent.com/39330037/149615665-c109aa34-dc98-43de-bddb-b826d729defc.png">
