### PR TITLE
add ThemeProvider.extendWith method

### DIFF
--- a/io/src/main/scala/laika/io/model/Input.scala
+++ b/io/src/main/scala/laika/io/model/Input.scala
@@ -21,7 +21,6 @@ import java.io._
 import cats.Applicative
 import cats.data.Kleisli
 import cats.effect.{Resource, Sync}
-import cats.instances.stream
 import laika.ast.Path.Root
 import laika.ast.{Document, DocumentTreeRoot, DocumentType, Navigatable, Path, StaticDocument, StyleDeclaration, StyleDeclarationSet, TemplateDocument, TextDocumentType}
 import laika.bundle.{DocumentTypeMatcher, Precedence}
@@ -96,7 +95,11 @@ case class InputTree[F[_]](textInputs: Seq[TextInput[F]] = Nil,
     */
   lazy val allPaths: Seq[Path] = textInputs.map(_.path) ++ binaryInputs.map(_.path) ++ parsedResults.map(_.path) 
   
-  /** Merges the inputs of two collections.
+  /** Merges the inputs of two trees recursively.
+    * 
+    * This method does not perform any de-duplication in case both trees contain entries with the same virtual path, 
+    * which would lead to errors when such a tree is used as input for a transformation.
+    * If one tree should take precedence over the other in case of duplicates, use `overrideWith` instead. 
     */
   def ++ (other: InputTree[F]): InputTree[F] = InputTree(
     textInputs ++ other.textInputs, 
@@ -106,10 +109,30 @@ case class InputTree[F[_]](textInputs: Seq[TextInput[F]] = Nil,
     sourcePaths ++ other.sourcePaths
   )
   
+  /** Overrides inputs in this instance with the provided inputs.
+    * 
+    * Merges the inputs of two trees recursively, like the `++` method, but with the main difference
+    * that in case both trees contain an entry with the same virtual path, 
+    * the one in the overriding tree will take precedence and the one in this tree will be removed.
+    */
+  def overrideWith (overrides: InputTree[F]): InputTree[F] = remove(overrides.allPaths.toSet) ++ overrides
+  
   def + (textInput: TextInput[F]): InputTree[F] = copy(textInputs = textInputs :+ textInput)
   def + (binaryInput: BinaryInput[F]): InputTree[F] = copy(binaryInputs = binaryInputs :+ binaryInput)
   def + (parsedResult: ParserResult): InputTree[F] = copy(parsedResults = parsedResults :+ parsedResult)
   def + (providedPath: StaticDocument): InputTree[F] = copy(providedPaths = providedPaths :+ providedPath)
+
+  /** Returns a new input tree with all inputs matching the provided exclusions removed from this tree.
+    */
+  def remove (paths: Set[Path]): InputTree[F] = {
+    InputTree(
+      textInputs    = textInputs.filterNot(in => paths.contains(in.path)),
+      binaryInputs  = binaryInputs.filterNot(in => paths.contains(in.path)),
+      parsedResults = parsedResults.filterNot(in => paths.contains(in.path)),
+      sourcePaths   = sourcePaths
+    )
+  }
+  
 }
 
 /** Factory methods for creating `InputTreeBuilder` instances.

--- a/io/src/main/scala/laika/io/runtime/ParserRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/ParserRuntime.scala
@@ -56,22 +56,10 @@ object ParserRuntime {
         else Sync[F].raiseError(ParserErrors(duplicates.toSet))
       }
 
-      def mergedInputs: InputTree[F] = {
-        // user inputs override theme inputs
-        val userPaths = userInputs.allPaths.toSet
-        val filteredThemeInputs = InputTree(
-          textInputs = themeInputs.textInputs.filterNot(in => userPaths.contains(in.path)),
-          binaryInputs = themeInputs.binaryInputs.filterNot(in => userPaths.contains(in.path)),
-          parsedResults = themeInputs.parsedResults.filterNot(in => userPaths.contains(in.path)),
-          sourcePaths = themeInputs.sourcePaths
-        )
-        userInputs ++ filteredThemeInputs
-      }
-
       for {
         _ <- validateInputPaths(userInputs)
         _ <- validateInputPaths(themeInputs)
-      } yield mergedInputs
+      } yield themeInputs.overrideWith(userInputs)
     }
     
     def parseAll(inputs: InputTree[F]): F[ParsedTree[F]] = {

--- a/io/src/main/scala/laika/theme/ThemeProvider.scala
+++ b/io/src/main/scala/laika/theme/ThemeProvider.scala
@@ -17,6 +17,9 @@
 package laika.theme
 
 import cats.effect.{Resource, Sync}
+import laika.bundle.ExtensionBundle
+import laika.factory.Format
+import laika.io.model.InputTree
 
 /** Responsible for building a theme resource with the user-provided effect type and runtime configuration.
   * 
@@ -27,7 +30,7 @@ import cats.effect.{Resource, Sync}
   * 
   * @author Jens Halm
   */
-trait ThemeProvider {
+trait ThemeProvider { self =>
 
   /** Builds the theme resource with the user-provided effect type and runtime configuration.
     * 
@@ -35,5 +38,32 @@ trait ThemeProvider {
     * `Theme` instances, but this is not mandatory.
     */
   def build[F[_]: Sync]: Resource[F, Theme[F]]
+
+  /** Creates a new theme using this instance as a base and the provided instance as the extension.
+    * 
+    * The exact mechanics of extending a theme vary depending on the type of functionality supported by themes.
+    * They are roughly as follows:
+    * 
+    * - For functionality that is an accumulation of features, for example parser extensions, renderer overrides
+    *   or AST rewrite rules, the effect is accumulative, this theme and the extensions will be merged to a single set
+    *   of features.
+    *   
+    * - For functionality that is provided by unique instances, for example the template engine or the default template,
+    *   the effect is replacement, where the instance in the extension replaces the corresponding instance in the base,
+    *   if present.
+    */
+  def extendWith (extensions: ThemeProvider): ThemeProvider = new ThemeProvider {
+    def build[F[_]: Sync] = for {
+      base <- self.build
+      ext  <- extensions.build
+    } yield {
+      new Theme[F] {
+        override def inputs: InputTree[F] = base.inputs.overrideWith(ext.inputs)
+        override def extensions: Seq[ExtensionBundle] = base.extensions ++ ext.extensions
+        override def treeProcessor: Format => Theme.TreeProcessor[F] = fmt =>
+          base.treeProcessor(fmt).andThen(ext.treeProcessor(fmt))
+      }
+    }
+  }
   
 }

--- a/io/src/test/scala/laika/io/ParserSetup.scala
+++ b/io/src/test/scala/laika/io/ParserSetup.scala
@@ -57,4 +57,11 @@ trait ParserSetup {
       .parallel[IO]
       .withTheme(TestThemeBuilder.forBundle(themeBundle))
       .build
+
+  def parserWithThemeExtension (themeBundle: ExtensionBundle, themeExtBundle: ExtensionBundle): Resource[IO, TreeParser[IO]] =
+    MarkupParser
+      .of(Markdown)
+      .parallel[IO]
+      .withTheme(TestThemeBuilder.forBundle(themeBundle).extendWith(TestThemeBuilder.forBundle(themeExtBundle)))
+      .build
 }

--- a/io/src/test/scala/laika/io/TreeParserSpec.scala
+++ b/io/src/test/scala/laika/io/TreeParserSpec.scala
@@ -508,6 +508,14 @@ class TreeParserSpec
       )
         .use(_.fromInput(input).parse)
         .map(_.root.allDocuments.head.content)
+
+    def parseWithThemeExtension (themeParsers: Seq[SpanParserBuilder] = Nil, themeExtensionParsers: Seq[SpanParserBuilder] = Nil): IO[RootElement] =
+      parserWithThemeExtension(
+        BundleProvider.forMarkupParser(spanParsers = themeParsers, origin = BundleOrigin.Theme),
+        BundleProvider.forMarkupParser(spanParsers = themeExtensionParsers)
+      )
+        .use(_.fromInput(input).parse)
+        .map(_.root.allDocuments.head.content)
   }
 
   test("use a span parser from a theme") {
@@ -529,6 +537,19 @@ class TreeParserSpec
     val appParsers = Seq(spanFor('+', '!'))
 
     parse(themeParsers, appParsers).assertEquals(RootElement(Paragraph(
+      Text("aaa "),
+      DecoratedSpan('!', "bbb"),
+      Text(" ccc")
+    )))
+  }
+
+  test("let a span parser from a theme extension override a span parser from a base theme") {
+    import CustomSpanParsers._
+
+    val themeParsers = Seq(spanFor('+'))
+    val themeExtParsers = Seq(spanFor('+', '!'))
+
+    parseWithThemeExtension(themeParsers, themeExtParsers).assertEquals(RootElement(Paragraph(
       Text("aaa "),
       DecoratedSpan('!', "bbb"),
       Text(" ccc")

--- a/io/src/test/scala/laika/io/TreeTransformerSpec.scala
+++ b/io/src/test/scala/laika/io/TreeTransformerSpec.scala
@@ -343,7 +343,9 @@ class TreeTransformerSpec extends CatsEffectSuite
     val inputs = Seq(
       Root / "omg.txt" -> Contents.name
     )
-    transformTree(inputs).assertEquals(renderedRoot(Nil, staticDocuments = Seq(Root / "omg.txt") ++ TestTheme.staticASTPaths))
+    transformTree(inputs).assertEquals(
+      renderedRoot(Nil, staticDocuments = TestTheme.staticASTPaths :+ Root / "omg.txt")
+    )
   }
   
   object DocWithSection {
@@ -458,7 +460,7 @@ class TreeTransformerSpec extends CatsEffectSuite
           (Root / "dir2" / "doc6.txt", withTemplate1),
         ))
       ), 
-      staticDocuments = Seq(Root / "dir2" / "omg.txt") ++ TestTheme.staticASTPaths
+      staticDocuments = TestTheme.staticASTPaths :+ Root / "dir2" / "omg.txt"
     ))
   }
 

