### PR TITLE
sbt plugin: split preview task into builder + launcher

### DIFF
--- a/sbt/src/main/scala/laika/sbt/LaikaPlugin.scala
+++ b/sbt/src/main/scala/laika/sbt/LaikaPlugin.scala
@@ -177,7 +177,7 @@ object LaikaPlugin extends AutoPlugin {
     laikaAST                := Tasks.generate.toTask(" ast").value,
     
     laikaPackageSite        := Tasks.packageSite.value,
-    laikaPreview            := Tasks.preview.value,
+    laikaPreview            := Tasks.startPreviewServer.value,
     Laika / clean           := Tasks.clean.value,
 
     laikaSite / mappings    := Def.sequential(Tasks.site, Tasks.mappings).value,


### PR DESCRIPTION
This addresses the issue described in #259 where integrators who need to launch the preview server in a slightly different way had to copy the entire implementation from Laika's plugin.

This PR splits the task into two, where one builds the server as a `cats.effect.Resource` and the other one launches it.

 Closes #259