### PR TITLE
Switch to Ember server

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ val munitCE3   = "org.typelevel"          %% "munit-cats-effect-3" % versions.mu
 val fop        = "org.apache.xmlgraphics" %  "fop"         % versions.fop
 val http4s     = Seq(
                    "org.http4s"           %% "http4s-dsl"          % versions.http4s,
-                   "org.http4s"           %% "http4s-blaze-server" % versions.http4s
+                   "org.http4s"           %% "http4s-ember-server" % versions.http4s
                  )
 
 lazy val root = project.in(file("."))

--- a/demo/jvm/src/main/scala/laika/webtool/Main.scala
+++ b/demo/jvm/src/main/scala/laika/webtool/Main.scala
@@ -18,9 +18,10 @@ package laika.webtool
 
 import cats.effect.{ExitCode, IO, IOApp, Resource}
 import cats.implicits._
+import com.comcast.ip4s._
 import org.http4s.implicits._
 import org.http4s.server.Server
-import org.http4s.blaze.server.BlazeServerBuilder
+import org.http4s.ember.server.EmberServerBuilder
 
 /**
   * @author Jens Halm
@@ -34,11 +35,9 @@ object Main extends IOApp {
     app.use(_ => IO.never).as(ExitCode.Success)
 
   val app: Resource[IO, Server] =
-    for {
-      ctx    <- Resource.eval(IO.executionContext)
-      server <- BlazeServerBuilder[IO](ctx)
-        .bindHttp(8080, "0.0.0.0")
-        .withHttpApp(service)
-        .resource
-    } yield server
+    EmberServerBuilder.default[IO]
+      .withHost(host"0.0.0.0")
+      .withPort(port"8080")
+      .withHttpApp(service)
+      .build
 }

--- a/preview/src/main/scala/laika/preview/ServerBuilder.scala
+++ b/preview/src/main/scala/laika/preview/ServerBuilder.scala
@@ -21,6 +21,7 @@ import java.io.{File, PrintWriter, StringWriter}
 import cats.data.{Kleisli, OptionT}
 import cats.effect._
 import cats.syntax.all._
+import com.comcast.ip4s._
 import fs2.concurrent.Topic
 import laika.ast
 import laika.ast.DocumentType
@@ -32,7 +33,7 @@ import org.http4s.dsl.Http4sDsl
 import org.http4s.{HttpApp, HttpRoutes, Request}
 import org.http4s.implicits._
 import org.http4s.server.{Router, Server}
-import org.http4s.blaze.server.BlazeServerBuilder
+import org.http4s.ember.server.EmberServerBuilder
 
 import scala.concurrent.duration._
 
@@ -80,10 +81,11 @@ class ServerBuilder[F[_]: Async] (parser: Resource[F, TreeParser[F]],
   }
     
   private def createServer (httpApp: HttpApp[F]): Resource[F, Server] =
-    BlazeServerBuilder[F]
-      .bindHttp(config.port, config.host)
+    EmberServerBuilder.default[F]
+      .withPort(config.port)
+      .withHost(config.host)
       .withHttpApp(httpApp)
-      .resource
+      .build
   
   private def binaryRenderFormats =
     List(EPUB).filter(_ => config.includeEPUB) ++
@@ -131,8 +133,8 @@ object ServerBuilder {
   * @param isVerbose whether each served page and each detected file change should be logged (default false)
   * @param apiDir an optional API directory from which API documentation should be served (default None)
   */
-class ServerConfig private (val port: Int,
-                            val host:String,
+class ServerConfig private (val port: Port,
+                            val host:Host,
                             val pollInterval: FiniteDuration,
                             val artifactBasename: String,
                             val includeEPUB: Boolean,
@@ -140,8 +142,8 @@ class ServerConfig private (val port: Int,
                             val isVerbose: Boolean,
                             val apiDir: Option[File]) {
 
-  private def copy (newPort: Int = port,
-                    newHost: String = host,
+  private def copy (newPort: Port = port,
+                    newHost: Host = host,
                     newPollInterval: FiniteDuration = pollInterval,
                     newArtifactBasename: String = artifactBasename,
                     newIncludeEPUB: Boolean = includeEPUB,
@@ -152,11 +154,11 @@ class ServerConfig private (val port: Int,
 
   /** Specifies the port the server should run on (default 4242).
     */
-  def withPort (port: Int): ServerConfig = copy(newPort = port)
+  def withPort (port: Port): ServerConfig = copy(newPort = port)
 
   /** Specifies the host the server should run on (default localhost).
   */
-  def withHost(host:String):ServerConfig = copy(newHost = host)
+  def withHost(host:Host):ServerConfig = copy(newHost = host)
 
   /** Specifies the interval at which input file resources are polled for changes (default 1 second).
     */
@@ -190,9 +192,9 @@ class ServerConfig private (val port: Int,
   */
 object ServerConfig {
 
-  val defaultPort: Int = 4242
+  val defaultPort: Port = port"4242"
 
-  val defaultHost:String = "localhost"
+  val defaultHost:Host = host"localhost"
 
   val defaultPollInterval: FiniteDuration = 1.second
 

--- a/sbt/src/main/scala/laika/sbt/LaikaPreviewConfig.scala
+++ b/sbt/src/main/scala/laika/sbt/LaikaPreviewConfig.scala
@@ -16,6 +16,7 @@
 
 package laika.sbt
 
+import com.comcast.ip4s._
 import laika.preview.ServerConfig
 
 import scala.concurrent.duration.FiniteDuration
@@ -26,22 +27,22 @@ import scala.concurrent.duration.FiniteDuration
   * @param pollInterval the interval at which input file resources are polled for changes (default 3 seconds)
   * @param isVerbose whether each served page and each detected file change should be logged (default false)
   */
-class LaikaPreviewConfig (val port: Int,
-                          val host:String,
+class LaikaPreviewConfig (val port: Port,
+                          val host:Host,
                           val pollInterval: FiniteDuration,
                           val isVerbose: Boolean) {
 
-  private def copy (newPort: Int = port,
-                    newHost:String = host,
+  private def copy (newPort: Port = port,
+                    newHost:Host = host,
                     newPollInterval: FiniteDuration = pollInterval,
                     newVerbose: Boolean = isVerbose): LaikaPreviewConfig =
     new LaikaPreviewConfig(newPort, newHost,newPollInterval, newVerbose)
   
   /** Specifies the port the server should run on (default 4242).
     */
-  def withPort (port: Int): LaikaPreviewConfig = copy(newPort = port)
+  def withPort (port: Port): LaikaPreviewConfig = copy(newPort = port)
 
-  def withHost(host:String):LaikaPreviewConfig = copy(newHost = host)
+  def withHost(host:Host):LaikaPreviewConfig = copy(newHost = host)
 
   /** Specifies the interval at which input file resources are polled for changes (default 3 seconds).
     */


### PR DESCRIPTION
As discussed in https://github.com/planet42/Laika/issues/259.

The switch to ember is straightforward. `ServerSentEvent` is a core feature of http4s, not specific to blaze/ember backend.

Most of the changes here are replacing `Int`/`String` for port/host with specialized types from [ip4s](https://github.com/Comcast/ip4s). This isn't necessary, though: you can keep `Int`/`String` in the public APIs and convert internally instead.