### PR TITLE
variable substitutions: support output paths in addition to source paths

### DIFF
--- a/core/shared/src/main/scala/laika/directive/std/StandardDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/StandardDirectives.scala
@@ -66,7 +66,7 @@ import scala.collection.immutable.TreeSet
   * 
   * - `linkCSS`: Adds link elements to HTML/EPUB output for all or selected CSS files found in the document tree
   * - `linkJS`: Adds link elements to HTML/EPUB output for all or selected JavaScript files found in the document tree
-  * - `relativePath`: Translates an absolute or relative path from the perspective of a template
+  * - `path`: Translates an absolute or relative path from the perspective of a template
   *   to a path relative to the document the template had been applied to
   * 
   * '''Conditionals and Loops'''

--- a/core/shared/src/main/scala/laika/rewrite/ReferenceResolver.scala
+++ b/core/shared/src/main/scala/laika/rewrite/ReferenceResolver.scala
@@ -18,7 +18,7 @@ package laika.rewrite
 
 import laika.config.Config.ConfigResult
 import laika.config.{ASTValue, Config, ConfigBuilder, ConfigValue, Field, Key, ObjectValue, StringValue}
-import laika.ast.{Document, DocumentTree, Path, SpanSequence, TreeCursor, TreePosition}
+import laika.ast.{Document, DocumentTree, Path, RawLink, SpanSequence, TreeCursor, TreePosition}
 
 /** A resolver for context references in templates or markup documents.
  *  
@@ -63,7 +63,8 @@ object ReferenceResolver {
     val baseBuilder = ConfigBuilder
       .withFallback(config)
       .withValue(rootKey.child("currentDocument"), ObjectValue(Seq(
-        Field("path", StringValue(document.path.toString)),
+        Field("path", StringValue(document.path.toString)), // deprecated since 0.19.0
+        Field("sourcePath", StringValue(document.path.toString)),
         Field("content", ASTValue(document.content), config.origin),
         Field("title", ASTValue(document.title.getOrElse(emptyTitle)), config.origin),
         Field("fragments", ObjectValue(document.fragments.toSeq.map {
@@ -88,9 +89,12 @@ object ReferenceResolver {
 
     def addDocConfig (key: Key, doc: Option[Document])(builder: ConfigBuilder): ConfigBuilder =
       doc.fold(builder) { doc =>
+        val sourcePath = StringValue(doc.path.toString)
         builder.withValue(key, ObjectValue(Seq(
-          Field("absolutePath", StringValue(doc.path.toString)),
-          Field("relativePath", StringValue(doc.path.relativeTo(document.path).toString)),
+          Field("path", ASTValue(RawLink.internal(doc.path))),
+          Field("sourcePath", sourcePath),
+          Field("absolutePath", sourcePath), // deprecated since 0.19.0
+          Field("relativePath", StringValue(doc.path.relativeTo(document.path).toString)), // deprecated since 0.19.0
           Field("title", ASTValue(doc.title.getOrElse(emptyTitle)))
         )))
       }

--- a/core/shared/src/test/scala/laika/ast/DocumentTreeAPISpec.scala
+++ b/core/shared/src/test/scala/laika/ast/DocumentTreeAPISpec.scala
@@ -237,39 +237,67 @@ class DocumentTreeAPISpec extends FunSuite
     )
   }
   
-  test("resolve a substitution reference to the previous document") { 
-    val cursor = leafDocCursor(Some("cursor.previousDocument.relativePath"))
+  test("resolve a substitution reference to the source path of the previous document") { 
+    val cursor = leafDocCursor(Some("cursor.previousDocument.sourcePath"))
     assertEquals(
       cursor.flatMap(c => c.target.rewrite(TemplateRewriter.rewriteRules(c)).map(_.content)),
-      Right(RootElement(p("doc-5")))
+      Right(RootElement(p("/tree-2/doc-5")))
+    )
+  }
+
+  test("resolve a substitution reference to the output path of the previous document") {
+    val cursor = leafDocCursor(Some("cursor.previousDocument.path"))
+    assertEquals(
+      cursor.flatMap(c => c.target.rewrite(TemplateRewriter.rewriteRules(c)).map(_.content)),
+      Right(RootElement(RawLink.internal(Root / "tree-2" / "doc-5")))
     )
   }
 
   test("be empty for the next document in the final leaf node of the tree") { 
-    val cursor = leafDocCursor(Some("cursor.nextDocument.relativePath"))
+    val cursor = leafDocCursor(Some("cursor.nextDocument.path"))
     assertEquals(
       cursor.flatMap(c => c.target.rewrite(TemplateRewriter.rewriteRules(c)).map(_.content)),
       Right(RootElement(p("")))
     )
   }
 
-  test("resolve a substitution reference to the parent document") { 
-    val cursor = leafDocCursor(Some("cursor.parentDocument.relativePath"))
+  test("resolve a substitution reference to the source path of the parent document") { 
+    val cursor = leafDocCursor(Some("cursor.parentDocument.sourcePath"))
     assertEquals(
       cursor.flatMap(c => c.target.rewrite(TemplateRewriter.rewriteRules(c)).map(_.content)),
-      Right(RootElement(p("README")))
+      Right(RootElement(p("/tree-2/README")))
     )
   }
 
-  test("resolve a substitution reference to the previous document in a flattened view") { 
-    val cursor = leafDocCursor(Some("cursor.flattenedSiblings.previousDocument.relativePath")).map(_
+  test("resolve a substitution reference to the output path of the parent document") {
+    val cursor = leafDocCursor(Some("cursor.parentDocument.path"))
+    assertEquals(
+      cursor.flatMap(c => c.target.rewrite(TemplateRewriter.rewriteRules(c)).map(_.content)),
+      Right(RootElement(RawLink.internal(Root / "tree-2" / "README")))
+    )
+  }
+
+  test("resolve a substitution reference to the source path of the previous document in a flattened view") { 
+    val cursor = leafDocCursor(Some("cursor.flattenedSiblings.previousDocument.sourcePath")).map(_
       .flattenedSiblings.previousDocument
       .flatMap(_.flattenedSiblings.previousDocument)
       .get
     )
     assertEquals(
       cursor.flatMap(c => c.target.rewrite(TemplateRewriter.rewriteRules(c)).map(_.content)),
-      Right(RootElement(p("../tree-1/doc-4")))
+      Right(RootElement(p("/tree-1/doc-4")))
+    )
+  }
+
+  test("resolve a substitution reference to the output path of the previous document in a flattened view") {
+    val cursor = leafDocCursor(Some("cursor.flattenedSiblings.previousDocument.path")).map(_
+      .flattenedSiblings.previousDocument
+      .flatMap(_.flattenedSiblings.previousDocument)
+      .get
+    )
+    assertEquals(
+      cursor.flatMap(c => c.target.rewrite(TemplateRewriter.rewriteRules(c)).map(_.content)),
+      Right(RootElement(RawLink.internal(Root / "tree-1" / "doc-4")))
     )
   }
   

--- a/docs/src/07-reference/02-substitution-variables.md
+++ b/docs/src/07-reference/02-substitution-variables.md
@@ -66,7 +66,9 @@ This is a complete list of values exposed in the `cursor` namespace:
 
     * `title`: the AST of the title of this document - including formatting.
 
-    * `path`: the absolute (virtual) path of the document inside the input tree.
+    * `sourcePath`: the absolute (virtual) path of the document in the input tree.
+
+    * `path` (deprecated since 0.19.0): use `sourcePath`.
     
 * Access to surrounding documents via `cursor.parentDocument`, `cursor.previousDocument`, `cursor.nextDocument`,
   `cursor.flattenedSiblings.previousDocument` and `cursor.flattenedSiblings.nextDocument`.
@@ -80,10 +82,14 @@ This is a complete list of values exposed in the `cursor` namespace:
   Sub-keys of these document pointers are:
   
     * `title`: the AST of the title of the document - including formatting.
+
+    * `path`: the path of the document in the generated output, e.g. `../herbs/parsley.html`.
+
+    * `sourcePath`: the absolute (virtual) path of the document in the input tree, e.g. `/herbs/parsley.md`.
     
-    * `absolutePath`: the absolute path in the virtual input tree as a string, e.g. `/herbs/parsley.md`.
+    * `absolutePath` (deprecated since 0.19.0): use `sourcePath`.
     
-    * `relativePath`: the path relative to this document as a string, e.g. `../parsley.md`.
+    * `relativePath` (deprecated since 0.19.0): use `sourcePath`.
     
 * `root.title`: The title of the root node, usually the title of the website or e-book.
     


### PR DESCRIPTION
The following variable substitutions only point to the source paths, even though in templating the most common need would be to point to the output path:

* `cursor.parentDocument.relativePath/absolutePath`
* `cursor.previousDocument.relativePath/absolutePath`
* `cursor.nextDocument.relativePath/absolutePath`
* `cursor.flattenedSiblings.previousDocument.relativePath/absolutePath`
* `cursor.flattenedSiblings.nextDocument.relativePath/absolutePath`

This PR deprecates the existing variable name segments `relativePath` and `absolutePath` in favour of the new path segments:

* `sourcePath`: equivalent to the old `absolutePath` and still pointing to the path of the input document, but with a new name that better distinguishes it from the new `path` segment.
* `path`: Pointing to the path of the corresponding output document, so that it can be used to create links in templates.

This addresses the underlying issue reported in #245.