### PR TITLE
add new @:target directive as a replacement for the old @:path directive

### DIFF
--- a/core/jvm/src/test/resources/markdownTestSuite/Links, inline style.md
+++ b/core/jvm/src/test/resources/markdownTestSuite/Links, inline style.md
@@ -1,12 +1,12 @@
-Just a [URL](/url/).
+Just a [URL](ext:/url/).
 
-[URL and title](/url/ "title").
+[URL and title](ext:/url/ "title").
 
-[URL and title](/url/  "title preceded by two spaces").
+[URL and title](ext:/url/  "title preceded by two spaces").
 
-[URL and title](/url/	"title preceded by a tab").
+[URL and title](ext:/url/	"title preceded by a tab").
 
-[URL and title](/url/ "title has spaces afterward"  ).
+[URL and title](ext:/url/ "title has spaces afterward"  ).
 
 
 [Empty]().

--- a/core/jvm/src/test/resources/markdownTestSuite/Links, reference style.md
+++ b/core/jvm/src/test/resources/markdownTestSuite/Links, reference style.md
@@ -5,7 +5,7 @@ Foo [bar][1].
 Foo [bar]
 [1].
 
-[1]: /url/  "Title"
+[1]: ext:/url/  "Title"
 
 
 With [embedded [brackets]] [b].
@@ -19,16 +19,16 @@ Indented [thrice][].
 
 Indented [four][] times.
 
- [once]: /url
+ [once]: ext:/url
 
-  [twice]: /url
+  [twice]: ext:/url
 
-   [thrice]: /url
+   [thrice]: ext:/url
 
     [four]: /url
 
 
-[b]: /url/
+[b]: ext:/url/
 
 * * *
 
@@ -52,11 +52,11 @@ Nor [that].
 
 [Same with [this].]
 
-In this case, [this](/somethingelse/) points to something else.
+In this case, [this](ext:/somethingelse/) points to something else.
 
 Backslashing should suppress \[this] and [this\].
 
-[this]: /foo
+[this]: ext:/foo
 
 
 * * *
@@ -68,4 +68,4 @@ Here's another where the [link
 breaks] across lines, but with a line-ending space.
 
 
-[link breaks]: /url/
+[link breaks]: ext:/url/

--- a/core/jvm/src/test/resources/markdownTestSuite/Links, shortcut references.md
+++ b/core/jvm/src/test/resources/markdownTestSuite/Links, shortcut references.md
@@ -1,6 +1,6 @@
 This is the [simple case].
 
-[simple case]: /simple
+[simple case]: ext:/simple
 
 
 
@@ -10,11 +10,11 @@ break].
 This one has a [line 
 break] with a line-ending space.
 
-[line break]: /foo
+[line break]: ext:/foo
 
 
 [this] [that] and the [other]
 
-[this]: /this
-[that]: /that
-[other]: /other
+[this]: ext:/this
+[that]: ext:/that
+[other]: ext:/other

--- a/core/jvm/src/test/resources/markdownTestSuite/Literal quotes in titles.md
+++ b/core/jvm/src/test/resources/markdownTestSuite/Literal quotes in titles.md
@@ -1,7 +1,7 @@
 Foo [bar][].
 
-Foo [bar](/url/ "Title with "quotes" inside").
+Foo [bar](ext:/url/ "Title with "quotes" inside").
 
 
-  [bar]: /url/ "Title with "quotes" inside"
+  [bar]: ext:/url/ "Title with "quotes" inside"
 

--- a/core/jvm/src/test/resources/markdownTestSuite/Markdown Documentation - Basics.md
+++ b/core/jvm/src/test/resources/markdownTestSuite/Markdown Documentation - Basics.md
@@ -27,9 +27,9 @@ and translate it to XHTML.
 **Note:** This document is itself written using Markdown; you
 can [see the source for it by adding '.text' to the URL] [src].
 
-  [s]: /projects/markdown/syntax  "Markdown Syntax"
-  [d]: /projects/markdown/dingus  "Markdown Dingus"
-  [src]: /projects/markdown/basics.text
+  [s]: ext:/projects/markdown/syntax  "Markdown Syntax"
+  [d]: ext:/projects/markdown/dingus  "Markdown Dingus"
+  [src]: ext:/projects/markdown/basics.text
 
 
 ## Paragraphs, Headers, Blockquotes ##

--- a/core/jvm/src/test/resources/markdownTestSuite/Markdown Documentation - Syntax.md
+++ b/core/jvm/src/test/resources/markdownTestSuite/Markdown Documentation - Syntax.md
@@ -34,7 +34,7 @@ Markdown: Syntax
 **Note:** This document is itself written using Markdown; you
 can [see the source for it by adding '.text' to the URL][src].
 
-  [src]: /projects/markdown/syntax.text
+  [src]: ext:/projects/markdown/syntax.text
 
 * * *
 

