### PR TITLE
Fix favicon href in helium template?

### DIFF
--- a/io/src/main/resources/laika/helium/templates/default.template.html
+++ b/io/src/main/resources/laika/helium/templates/default.template.html
@@ -13,7 +13,7 @@
       <meta name="description" content="${_}"/>
     @:@
     @:for(helium.favIcons)
-      <link rel="icon" @:attribute(sizes, _.sizes) @:attribute(type, _.type) href="@:path(_.target)"/>
+      <link rel="icon" @:attribute(sizes, _.sizes) @:attribute(type, _.type) @:attribute(href, _.target)/>
     @:@
     @:for(helium.webFonts)
       <link rel="stylesheet" href="${_}">


### PR DESCRIPTION
I'm not sure if this is the right way to fix this, but it solves this error:

```
[error]   [/default.template.html:16]: One or more errors processing directive 'path': unresolved internal reference: https://typelevel.org/img/favicon.png
[error] 
[error]         <link rel="icon" @:attribute(sizes, _.sizes) @:attribute(type, _.type) href="@:path(_.target)"/>
```

Thanks!