### PR TITLE
Add convenience methods to document AST to reduce boilerplate

### DIFF
--- a/core/shared/src/main/scala/laika/ast/documents.scala
+++ b/core/shared/src/main/scala/laika/ast/documents.scala
@@ -397,6 +397,24 @@ case class Document (path: Path,
   
   protected val configScope: Origin.Scope = Origin.DocumentScope
 
+  /** Appends the specified content to this tree and return a new instance.
+    */
+  def appendContent (content: Block, contents: Block*): Document = appendContent(content +: contents)
+
+  /** Appends the specified content to this tree and return a new instance.
+    */
+  def appendContent (newContent: Seq[Block]): Document = 
+    copy(content = content.withContent(this.content.content ++ newContent))
+
+  /** Prepends the specified content to this tree and return a new instance.
+    */
+  def prependContent (content: Block, contents: Block*): Document = prependContent(content +: contents)
+
+  /** Prepends the specified content to this tree and return a new instance.
+    */
+  def prependContent (newContent: Seq[Block]): Document = 
+    copy(content = content.withContent(newContent ++ this.content.content))
+
 }
 
 /** Represents a tree with all its documents, templates, configurations and subtrees.

--- a/core/shared/src/main/scala/laika/ast/documents.scala
+++ b/core/shared/src/main/scala/laika/ast/documents.scala
@@ -276,6 +276,22 @@ trait TreeStructure { this: TreeContent =>
       None
   }
 
+  /** Appends the specified content to this tree and return a new instance.
+    */
+  def appendContent (content: TreeContent, contents: TreeContent*): DocumentTree = appendContent(content +: contents)
+
+  /** Appends the specified content to this tree and return a new instance.
+    */
+  def appendContent (content: Seq[TreeContent]): DocumentTree = targetTree.copy(content = targetTree.content ++ content)
+
+  /** Prepends the specified content to this tree and return a new instance.
+    */
+  def prependContent (content: TreeContent, contents: TreeContent*): DocumentTree = prependContent(content +: contents)
+
+  /** Prepends the specified content to this tree and return a new instance.
+    */
+  def prependContent (content: Seq[TreeContent]): DocumentTree = targetTree.copy(content = content ++ targetTree.content)
+
   /** Selects a template from this tree or one of its subtrees by the specified path.
     * The path needs to be relative.
     */