--- a/core/jvm/src/test/scala/laika/markdown/MarkdownToHTMLSpec.scala
+++ b/core/jvm/src/test/scala/laika/markdown/MarkdownToHTMLSpec.scala
@@ -17,7 +17,7 @@
 package laika.markdown
 
 import laika.api.Transformer
-import laika.ast.{ExternalTarget, Header, Id, InvalidSpan, LinkPathReference, Literal, MessageFilter, NoOpt, QuotedBlock, RelativePath, Replace, SpanLink, Target, Text, Title}
+import laika.ast.{ExternalTarget, Header, Id, InvalidSpan, LinkPathReference, Literal, MessageFilter, NoOpt, PathBase, QuotedBlock, RelativePath, Replace, SpanLink, Target, Text, Title}
 import laika.file.FileIO
 import laika.format.{HTML, Markdown}
 import laika.html.TidyHTML
@@ -48,7 +48,7 @@ class MarkdownToHTMLSpec extends FunSuite {
   }
 
   def transformAndCompare (name: String): Unit = {
-    def renderPath(relPath: RelativePath): Target = 
+    def renderPath(relPath: PathBase): Target = 
       if (relPath == RelativePath.CurrentDocument()) ExternalTarget("") else ExternalTarget(relPath.toString)
     val path = FileIO.classPathResourcePath("/markdownTestSuite") + "/" + name
     val input = FileIO.readFile(path + ".md")

--- a/core/shared/src/main/scala/laika/rewrite/link/LinkResolver.scala
+++ b/core/shared/src/main/scala/laika/rewrite/link/LinkResolver.scala
@@ -86,7 +86,7 @@ class LinkResolver (root: DocumentTreeRoot, slugBuilder: String => String) exten
     def resolveLocal (ref: Reference, selector: Selector, msg: => String): RewriteAction[Span] =
       resolveWith(ref, targets.select(cursor.path, selector), msg)
 
-    def resolvePath (ref: Reference, path: RelativePath, msg: => String): RewriteAction[Span] = {
+    def resolvePath (ref: Reference, path: PathBase, msg: => String): RewriteAction[Span] = {
       val selector = PathSelector(InternalTarget(path).relativeTo(cursor.path).absolutePath)
       resolveWith(ref, targets.select(Root, selector), msg)
     }

--- a/core/shared/src/main/scala/laika/rewrite/link/TargetResolver.scala
+++ b/core/shared/src/main/scala/laika/rewrite/link/TargetResolver.scala
@@ -58,11 +58,11 @@ object ReferenceResolver {
     case LinkSource(LinkIdReference (content, _, _, opt), sourcePath) =>
       SpanLink(content, InternalTarget(target).relativeTo(sourcePath), None, opt)
   }
-  def resolveTarget (target: RelativePath, refPath: Path): Target = {
-    /* If an internal target point upwards beyond the virtual root of the processed tree, 
-       it is treated as an external target and does not get validated. */
-    if (target.parentLevels >= refPath.depth) ExternalTarget(target.toString)
-    else InternalTarget(target).relativeTo(refPath)
+  def resolveTarget (target: PathBase, refPath: Path): Target = target match {
+      /* If an internal target point upwards beyond the virtual root of the processed tree, 
+         it is treated as an external target and does not get validated. */
+    case rp: RelativePath if (rp.parentLevels >= refPath.depth) => ExternalTarget(target.toString)
+    case _ => InternalTarget(target).relativeTo(refPath)
   }
   def resolveTarget (target: Target, refPath: Path): Target = target match {
     case it: RelativeInternalTarget => resolveTarget(it.path, refPath)

--- a/docs/src/07-reference/01-standard-directives.md
+++ b/docs/src/07-reference/01-standard-directives.md
@@ -56,20 +56,32 @@ Serves as a shortcut for creating links to the source code of types, e.g. `@:sou
 See [Linking to Source Code] for details.
 
 
+### `@:target`
+
+Can only be used in templates.
+
+Renders a link target which is specified as the only (required) attribute of this directive.
+
+The attribute can either be a literal target or the key of a config value of type string.
+
+External targets will be rendered unmodified, internal targets will be interpreted as relative to the template,
+validated and then translated. 
+For every document the template is applied to it is resolved as relative to that rendered document.
+
+Example:
+```laika-html
+<link rel="icon" href="@:target(../styles/manual.css)" />
+```
+
+See [Disabling Validation] when you only want the path translation without the validation.
+
+
 ### `@:path`
 
 Can only be used in templates.
 
-Renders a validated path from the virtual input tree which can be absolute or relative. 
-If it is relative, it is interpreted as relative to the template, 
-but when rendering translated for every document the template is applied to as relative to that rendered document.
-
-Example:
-```laika-html
-<link rel="icon" href="@:path(../styles/manual.css)" />
-```
-
-See [Disabling Validation] when you only want to path translation without the validation.
+Deprecated since version 0.19.0 - use the `@:target` directive which is a superset of the functionality
+of the old `@:path` directive which did not support external targets.
 
 
 Inclusions

--- a/docs/src/olderVersions/reduced.template.html
+++ b/docs/src/olderVersions/reduced.template.html
@@ -13,7 +13,7 @@
       <meta name="description" content="${_}"/>
     @:@
     @:for(helium.favIcons)
-      <link rel="icon" @:attribute(sizes, _.sizes) @:attribute(type, _.type) href="@:path(_.target)"/>
+      <link rel="icon" @:attribute(sizes, _.sizes) @:attribute(type, _.type) href="@:target(_.target)"/>
     @:@
     @:for(helium.webFonts)
       <link rel="stylesheet" href="${_}">

--- a/io/src/main/resources/laika/helium/templates/default.template.html
+++ b/io/src/main/resources/laika/helium/templates/default.template.html
@@ -13,7 +13,7 @@
       <meta name="description" content="${_}"/>
     @:@
     @:for(helium.favIcons)
-      <link rel="icon" @:attribute(sizes, _.sizes) @:attribute(type, _.type) href="@:path(_.target)"/>
+      <link rel="icon" @:attribute(sizes, _.sizes) @:attribute(type, _.type) href="@:target(_.target)"/>
     @:@
     @:for(helium.webFonts)
       <link rel="stylesheet" href="${_}">

--- a/io/src/main/resources/laika/helium/templates/landing.template.html
+++ b/io/src/main/resources/laika/helium/templates/landing.template.html
@@ -13,7 +13,7 @@
       <meta name="description" content="${_}"/>
     @:@
     @:for(helium.favIcons)
-      <link rel="icon" @:attribute(sizes, _.sizes) @:attribute(type, _.type) href="@:path(_.target)"/>
+      <link rel="icon" @:attribute(sizes, _.sizes) @:attribute(type, _.type) href="@:target(_.target)"/>
     @:@
     @:for(helium.webFonts)
       <link rel="stylesheet" href="${_}">

--- a/io/src/test/scala/laika/io/TreeParserSpec.scala
+++ b/io/src/test/scala/laika/io/TreeParserSpec.scala
@@ -49,7 +49,7 @@ class TreeParserSpec
 
   
   object Contents {
-    val link = "[link](/foo)"
+    val link = "[link](http://foo.com)"
     val name = "foo"
     val name2 = "bar"
     val multiline: String = 
@@ -331,8 +331,8 @@ class TreeParserSpec
       Root / "static-1" / "omg.js" -> Contents.name,
     )
     
-    val linkResult = Seq(p(SpanLink.external("/foo")("link")))
-    val rstResult = Seq(p("[link](/foo)"))
+    val linkResult = Seq(p(SpanLink.external("http://foo.com")("link")))
+    val rstResult = Seq(p(Text("[link]("), SpanLink.external("http://foo.com")("http://foo.com"), Text(")")))
     
     val expected = SampleTrees.sixDocuments
       .staticDoc(Root / "static-1" / "omg.js", "html")

--- a/io/src/test/scala/laika/io/TreeTransformerSpec.scala
+++ b/io/src/test/scala/laika/io/TreeTransformerSpec.scala
@@ -113,7 +113,7 @@ class TreeTransformerSpec extends CatsEffectSuite
       """.stripMargin
     val aa = "aa"
     val style = "13"
-    val link = "[link](/foo)"
+    val link = "[link](http://foo.com)"
     val directive = "${cursor.currentDocument.content} @:foo(bar) bb"
     val templateConfigRef = "${cursor.currentDocument.content}${value}"
     val template1 = "${cursor.currentDocument.content}"
@@ -436,12 +436,15 @@ class TreeTransformerSpec extends CatsEffectSuite
     val markdown =
       """RootElement - Blocks: 1
         |. Paragraph - Spans: 1
-        |. . SpanLink(ExternalTarget(/foo),None) - Spans: 1
+        |. . SpanLink(ExternalTarget(http://foo.com),None) - Spans: 1
         |. . . Text - 'link'""".stripMargin
     val rst =
       """RootElement - Blocks: 1
-        |. Paragraph - Spans: 1
-        |. . Text - '[link](/foo)'""".stripMargin
+        |. Paragraph - Spans: 3
+        |. . Text - '[link]('
+        |. . SpanLink(ExternalTarget(http://foo.com),None) - Spans: 1
+        |. . . Text - 'http://foo.com'
+        |. . Text - ')'""".stripMargin
         
     transformMixedMarkup(inputs).assertEquals(renderedRoot(
       docs(


### PR DESCRIPTION
The old `@:path` directive did not support external targets, even though a lot of APIs in Laika's internal document AST model external and internal targets transparently behind the `Target` type.

This PR implements a new `@:target` directive that supports all functionality of the existing `@:path` directive, plus external targets which are simply rendered verbatim.

This PR also deprecates the old `@:path` directive, as it is now merely a strict subset of the functionality of the `@:target` directive.

Closes #251 