### PR TITLE
migrate to fs2-io

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,6 +65,8 @@ val munit      = "org.scalameta"          %% "munit"       % versions.munit     
 val jTidy      = "net.sf.jtidy"           %  "jtidy"       % versions.jTidy     % "test"
 
 val catsEffect = "org.typelevel"          %% "cats-effect"         % versions.catsEffect
+val fs2 = "co.fs2"          %% "fs2-core"         % versions.fs2
+val fs2IO = "co.fs2"          %% "fs2-io"         % versions.fs2
 val munitCE3   = "org.typelevel"          %% "munit-cats-effect-3" % versions.munitCE3 % "test"
 
 val fop        = "org.apache.xmlgraphics" %  "fop"         % versions.fop
@@ -123,7 +125,7 @@ lazy val io = project.in(file("io"))
   .settings(publishSettings)
   .settings(
     name := "laika-io",
-    libraryDependencies ++= Seq(catsEffect, munit, munitCE3)
+    libraryDependencies ++= Seq(catsEffect, fs2,fs2IO,munit, munitCE3)
   )
   
 lazy val pdf = project.in(file("pdf"))

--- a/io/src/main/scala/laika/helium/builder/HeliumInputBuilder.scala
+++ b/io/src/main/scala/laika/helium/builder/HeliumInputBuilder.scala
@@ -25,13 +25,14 @@ import laika.helium.generate.{CSSVarGenerator, FOStyles, MergedCSSGenerator}
 import laika.io.model.{InputTree, InputTreeBuilder}
 import laika.rewrite.DefaultTemplatePath
 import laika.theme.config.{EmbeddedFontFile, EmbeddedFontResource}
