### PR TITLE
avoid naive seq size comparison for performance

### DIFF
--- a/core/shared/src/main/scala/laika/ast/Cursor.scala
+++ b/core/shared/src/main/scala/laika/ast/Cursor.scala
@@ -300,7 +300,7 @@ case class DocumentCursor (target: Document,
 
     /** The next document in a flattened tree view or None if this is the cursor points to the last document.
       */
-    def nextDocument: Option[DocumentCursor] = if (currentIndex + 1 == documents.size) None else Some(documents(currentIndex + 1))
+    def nextDocument: Option[DocumentCursor] = if ( 0 == documents.lengthCompare(currentIndex + 1)) None else Some(documents(currentIndex + 1))
   }
 
   /** Provides navigation capabilities to the siblings of this document where the entire

--- a/core/shared/src/main/scala/laika/markdown/github/Tables.scala
+++ b/core/shared/src/main/scala/laika/markdown/github/Tables.scala
@@ -79,7 +79,7 @@ object Tables {
     case class Header (row: Row, columnOptions: Seq[Options])
 
     val header: PrefixedParser[Header] = (firstRow ~ sepRow).collect {
-      case row ~ sep if row.content.size == sep.size => Header(row, sep)
+      case row ~ sep if   row.content.lengthCompare(sep.size)==0 => Header(row, sep)
     }
 
     def applyColumnOptions (rows: Seq[Row], columnOptions: Seq[Options]): Seq[Row] = {

--- a/core/shared/src/main/scala/laika/parse/SourceCursor.scala
+++ b/core/shared/src/main/scala/laika/parse/SourceCursor.scala
@@ -448,7 +448,7 @@ class Position(s: InputString, offset: Int) {
     */
   lazy val line: Int = {
     val result = java.util.Arrays.binarySearch(s.lineStarts, offset)
-    if (result == s.lineStarts.length - 1) result // EOF position is not on a new line
+    if (s.lineStarts.lengthCompare(result+1)==0) result // EOF position is not on a new line
     else if (result < 0) Math.abs(result) - 1 // see javadoc for binarySearch
     else result + 1 // line is 1-based
   }

--- a/core/shared/src/main/scala/laika/parse/combinator/Repeat.scala
+++ b/core/shared/src/main/scala/laika/parse/combinator/Repeat.scala
@@ -61,10 +61,10 @@ class Repeat[+T] (parser: Parser[T], min: Int = 0, max: Int = Int.MaxValue, sep:
 
     @tailrec
     def rec (source: SourceCursor, p: Parser[T]): Parsed[List[T]] =
-      if (elems.length == max) Success(elems.toList, source)
+      if (elems.lengthCompare(max) == 0) Success(elems.toList, source)
       else p.parse(source) match {
         case Success(x, next)                  => elems += x; rec(next, repParser)
-        case _: Failure if elems.length >= min => Success(elems.toList, source)
+        case _: Failure if elems.lengthCompare(min) >= 0 => Success(elems.toList, source)
         case f: Failure                        => f
       }
 

--- a/core/shared/src/main/scala/laika/parse/text/Literal.scala
+++ b/core/shared/src/main/scala/laika/parse/text/Literal.scala
@@ -41,11 +41,11 @@ case class Literal (expected: String) extends PrefixedParser[String] {
     val start = in.offset
     var i = 0
     var j = start
-    while (i < expected.length && j < source.length && expected.charAt(i) == source.charAt(j)) {
+    while (expected.lengthCompare(i) > 0 && source.lengthCompare(j) > 0 && expected.charAt(i) == source.charAt(j)) {
       i += 1
       j += 1
     }
-    if (i == expected.length) Success(expected, in.consume(i))
+    if (expected.lengthCompare(i)==0) Success(expected, in.consume(i))
     else Failure(msgProvider, in, j)
   }
 

--- a/core/shared/src/main/scala/laika/render/FORenderer.scala
+++ b/core/shared/src/main/scala/laika/render/FORenderer.scala
@@ -209,7 +209,7 @@ object FORenderer extends ((FOFormatter, Element) => String) {
         val styles = fmt.styles.collectStyles(SpanSequence.empty.withStyle("svg-shape"), fmt.parents).get("color")
         val svg = styles.fold(icon.content) { color =>
           val parts = icon.content.split(">", 2) // inlining styles as FOP itself does not support CSS for SVG
-          if (parts.length == 2) parts.head + s">\n  <style>.svg-shape { fill: $color; }</style>" + parts.last
+          if (parts.lengthCompare(2) == 0) parts.head + s">\n  <style>.svg-shape { fill: $color; }</style>" + parts.last
           else icon.content
         }
         fmt.rawElement("fo:instream-foreign-object", icon, svg)

--- a/core/shared/src/main/scala/laika/rst/BlockParsers.scala
+++ b/core/shared/src/main/scala/laika/rst/BlockParsers.scala
@@ -182,7 +182,7 @@ object BlockParsers {
     def processLiteralMarker (par: Paragraph) = {
       par.content.lastOption match {
         case Some(Text(text,opt)) if text.trim.endsWith("::") =>
-          val drop = if (text.length > 2 && text.charAt(text.length-3) == ' ') 3 else 1
+          val drop = if (text.lengthCompare(2) > 0 && text.charAt(text.length-3) == ' ') 3 else 1
           val spans = par.content.init.toList ::: List(Text(text.dropRight(drop),opt))
           (Paragraph(spans,par.options), litBlock)
         case _ => (par, defaultBlock)

--- a/io/src/main/scala/laika/io/runtime/RendererRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/RendererRuntime.scala
@@ -50,7 +50,7 @@ object RendererRuntime {
     def validatePaths (staticDocs: Seq[BinaryInput[F]]): F[Unit] = {
       val paths = op.input.allDocuments.map(_.path) ++ staticDocs.map(_.path)
       val duplicates = paths.groupBy(identity).values.collect {
-        case p if p.size > 1 => DuplicatePath(p.head)
+        case p if p.lengthCompare(1) > 0 => DuplicatePath(p.head)
       }
       if (duplicates.isEmpty) Sync[F].unit
       else Sync[F].raiseError(RendererErrors(duplicates.toSeq.sortBy(_.path.toString)))

--- a/io/src/main/scala/laika/theme/config/Color.scala
+++ b/io/src/main/scala/laika/theme/config/Color.scala
@@ -61,7 +61,7 @@ object Color {
     */
   def hex (hexValue: String): Color = new Color(s"#$hexValue") {
     def validate: Option[String] =
-      if ((hexValue.length != 3 && hexValue.length != 6) || hexValue.forall(CharGroup.hexDigit.contains))
+      if ((hexValue.lengthCompare(3) != 0 && hexValue.lengthCompare(6) != 0) || hexValue.forall(CharGroup.hexDigit.contains))
         Some("value must be 3 or 6 hexadecimal digits")
       else None
   }


### PR DESCRIPTION
`lengthCompare` is usually more performant than combination of `length` and compare
operator.