--- a/core/shared/src/main/scala/laika/ast/documents.scala
+++ b/core/shared/src/main/scala/laika/ast/documents.scala
@@ -497,6 +497,10 @@ case class DocumentTreeRoot (tree: DocumentTree,
   def withConfig (config: Config): DocumentTreeRoot = {
     copy(tree = tree.copy(config = config))
   }
+
+  /** Creates a new instance by applying the specified function to the root tree.
+    */
+  def modifyTree (f: DocumentTree => DocumentTree): DocumentTreeRoot = copy(tree = f(tree))
   
   /** Returns a new tree, with all the document models contained in it rewritten based on the specified rewrite rules.
     *

--- a/core/shared/src/main/scala/laika/rst/bundle/DocInfoExtractor.scala
+++ b/core/shared/src/main/scala/laika/rst/bundle/DocInfoExtractor.scala
@@ -48,12 +48,9 @@ object DocInfoExtractor extends (UnresolvedDocument => UnresolvedDocument) {
       }
     }
     
-    embeddedConfigs.fold(doc){ configs =>
-      val block = BlockSequence(configs)
-      val oldRoot = doc.document.content
-      doc.copy(document = doc.document.copy(content = oldRoot.copy(content = block +: oldRoot.content)))
+    embeddedConfigs.fold(doc) { configs =>
+      doc.copy(document = doc.document.prependContent(BlockSequence(configs)))
     }
-    
   }
 
 }

--- a/core/shared/src/test/scala/laika/config/ParserBundleSpec.scala
+++ b/core/shared/src/test/scala/laika/config/ParserBundleSpec.scala
@@ -240,13 +240,14 @@ class ParserHookSpec extends FunSuite with ParserSetup {
     val raw = input.source.input
     input.copy(source = SourceCursor(raw + append, input.path))
   }
+  
+  def appendString (root: RootElement, append: String): RootElement = root.copy(content = root.content.map {
+    case Paragraph(Seq(Text(text, _)), _) => Paragraph(text + append)
+  })
 
-  def processDoc (append: String): UnresolvedDocument => UnresolvedDocument = { unresolved => unresolved.copy(
-     document =
-       unresolved.document.copy(content = unresolved.document.content.copy(content = unresolved.document.content.content map {
-        case Paragraph(Seq(Text(text, _)), _) => Paragraph(text + append)
-      })))
-    }
+  def processDoc (append: String): UnresolvedDocument => UnresolvedDocument = { unresolved => 
+    unresolved.copy(document = unresolved.document.copy(content = appendString(unresolved.document.content, append)))
+  }
 
   def processBlocks (append: String): Seq[Block] => Seq[Block] = { blocks =>
     blocks map {

--- a/io/src/main/scala/laika/format/EPUB.scala
+++ b/io/src/main/scala/laika/format/EPUB.scala
@@ -162,7 +162,7 @@ case object EPUB extends TwoPhaseRenderFormat[HTMLFormatter, BinaryPostProcessor
     BookConfig.decodeWithDefaults(root.config).map { treeConfig =>
       
       treeConfig.coverImage.fold(root) { image =>
-        root.copy(tree = root.tree.copy(
+        root.modifyTree(_.copy(
           content = Document(
             path    = Root / "cover", 
             content = RootElement(SpanSequence(Image(InternalTarget(image), alt = Some("cover")))), 

--- a/io/src/main/scala/laika/helium/generate/LandingPageGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/LandingPageGenerator.scala
@@ -56,11 +56,12 @@ private[helium] object LandingPageGenerator {
         if (doc.config.hasKey(LaikaKeys.template)) doc
         else doc.copy(config = doc.config.withValue(LaikaKeys.template, "landing.template.html").build)
         
-      // TODO - add API for replaceDocument, removeDocument, appendDocument, prependDocument
-      tree.copy(root = tree.root.copy(tree = tree.root.tree.copy(
-        titleDocument = Some(titleDocWithTemplate),
-        content = tree.root.tree.content.filterNot(_.path.withoutSuffix.name == "landing-page")
-      )))
+      tree.modifyTree { tree => 
+        tree.copy(
+          titleDocument = Some(titleDocWithTemplate),
+          content = tree.content.filterNot(_.path.withoutSuffix.name == "landing-page")
+        )
+      }
     }
     
     Sync[F].fromEither(result.leftMap(ConfigException.apply))

--- a/io/src/main/scala/laika/helium/generate/TocPageGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/TocPageGenerator.scala
@@ -61,9 +61,7 @@ private[helium] object TocPageGenerator {
         val title = Title(tocConfig.title).withOptions(Style.title)
         val root = RootElement(Preamble(tocConfig.title), title, navList) // TODO - Preamble should be inserted in PDF.prepareTree
         val doc = Document(Root / "table-of-content", root, config = tree.root.config.withValue("helium.markupEditLinks", false).build)
-        val oldTree = tree.root.tree
-        val newTree = tree.copy(root = tree.root.copy(tree = oldTree.copy(content = doc +: oldTree.content)))
-        newTree
+        tree.modifyTree(tree => tree.copy(content = doc +: tree.content))
       }
     Sync[F].pure(result)
   }

--- a/io/src/main/scala/laika/helium/generate/TocPageGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/TocPageGenerator.scala
@@ -61,7 +61,7 @@ private[helium] object TocPageGenerator {
         val title = Title(tocConfig.title).withOptions(Style.title)
         val root = RootElement(Preamble(tocConfig.title), title, navList) // TODO - Preamble should be inserted in PDF.prepareTree
         val doc = Document(Root / "table-of-content", root, config = tree.root.config.withValue("helium.markupEditLinks", false).build)
-        tree.modifyTree(tree => tree.copy(content = doc +: tree.content))
+        tree.modifyTree(_.appendContent(doc))
       }
     Sync[F].pure(result)
   }

--- a/io/src/main/scala/laika/helium/generate/TocPageGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/TocPageGenerator.scala
@@ -61,7 +61,7 @@ private[helium] object TocPageGenerator {
         val title = Title(tocConfig.title).withOptions(Style.title)
         val root = RootElement(Preamble(tocConfig.title), title, navList) // TODO - Preamble should be inserted in PDF.prepareTree
         val doc = Document(Root / "table-of-content", root, config = tree.root.config.withValue("helium.markupEditLinks", false).build)
-        tree.modifyTree(_.appendContent(doc))
+        tree.modifyTree(_.prependContent(doc))
       }
     Sync[F].pure(result)
   }

--- a/io/src/main/scala/laika/io/model/Input.scala
+++ b/io/src/main/scala/laika/io/model/Input.scala
@@ -432,7 +432,7 @@ case class ParsedTree[F[_]] (root: DocumentTreeRoot, staticDocuments: Seq[Binary
 
   /** Creates a new instance by applying the specified function to the nested tree.
     */
-  def modifyTree (f: DocumentTree => DocumentTree): ParsedTree[F] = copy(root = root.copy(tree = f(root.tree)))
+  def modifyTree (f: DocumentTree => DocumentTree): ParsedTree[F] = copy(root = root.modifyTree(f))
   
   /** Removes all static documents of this instance that match the specified filter.
     */

--- a/io/src/main/scala/laika/io/model/Input.scala
+++ b/io/src/main/scala/laika/io/model/Input.scala
@@ -17,13 +17,12 @@
 package laika.io.model
 
 import java.io._
-
 import cats.Applicative
 import cats.data.Kleisli
 import cats.effect.{Resource, Sync}
 import cats.instances.stream
 import laika.ast.Path.Root
-import laika.ast.{Document, DocumentTreeRoot, DocumentType, Navigatable, Path, StaticDocument, StyleDeclaration, StyleDeclarationSet, TemplateDocument, TextDocumentType}
+import laika.ast.{Document, DocumentTree, DocumentTreeRoot, DocumentType, Navigatable, Path, StaticDocument, StyleDeclaration, StyleDeclarationSet, TemplateDocument, TextDocumentType}
 import laika.bundle.{DocumentTypeMatcher, Precedence}
 import laika.config.Config
 import laika.io.runtime.TreeResultBuilder.{ConfigResult, DocumentResult, ParserResult, StyleResult, TemplateResult}
@@ -427,6 +426,14 @@ object DirectoryInput {
   */
 case class ParsedTree[F[_]] (root: DocumentTreeRoot, staticDocuments: Seq[BinaryInput[F]]) {
 
+  /** Creates a new instance by applying the specified function to the root tree.
+    */
+  def modifyRoot (f: DocumentTreeRoot => DocumentTreeRoot): ParsedTree[F] = copy(root = f(root))
+
+  /** Creates a new instance by applying the specified function to the nested tree.
+    */
+  def modifyTree (f: DocumentTree => DocumentTree): ParsedTree[F] = copy(root = root.copy(tree = f(root.tree)))
+  
   /** Removes all static documents of this instance that match the specified filter.
     */
   def removeStaticDocuments (filter: Path => Boolean): ParsedTree[F] = copy(

--- a/io/src/main/scala/laika/io/ops/TreeMapperOps.scala
+++ b/io/src/main/scala/laika/io/ops/TreeMapperOps.scala
@@ -58,7 +58,7 @@ abstract class TreeMapperOps[F[_]: Sync] {
     for {
       mappedTree  <- mapTree(parsed.root.tree)
       mappedCover <- parsed.root.coverDocument.map(f).sequence
-    } yield parsed.copy(root = parsed.root.copy(tree = mappedTree, coverDocument = mappedCover))
+    } yield parsed.modifyRoot(_.copy(tree = mappedTree, coverDocument = mappedCover))
 
   }
 

--- a/io/src/main/scala/laika/io/runtime/RendererRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/RendererRuntime.scala
@@ -171,9 +171,11 @@ object RendererRuntime {
 
     def applyTemplate (root: DocumentTreeRoot): Either[Throwable, DocumentTreeRoot] = {
 
-      val treeWithTpl: DocumentTree = root.tree.getDefaultTemplate(context.templateSuffix).fold(
-        root.tree.withDefaultTemplate(getDefaultTemplate(themeInputs, context.templateSuffix), context.templateSuffix)
-      )(_ => root.tree)
+      val treeWithTpl: DocumentTree = 
+        if (root.tree.getDefaultTemplate(context.templateSuffix).isEmpty)
+          root.tree.withDefaultTemplate(getDefaultTemplate(themeInputs, context.templateSuffix), context.templateSuffix)
+        else 
+          root.tree
       
       mapError(TemplateRewriter.applyTemplates(root.copy(tree = treeWithTpl), context))
         .flatMap(root => InvalidDocuments.from(root, op.config.failOnMessages).toLeft(root))

--- a/io/src/test/scala/laika/io/TreeParserFileIOSpec.scala
+++ b/io/src/test/scala/laika/io/TreeParserFileIOSpec.scala
@@ -164,7 +164,7 @@ class TreeParserFileIOSpec
     def customizeTree (sample: DocumentTreeRoot): DocumentTreeRoot = sample.copy(
       tree = sample.tree.copy(
         content = sample.tree.content.map {
-          case tree: DocumentTree if tree.path.name == "tree-2" => tree.copy(content = tree.content :+ extraDoc)
+          case tree: DocumentTree if tree.path.name == "tree-2" => tree.appendContent(extraDoc)
           case other => other
         }
       )
@@ -298,14 +298,13 @@ class TreeParserFileIOSpec
 
     private val tree2 = baseTree.tree.content(3).asInstanceOf[DocumentTree]
 
-    val expected: DocumentTreeRoot = baseTree.copy(
-      tree = baseTree.tree.copy(
-        content =
-          baseTree.tree.content.take(2) :+
-            doc9 :+
-            baseTree.tree.content(2) :+
-            tree2.copy(content = tree2.content :+ doc7) :+
-            DocumentTree(Root / "tree-3", Seq(doc8))
+    val expected: DocumentTreeRoot = baseTree.modifyTree(tree =>
+      tree.copy(content =
+        tree.content.take(2) :+
+          doc9 :+
+          tree.content(2) :+
+          tree2.appendContent(doc7) :+
+          DocumentTree(Root / "tree-3", Seq(doc8))
       )
     )
   }

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -559,7 +559,7 @@ class TreeRendererSpec extends CatsEffectSuite
         .tree
     )
 
-    val finalInput = input.copy(content = input.content :+ fontConfigTree)
+    val finalInput = input.appendContent(fontConfigTree)
 
     val staticDocs = Seq(
       Inputs.staticDoc(1, Root),
@@ -604,7 +604,7 @@ class TreeRendererSpec extends CatsEffectSuite
       .tree2.config(SampleConfig.versioned(true))
       .build
       .tree
-    val finalInput = input.copy(content = input.content :+ HTMLRenderer.fontConfigTree)
+    val finalInput = input.appendContent(HTMLRenderer.fontConfigTree)
 
     val staticDocs = Seq(
       Inputs.staticDoc(1, Root),

--- a/pdf/src/main/scala/laika/format/PDF.scala
+++ b/pdf/src/main/scala/laika/format/PDF.scala
@@ -70,7 +70,7 @@ object PDF extends TwoPhaseRenderFormat[FOFormatter, BinaryPostProcessorBuilder]
     */
   def prepareTree (root: DocumentTreeRoot): Either[Throwable, DocumentTreeRoot] =
     Right(root
-      .copy(tree = root.tree.withDefaultTemplate(TemplateRoot.fallback, "fo"))
+      .modifyTree(_.withDefaultTemplate(TemplateRoot.fallback, "fo"))
       .mapDocuments { doc =>
         val preamble = Preamble(doc.title.fold(doc.name)(_.extractText))
         doc.copy(content = doc.content.copy(content = preamble +: doc.content.content))

--- a/pdf/src/main/scala/laika/format/PDF.scala
+++ b/pdf/src/main/scala/laika/format/PDF.scala
@@ -73,7 +73,7 @@ object PDF extends TwoPhaseRenderFormat[FOFormatter, BinaryPostProcessorBuilder]
       .modifyTree(_.withDefaultTemplate(TemplateRoot.fallback, "fo"))
       .mapDocuments { doc =>
         val preamble = Preamble(doc.title.fold(doc.name)(_.extractText))
-        doc.copy(content = doc.content.copy(content = preamble +: doc.content.content))
+        doc.prependContent(preamble)
       })
 
   /** Processes the interim XSL-FO result, transforms it to PDF and writes it to the specified final output.

--- a/pdf/src/test/scala/laika/render/PDFNavigationSpec.scala
+++ b/pdf/src/test/scala/laika/render/PDFNavigationSpec.scala
@@ -44,7 +44,7 @@ class PDFNavigationSpec extends CatsEffectSuite with FileIO with PDFTreeModel {
     val interimFormat: RenderFormat[FOFormatter] = XSLFO
     
     def prepareTree (root: DocumentTreeRoot): Either[Throwable, DocumentTreeRoot] = Right(root
-      .copy(tree = root.tree.withDefaultTemplate(TemplateRoot.fallback, "fo"))
+      .modifyTree(_.withDefaultTemplate(TemplateRoot.fallback, "fo"))
       .mapDocuments { doc =>
         val preamble = Preamble(doc.title.fold(doc.name)(_.extractText))
         doc.copy(content = doc.content.withContent(preamble +: doc.content.content))


### PR DESCRIPTION
Currently some fairly common modifications like adding a document to an existing document tree require a set of nested copy operations which are very verbose and error-prone to write. This PR adds the following new shortcut methods (and also uses them in various places in Laika's own code):

* `Document.appendContent(Block*)`
* `Document.prependContent(Block*)`
* `DocumentTree.appendContent(TreeContent*)`
* `DocumentTree.prependContent(TreeContent*)`
* `DocumentTreeRoot.modifyTree(DocumentTree => DocumentTree)`
* `ParsedTree.modifyTree(DocumentTree => DocumentTree)`
* `ParsedTree.modifyRoot(DocumentTreeRoot => DocumentTreeRoot)`