+import cats.effect.kernel.Async
 
 /**
   * @author Jens Halm
   */
 private[helium] object HeliumInputBuilder {
 
-  def build[F[_]: Sync] (helium: Helium): F[InputTreeBuilder[F]] = {
+  def build[F[_]: Async] (helium: Helium): F[InputTreeBuilder[F]] = {
     
     import helium._
     

--- a/io/src/main/scala/laika/helium/builder/HeliumThemeBuilder.scala
+++ b/io/src/main/scala/laika/helium/builder/HeliumThemeBuilder.scala
@@ -23,6 +23,7 @@ import laika.format.{EPUB, HTML, XSLFO}
 import laika.helium.Helium
 import laika.helium.generate._
 import laika.theme.{Theme, ThemeBuilder, ThemeProvider}
+import cats.effect.kernel.Async
 
 /**
   * @author Jens Halm
@@ -39,7 +40,7 @@ private[helium] class HeliumThemeBuilder (helium: Helium) extends ThemeProvider 
   }
   
   
-  def build[F[_]: Sync]: Resource[F, Theme[F]] = {
+  def build[F[_]: Async]: Resource[F, Theme[F]] = {
 
     import helium._
 

--- a/io/src/main/scala/laika/helium/generate/MergedCSSGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/MergedCSSGenerator.scala
@@ -20,10 +20,11 @@ import cats.effect.Sync
 import cats.implicits._
 import laika.ast.Path.Root
 import laika.io.model.InputTree
+import cats.effect.kernel.Async
 
 private[helium] object MergedCSSGenerator {
 
-  def mergeSiteCSS[F[_]: Sync](varBlock: String): F[String] = {
+  def mergeSiteCSS[F[_]:Async](varBlock: String): F[String] = {
 
     val inputTree = InputTree[F]
       .addClasspathResource("laika/helium/css/container.css", Root / "css" / "container.css")
@@ -39,7 +40,7 @@ private[helium] object MergedCSSGenerator {
     } yield varBlock + merged
   }
 
-  def mergeEPUBCSS[F[_]: Sync](varBlock: String): F[String] = {
+  def mergeEPUBCSS[F[_]: Async](varBlock: String): F[String] = {
     
     val importantVars = 
       (1 to 5).map("syntax-wheel" + _) ++ 

--- a/io/src/main/scala/laika/io/api/TreeParser.scala
+++ b/io/src/main/scala/laika/io/api/TreeParser.scala
@@ -28,16 +28,17 @@ import laika.io.runtime.{ParserRuntime, Batch}
 import laika.theme.{Theme, ThemeProvider}
 import laika.parse.markup.DocumentParser
 import laika.parse.markup.DocumentParser.{ParserError, DocumentInput}
+import cats.effect.kernel.Async
 
 /** Parser for a tree of input documents.
   *
   * @author Jens Halm
   */
-class TreeParser[F[_]: Sync: Batch] (parsers: NonEmptyList[MarkupParser], val theme: Theme[F]) extends InputOps[F] {
+class TreeParser[F[_]: Async: Batch] (parsers: NonEmptyList[MarkupParser], val theme: Theme[F]) extends InputOps[F] {
 
   type Result = TreeParser.Op[F]
 
-  val F: Sync[F] = Sync[F]
+  val F: Async[F] = Async[F]
 
   val docType: TextDocumentType = DocumentType.Markup
 
@@ -62,7 +63,7 @@ object TreeParser {
   /** Builder step that allows to specify the execution context
     * for blocking IO and CPU-bound tasks.
     */
-  case class Builder[F[_]: Sync: Batch] (parsers: NonEmptyList[MarkupParser], theme: ThemeProvider) {
+  case class Builder[F[_]: Async: Batch] (parsers: NonEmptyList[MarkupParser], theme: ThemeProvider) {
 
     /** Specifies an additional parser for text markup.
       * 
@@ -96,7 +97,7 @@ object TreeParser {
     * default runtime implementation or by developing a custom runner that performs
     * the parsing based on this operation's properties.
     */
-  case class Op[F[_]: Sync: Batch] (parsers: NonEmptyList[MarkupParser], theme: Theme[F], input: InputTreeBuilder[F]) {
+  case class Op[F[_]: Async: Batch] (parsers: NonEmptyList[MarkupParser], theme: Theme[F], input: InputTreeBuilder[F]) {
 
     /** The merged configuration of all markup parsers of this operation, including the theme extensions.
       */

--- a/io/src/main/scala/laika/io/api/TreeRenderer.scala
+++ b/io/src/main/scala/laika/io/api/TreeRenderer.scala
@@ -26,12 +26,13 @@ import laika.io.model.{BinaryInput, ParsedTree, RenderedTreeRoot, TreeOutput}
 import laika.io.ops.TextOutputOps
 import laika.io.runtime.{Batch, RendererRuntime}
 import laika.theme.{Theme, ThemeProvider}
+import cats.effect.kernel.Async
 
 /** Renderer for a tree of output documents.
   *
   * @author Jens Halm
   */
-class TreeRenderer[F[_]: Sync: Batch] (renderer: Renderer, theme: Theme[F]) {
+class TreeRenderer[F[_]: Async: Batch] (renderer: Renderer, theme: Theme[F]) {
 
   /** Builder step that specifies the root of the document tree to render.
     */
@@ -52,7 +53,7 @@ object TreeRenderer {
 
   /** Builder step that allows to specify the execution context for blocking IO and CPU-bound tasks.
     */
-  class Builder[F[_]: Sync: Batch] (renderer: Renderer, theme: Resource[F, Theme[F]]) {
+  class Builder[F[_]: Async: Batch] (renderer: Renderer, theme: Resource[F, Theme[F]]) {
 
     /** Applies the specified theme to this renderer, overriding any previously specified themes.
       */
@@ -70,12 +71,12 @@ object TreeRenderer {
 
   /** Builder step that allows to specify the output to render to.
     */
-  case class OutputOps[F[_]: Sync: Batch] (renderer: Renderer,
+  case class OutputOps[F[_]: Async: Batch] (renderer: Renderer,
                                            theme: Theme[F],
                                            input: DocumentTreeRoot,
                                            staticDocuments: Seq[BinaryInput[F]]) extends TextOutputOps[F] {
 
-    val F: Sync[F] = Sync[F]
+    val F: Async[F] = Async[F]
 
     type Result = Op[F]
 
@@ -92,7 +93,7 @@ object TreeRenderer {
     * It can be run by invoking the `render` method which delegates to the library's default runtime implementation
     * or by developing a custom runner that performs the rendering based on this operation's properties.
     */
-  case class Op[F[_]: Sync: Batch] (renderer: Renderer,
+  case class Op[F[_]: Async: Batch] (renderer: Renderer,
                                     theme: Theme[F],
                                     input: DocumentTreeRoot,
                                     output: TreeOutput,

--- a/io/src/main/scala/laika/io/api/TreeTransformer.scala
+++ b/io/src/main/scala/laika/io/api/TreeTransformer.scala
@@ -28,19 +28,20 @@ import laika.io.model.{InputTreeBuilder, ParsedTree, RenderedTreeRoot, TreeOutpu
 import laika.io.ops.{InputOps, TextOutputOps, TreeMapperOps}
 import laika.io.runtime.{Batch, TransformerRuntime}
 import laika.theme.{Theme, ThemeProvider}
+import cats.effect.kernel.Async
 
 /** Transformer for a tree of input and output documents.
   *
   * @author Jens Halm
   */
-class TreeTransformer[F[_]: Sync: Batch] (parsers: NonEmptyList[MarkupParser],
+class TreeTransformer[F[_]: Async: Batch] (parsers: NonEmptyList[MarkupParser],
                                           renderer: Renderer,
                                           theme: Theme[F],
                                           mapper: TreeMapper[F]) extends InputOps[F] {
 
   type Result = TreeTransformer.OutputOps[F]
 
-  val F: Sync[F] = Sync[F]
+  val F: Async[F] = Async[F]
 
   val docType: TextDocumentType = DocumentType.Markup
 
@@ -61,7 +62,7 @@ object TreeTransformer {
   /** Builder step that allows to specify the execution context
     * for blocking IO and CPU-bound tasks.
     */
-  case class Builder[F[_]: Sync: Batch] (parsers: NonEmptyList[MarkupParser],
+  case class Builder[F[_]: Async: Batch] (parsers: NonEmptyList[MarkupParser],
                                          renderer: Renderer,
                                          theme: ThemeProvider,
                                          mapper: TreeMapper[F]) extends TreeMapperOps[F] {
@@ -101,13 +102,13 @@ object TreeTransformer {
 
   /** Builder step that allows to specify the output to render to.
     */
-  case class OutputOps[F[_]: Sync: Batch] (parsers: NonEmptyList[MarkupParser],
+  case class OutputOps[F[_]: Async: Batch] (parsers: NonEmptyList[MarkupParser],
                                            renderer: Renderer,
                                            theme: Theme[F],
                                            input: InputTreeBuilder[F],
                                            mapper: TreeMapper[F]) extends TextOutputOps[F] {
 
-    val F: Sync[F] = Sync[F]
+    val F: Async[F] = Async[F]
 
     type Result = Op[F]
 
@@ -121,7 +122,7 @@ object TreeTransformer {
     * default runtime implementation or by developing a custom runner that performs
     * the transformation based on this operation's properties.
     */
-  case class Op[F[_]: Sync: Batch] (parsers: NonEmptyList[MarkupParser],
+  case class Op[F[_]: Async: Batch] (parsers: NonEmptyList[MarkupParser],
                                     renderer: Renderer,
                                     theme: Theme[F],
                                     input: InputTreeBuilder[F],

--- a/io/src/main/scala/laika/io/config/IncludeHandler.scala
+++ b/io/src/main/scala/laika/io/config/IncludeHandler.scala
@@ -25,6 +25,7 @@ import laika.config.Config.IncludeMap
 import laika.config.{ConfigParser, ConfigResourceError}
 import laika.io.runtime.Batch
 import laika.parse.hocon.{IncludeAny, IncludeClassPath, IncludeFile, IncludeResource, IncludeUrl, ValidStringValue}
+import cats.effect.kernel.Async
 
 /** Internal utility that provides configuration files requested by include statements in other
   * configuration instances.
@@ -45,7 +46,7 @@ object IncludeHandler {
     * be mapped to the requested resource as a `Left`. Successfully loaded and parsed
     * resources appear in the result map as a `Right`.
     */
-  def load[F[_]: Sync : Batch] (includes: Seq[RequestedInclude]): F[IncludeMap] = 
+  def load[F[_]: Async : Batch] (includes: Seq[RequestedInclude]): F[IncludeMap] = 
     
     if (includes.isEmpty) Sync[F].pure(Map.empty) else {
       

--- a/io/src/main/scala/laika/io/descriptor/TransformerDescriptor.scala
+++ b/io/src/main/scala/laika/io/descriptor/TransformerDescriptor.scala
@@ -72,7 +72,7 @@ object TransformerDescriptor {
       renderer.renderFormatted
     )
   
-  def create[F[_]: Sync: Batch] (op: TreeTransformer.Op[F]): F[TransformerDescriptor] = for {
+  def create[F[_]: Async: Batch] (op: TreeTransformer.Op[F]): F[TransformerDescriptor] = for {
     parserDesc <- ParserDescriptor.create(TreeParser.Op(op.parsers, op.theme, op.input))
     renderDesc <- RendererDescriptor.create(TreeRenderer.Op(op.renderer, op.theme, DocumentTreeRoot(DocumentTree(Root, Nil)), op.output, Nil))
   } yield apply(parserDesc, renderDesc)

--- a/io/src/main/scala/laika/io/implicits.scala
+++ b/io/src/main/scala/laika/io/implicits.scala
@@ -68,21 +68,21 @@ import laika.io.runtime.Batch
   */
 object implicits {
 
-  implicit class ImplicitParserOps (val builder: ParserBuilder) extends SyncIOBuilderOps[TreeParser.Builder] {
+  implicit class ImplicitParserOps (val builder: ParserBuilder) extends AsyncIOBuilderOps[TreeParser.Builder] {
 
-    protected def build[F[_]: Sync: Batch]: TreeParser.Builder[F] =
+    protected def build[F[_]: Async: Batch]: TreeParser.Builder[F] =
       new TreeParser.Builder[F](NonEmptyList.of(builder.build), Helium.defaults.build)
   }
 
-  implicit class ImplicitTextRendererOps (val builder: RendererBuilder[_]) extends SyncIOBuilderOps[TreeRenderer.Builder] {
+  implicit class ImplicitTextRendererOps (val builder: RendererBuilder[_]) extends AsyncIOBuilderOps[TreeRenderer.Builder] {
 
-    protected def build[F[_]: Sync: Batch]: TreeRenderer.Builder[F] =
+    protected def build[F[_]: Async: Batch]: TreeRenderer.Builder[F] =
       new TreeRenderer.Builder[F](builder.build, Helium.defaults.build.build)
   }
 
-  implicit class ImplicitTextTransformerOps (val builder: TransformerBuilder[_]) extends SyncIOBuilderOps[TreeTransformer.Builder] {
+  implicit class ImplicitTextTransformerOps (val builder: TransformerBuilder[_]) extends AsyncIOBuilderOps[TreeTransformer.Builder] {
 
-    protected def build[F[_]: Sync: Batch]: TreeTransformer.Builder[F] = {
+    protected def build[F[_]: Async: Batch]: TreeTransformer.Builder[F] = {
       val transformer = builder.build
       new TreeTransformer.Builder[F](
         NonEmptyList.of(transformer.parser), transformer.renderer, Helium.defaults.build, Kleisli(Sync[F].pure))

--- a/io/src/main/scala/laika/io/runtime/DirectoryScanner.scala
+++ b/io/src/main/scala/laika/io/runtime/DirectoryScanner.scala
@@ -16,7 +16,7 @@
 
 package laika.io.runtime
 
-import java.nio.file.{Files, Path => JPath}
+import java.nio.file.{Path => JPath}
 
 import cats.effect.{Resource, Sync}
 import cats.implicits._
@@ -24,7 +24,9 @@ import laika.ast.DocumentType.Static
 import laika.ast.{Path, TextDocumentType}
 import laika.collection.TransitionalCollectionOps.JIteratorWrapper
 import laika.io.model._
-
+import cats.effect.kernel.Async
+import fs2._
+import fs2.io.file.{Files,Path=>FPath}
 /** Scans a directory in the file system and transforms it into a generic InputCollection
   * that can serve as input for parallel parsers or transformers.
   * 
@@ -34,36 +36,35 @@ object DirectoryScanner {
 
   /** Scans the specified directory passing all child paths to the given function.
     */
-  def scanDirectory[F[_]: Sync, A] (directory: JPath)(f: Seq[JPath] => F[A]): F[A] =
-    Resource
-      .fromAutoCloseable(Sync[F].delay(Files.newDirectoryStream(directory)))
-      .use(str => f(JIteratorWrapper(str.iterator).toSeq))
-  
+  def scanDirectory[F[_]: Async, A] (directory: JPath)(f: Seq[JPath] => F[A]): F[A] = io.file.Files[F].list(FPath.fromNioPath(directory)).compile.toList.flatMap(p => f(p.map(_.toNioPath)) )
   /** Scans the specified directory and transforms it into a generic InputCollection.
     */
-  def scanDirectories[F[_]: Sync] (input: DirectoryInput): F[InputTree[F]] = {
+  def scanDirectories[F[_]: Async] (input: DirectoryInput): F[InputTree[F]] = {
     val sourcePaths: Seq[String] = input.directories map (_.getAbsolutePath)
     join(input.directories.map(d => scanDirectory[F, InputTree[F]](d.toPath)(asInputCollection(input.mountPoint, input))))
       .map(_.copy(sourcePaths = sourcePaths))
   }
   
-  private def join[F[_]: Sync] (collections: Seq[F[InputTree[F]]]): F[InputTree[F]] = collections
-    .toVector
-    .sequence
-    .map(_.reduceLeftOption(_ ++ _).getOrElse(InputTree.empty))
-
-  private def asInputCollection[F[_]: Sync] (path: Path, input: DirectoryInput)(entries: Seq[JPath]): F[InputTree[F]] = {
+  private def join[F[_]: Sync] (collections: Seq[F[InputTree[F]]]): F[InputTree[F]] = 
+    collections.toList.foldM(InputTree.empty[F]){
+    case (a,fa) => fa.map(a ++ _)
+  }
+  private def asInputCollection[F[_]: Async] (path: Path, input: DirectoryInput)(entries: Seq[JPath]): F[InputTree[F]] = {
 
     def toCollection (filePath: JPath): F[InputTree[F]] = {
 
       val childPath = path / filePath.getFileName.toString
-
-      if (input.fileFilter(filePath.toFile)) InputTree.empty[F].pure[F]
-      else if (Files.isDirectory(filePath)) scanDirectory(filePath)(asInputCollection(childPath, input))
-      else input.docTypeMatcher(childPath) match {
-        case docType: TextDocumentType => InputTree[F](Seq(TextInput.fromFile(childPath, docType, filePath.toFile, input.codec)), Nil, Nil).pure[F]
-        case Static(formats)           => InputTree[F](Nil, Seq(BinaryInput.fromFile(childPath, filePath.toFile, formats)), Nil).pure[F]
-        case _                         => InputTree.empty[F].pure[F]
+      if(input.fileFilter(filePath.toFile)) {
+        InputTree.empty[F].pure[F]
+      }else {
+        Files[F].isDirectory(FPath.fromNioPath(filePath)).ifM(
+          scanDirectory(filePath)(asInputCollection(childPath,input)),
+          input.docTypeMatcher(childPath) match {
+            case docType: TextDocumentType => InputTree[F](Seq(TextInput.fromFile(childPath, docType, filePath.toFile, input.codec)), Nil, Nil).pure[F]
+            case Static(formats)           => InputTree[F](Nil, Seq(BinaryInput.fromFile(childPath, filePath.toFile, formats)), Nil).pure[F]
+            case _                         => InputTree.empty[F].pure[F]
+          }
+        )
       }
     }
 

--- a/io/src/main/scala/laika/io/runtime/ParserRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/ParserRuntime.scala
@@ -32,6 +32,7 @@ import laika.io.config.IncludeHandler.RequestedInclude
 import laika.io.model.{InputTree, ParsedTree, TextInput}
 import laika.parse.hocon.{IncludeFile, IncludeResource, ValidStringValue}
 import laika.parse.markup.DocumentParser.{InvalidDocuments, ParserError, DocumentInput}
+import cats.effect.kernel.Async
 
 /** Internal runtime for parser operations, for parallel and sequential execution. 
   * 
@@ -41,7 +42,7 @@ object ParserRuntime {
   
   /** Run the specified parser operation for an entire input tree, producing an AST tree.
     */
-  def run[F[_]: Sync: Batch] (op: TreeParser.Op[F]): F[ParsedTree[F]] = {
+  def run[F[_]: Async: Batch] (op: TreeParser.Op[F]): F[ParsedTree[F]] = {
     
     import DocumentType.{Config => ConfigType, _}
     import TreeResultBuilder._

--- a/io/src/main/scala/laika/io/runtime/TransformerRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/TransformerRuntime.scala
@@ -48,7 +48,7 @@ object TransformerRuntime {
 
   /** Process the specified transform operation for an entire input tree and a character output format.
     */
-  def run[F[_]: Sync: Batch] (op: TreeTransformer.Op[F]): F[RenderedTreeRoot[F]] = for {
+  def run[F[_]: Async: Batch] (op: TreeTransformer.Op[F]): F[RenderedTreeRoot[F]] = for {
     tree       <- TreeParser.Op(op.parsers, op.theme, op.input.withFileFilter(fileFilterFor(op.output))).parse
     mappedTree <- op.mapper.run(tree)
     res        <- TreeRenderer.Op(op.renderer, themeWithoutInputs(op.theme), mappedTree.root, op.output, mappedTree.staticDocuments).render

--- a/io/src/main/scala/laika/io/runtime/VersionedLinkTargets.scala
+++ b/io/src/main/scala/laika/io/runtime/VersionedLinkTargets.scala
@@ -30,10 +30,11 @@ import laika.rewrite.{VersionScannerConfig, Versions}
 
 import java.io.File
 import scala.io.Codec
+import cats.effect.kernel.Async
 
 private[runtime] object VersionedLinkTargets {
 
-  private def scanTargetDirectory[F[_]: Sync] (versions: Versions, config: VersionScannerConfig): F[Map[String, Seq[Path]]] = {
+  private def scanTargetDirectory[F[_]: Async] (versions: Versions, config: VersionScannerConfig): F[Map[String, Seq[Path]]] = {
     val existingVersions = (versions.newerVersions ++ versions.olderVersions).map(_.pathSegment).toSet
     val excluded = config.exclude.flatMap { exclude =>
       existingVersions.toSeq.map(v => Root / v / exclude.relative)
@@ -86,7 +87,7 @@ private[runtime] object VersionedLinkTargets {
       }
   }
   
-  def gatherTargets[F[_]: Sync] (versions: Versions, staticDocs: Seq[BinaryInput[F]]): F[Map[String, Seq[Path]]] =
+  def gatherTargets[F[_]: Async] (versions: Versions, staticDocs: Seq[BinaryInput[F]]): F[Map[String, Seq[Path]]] =
     (staticDocs.find(_.path == VersionInfoGenerator.path), versions.scannerConfig) match {
       case (Some(info), _)   => loadVersionInfo(info)
       case (_, Some(config)) => scanTargetDirectory(versions, config)

--- a/io/src/main/scala/laika/theme/Theme.scala
+++ b/io/src/main/scala/laika/theme/Theme.scala
@@ -22,6 +22,7 @@ import laika.bundle.ExtensionBundle
 import laika.factory.Format
 import laika.io.model.{InputTree, ParsedTree}
 import laika.theme.Theme.TreeProcessor
+import cats.effect.kernel.Async
 
 /** A theme is a way of pre-populating the input tree with a set of templates, styles and configurations
   * to achieve a particular look & feel without the need for the user to craft their own templates, 
@@ -86,7 +87,7 @@ object Theme {
     * right into the input directories.
     */
   def empty: ThemeProvider = new ThemeProvider {
-    def build[F[_]: Sync] = ThemeBuilder("Empty Theme").build
+    def build[F[_]: Async] = ThemeBuilder("Empty Theme").build
   }
 
 }

--- a/io/src/main/scala/laika/theme/ThemeBuilder.scala
+++ b/io/src/main/scala/laika/theme/ThemeBuilder.scala
@@ -28,6 +28,7 @@ import laika.factory.Format
 import laika.io.model.{InputTree, InputTreeBuilder, ParsedTree}
 import laika.theme.Theme.TreeProcessor
 import laika.theme.ThemeBuilder.BundleBuilder
+import cats.effect.kernel.Async
 
 /** Builder API for constructing `Theme` instances, providing several shortcuts for defining the contents
   * of a theme. 
@@ -170,7 +171,7 @@ object ThemeBuilder {
     * The theme name is used in logging or the data returned by the `describe` method of the parser,
     * renderer and transformer APIs.
     */
-  def apply[F[_] : Sync] (themeName: String): ThemeBuilder[F] = 
+  def apply[F[_] : Async] (themeName: String): ThemeBuilder[F] = 
     new ThemeBuilder[F](themeName, Sync[F].pure(InputTree[F]), Nil, BundleBuilder(themeName), Nil)
 
 }

--- a/io/src/main/scala/laika/theme/ThemeProvider.scala
+++ b/io/src/main/scala/laika/theme/ThemeProvider.scala
@@ -17,6 +17,7 @@
 package laika.theme
 
 import cats.effect.{Resource, Sync}
+import cats.effect.kernel.Async
 
 /** Responsible for building a theme resource with the user-provided effect type and runtime configuration.
   * 
@@ -34,6 +35,6 @@ trait ThemeProvider {
     * For convenience, implementations of this method usually utilize a [[laika.theme.ThemeBuilder]] to construct
     * `Theme` instances, but this is not mandatory.
     */
-  def build[F[_]: Sync]: Resource[F, Theme[F]]
+  def build[F[_]: Async]: Resource[F, Theme[F]]
   
 }

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -45,6 +45,7 @@ import laika.rewrite.nav.TargetFormats
 import munit.CatsEffectSuite
 
 import scala.io.Codec
+import cats.effect.kernel.Async
 
 class TreeRendererSpec extends CatsEffectSuite 
   with ParagraphCompanionShortcuts
@@ -357,7 +358,7 @@ class TreeRendererSpec extends CatsEffectSuite
       TemplateContextReference(CursorKeys.documentContent, required = true, GeneratedSource)
     )
     val inputs = new TestThemeBuilder.Inputs {
-      def build[F[_]: Sync] = InputTree[F]
+      def build[F[_]: Async] = InputTree[F]
         .addTemplate(TemplateDocument(DefaultTemplatePath.forHTML, template))
     }
     val renderer = Renderer.of(HTML)
@@ -425,7 +426,7 @@ class TreeRendererSpec extends CatsEffectSuite
       TemplateContextReference(CursorKeys.documentContent, required = true, GeneratedSource)
     )
     val inputs = new TestThemeBuilder.Inputs {
-      def build[F[_]: Sync] = InputTree[F]
+      def build[F[_]: Async] = InputTree[F]
         .addTemplate(TemplateDocument(DefaultTemplatePath.forEPUB, template))
     }
     val renderer = 
@@ -468,7 +469,7 @@ class TreeRendererSpec extends CatsEffectSuite
     import FORenderer._
     
     val inputs = new TestThemeBuilder.Inputs {
-      def build[F[_]: Sync] = InputTree[F]
+      def build[F[_]: Async] = InputTree[F]
         .addStyles(customThemeStyles, FOStyles.defaultPath)
         .addTemplate(TemplateDocument(DefaultTemplatePath.forFO, TestTheme.foTemplate))
     }
@@ -533,7 +534,7 @@ class TreeRendererSpec extends CatsEffectSuite
     val treeRoot = DocumentTreeRoot(input, staticDocuments = Seq(StaticDocument(Inputs.staticDoc(1).path)))
 
     val inputs = new TestThemeBuilder.Inputs {
-      def build[F[_] : Sync] = InputTree[F].addString("...", Root / "static1.txt")
+      def build[F[_] : Async] = InputTree[F].addString("...", Root / "static1.txt")
     }
     val theme = TestThemeBuilder.forInputs(inputs)
     Renderer

--- a/io/src/test/scala/laika/io/helper/TestThemeBuilder.scala
+++ b/io/src/test/scala/laika/io/helper/TestThemeBuilder.scala
@@ -22,34 +22,35 @@ import laika.bundle.ExtensionBundle
 import laika.factory.Format
 import laika.io.model.InputTreeBuilder
 import laika.theme.{ThemeBuilder, ThemeProvider, TreeProcessorBuilder}
+import cats.effect.kernel.Async
 
 
 object TestThemeBuilder {
   
   trait Inputs {
-    def build[F[_]: Sync]: InputTreeBuilder[F]
+    def build[F[_]: Async]: InputTreeBuilder[F]
   }
   
   def forInputs (themeInputs: Inputs): ThemeProvider = new ThemeProvider {
-    def build[F[_]: Sync] = ThemeBuilder("test").addInputs(themeInputs.build).build
+    def build[F[_]: Async] = ThemeBuilder("test").addInputs(themeInputs.build).build
   }
 
   def forBundle (bundle: ExtensionBundle): ThemeProvider = new ThemeProvider {
-    def build[F[_]: Sync] = ThemeBuilder("test").addExtensions(bundle).build
+    def build[F[_]: Async] = ThemeBuilder("test").addExtensions(bundle).build
   }
 
   def forBundles (bundles: Seq[ExtensionBundle]): ThemeProvider = new ThemeProvider {
-    def build[F[_]: Sync] = ThemeBuilder("test").addExtensions(bundles:_*).build
+    def build[F[_]: Async] = ThemeBuilder("test").addExtensions(bundles:_*).build
   }
   
   def forDocumentMapper (f: Document => Document): ThemeProvider = new ThemeProvider {
-    def build[F[_]: Sync] = ThemeBuilder("test")
+    def build[F[_]: Async] = ThemeBuilder("test")
       .processTree { case _ => TreeProcessorBuilder[F].mapDocuments(f) }
       .build
   }
 
   def forDocumentMapper (format: Format)(f: Document => Document): ThemeProvider = new ThemeProvider {
-    def build[F[_]: Sync] = {
+    def build[F[_]: Async] = {
       ThemeBuilder("test")
         .processTree(TreeProcessorBuilder[F].mapDocuments(f), format)
         .build

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,6 +15,7 @@ object Dependencies {
     val munitCE3   = "1.0.5"
     val jTidy      = "r938"
     val fop        = "2.6"
+    val fs2 = "3.2.5"
   }
 
 }


### PR DESCRIPTION
Hello.

In this PR, I replaced java.io stuffs with fs2.io.Files and fs2.io.Path.

I tried to keep signature as possible except for Sync/Async, but I think some API changes are needed. 

It makes sense to use fs2 library for io module despite additional dependencies because fs2 helps cross platform io operations as mentioned in #231. It will be great if laika-io runs on js too.