--- a/io/src/test/scala/laika/io/TreeTransformerSpec.scala
+++ b/io/src/test/scala/laika/io/TreeTransformerSpec.scala
@@ -204,6 +204,7 @@ class TreeTransformerSpec extends CatsEffectSuite
       Root / "cover.md" -> Contents.name
     )
     val mapperFunction: Document => Document = doc => doc.copy(content = doc.content.withContent(Seq(Paragraph("foo-bar"))))
+    val mapperFunctionExt: Document => Document = doc => doc.copy(content = doc.content.withContent(doc.content.content :+ Paragraph("baz")))
     def transformWithProcessor (theme: ThemeProvider): IO[RenderedTreeRoot[IO]] =
       transformWith(inputs, Transformer.from(Markdown).to(AST).parallel[IO].withTheme(theme).build)
 
@@ -219,6 +220,18 @@ class TreeTransformerSpec extends CatsEffectSuite
 
   test("tree with a document mapper from a theme") {
     TreeProcessors.run(TestThemeBuilder.forDocumentMapper(TreeProcessors.mapperFunction), mappedResult)
+  }
+
+  test("tree with a document mapper from a theme and one from a theme extension") {
+    val expectedResult: String = 
+      """RootElement - Blocks: 2
+        |. Paragraph - Spans: 1
+        |. . Text - 'foo-bar'
+        |. Paragraph - Spans: 1
+        |. . Text - 'baz'""".stripMargin
+    val theme = TestThemeBuilder.forDocumentMapper(TreeProcessors.mapperFunction)
+      .extendWith(TestThemeBuilder.forDocumentMapper(TreeProcessors.mapperFunctionExt))
+    TreeProcessors.run(theme, expectedResult)
   }
 
   test("tree with a document mapper from a theme specific to the output format") {


### PR DESCRIPTION
The new `extendWith` method is intended to improve the life of integrators, in particular projects or plugins that want to provide a theme that is an extension of an existing theme.

The exact mechanics of extending a theme vary depending on the type of functionality supported by themes.
They are roughly as follows:

* For functionality that is an accumulation of features, for example parser extensions, renderer overrides
   or AST rewrite rules, the effect is accumulative, the base theme and the extensions will be merged to a single set
   of features.
   
* For functionality that is provided by unique instances, for example the template engine or the default template,
   the effect is replacement, where the instance in the extension replaces the corresponding instance in the base,
   if present.

FYI @armanbilge