### PR TITLE
Split date metadata into datePublished and dateModified

### DIFF
--- a/core/shared/src/main/scala/laika/ast/DocumentMetadata.scala
+++ b/core/shared/src/main/scala/laika/ast/DocumentMetadata.scala
@@ -16,7 +16,6 @@
 
 package laika.ast
 
-import java.util.Date
 import laika.config.{ConfigDecoder, ConfigEncoder, DefaultKey, LaikaKeys}
 import laika.time.PlatformDateTime
 
@@ -29,7 +28,8 @@ case class DocumentMetadata (title: Option[String] = None,
                              identifier: Option[String] = None,
                              authors: Seq[String] = Nil,
                              language: Option[String] = None,
-                             date: Option[PlatformDateTime.Type] = None,
+                             datePublished: Option[PlatformDateTime.Type] = None,
+                             dateModified: Option[PlatformDateTime.Type] = None,
                              version: Option[String] = None) {
 
   /** Populates all empty Options in this instance with the provided defaults in case they are non-empty
@@ -40,7 +40,8 @@ case class DocumentMetadata (title: Option[String] = None,
     identifier.orElse(defaults.identifier),
     authors ++ defaults.authors,
     language.orElse(defaults.language),
-    date.orElse(defaults.date),
+    datePublished.orElse(defaults.datePublished),
+    dateModified.orElse(defaults.dateModified),
     version.orElse(defaults.version)
   )
   
@@ -51,7 +52,8 @@ case class DocumentMetadata (title: Option[String] = None,
         other.identifier == identifier &&
         other.authors == authors &&
         other.language == language &&
-        other.date.toString == date.toString && // equals does not work properly on js.Date
+        other.datePublished.toString == datePublished.toString && // equals does not work properly on js.Date
+        other.dateModified.toString == dateModified.toString && // equals does not work properly on js.Date
         other.version == version
     case _ => false
   } 
@@ -62,16 +64,17 @@ object DocumentMetadata {
 
   implicit val decoder: ConfigDecoder[DocumentMetadata] = ConfigDecoder.config.flatMap { config =>
     for {
-      title       <- config.getOpt[String]("title")
-      description <- config.getOpt[String]("description")
-      identifier <- config.getOpt[String]("identifier")
-      author     <- config.getOpt[String]("author")
-      authors    <- config.get[Seq[String]]("authors", Nil)
-      lang       <- config.getOpt[String]("language")
-      date       <- config.getOpt[PlatformDateTime.Type]("date")
-      version    <- config.getOpt[String]("version")
+      title         <- config.getOpt[String]("title")
+      description   <- config.getOpt[String]("description")
+      identifier    <- config.getOpt[String]("identifier")
+      author        <- config.getOpt[String]("author")
+      authors       <- config.get[Seq[String]]("authors", Nil)
+      lang          <- config.getOpt[String]("language")
+      datePublished <- config.getOpt[PlatformDateTime.Type]("datePublished")
+      dateModified  <- config.getOpt[PlatformDateTime.Type]("dateModified")
+      version       <- config.getOpt[String]("version")
     } yield {
-      DocumentMetadata(title, description, identifier, authors ++ author.toSeq, lang, date, version)
+      DocumentMetadata(title, description, identifier, authors ++ author.toSeq, lang, datePublished, dateModified, version)
     }
   }
   implicit val encoder: ConfigEncoder[DocumentMetadata] = ConfigEncoder[DocumentMetadata] { metadata =>
@@ -81,7 +84,8 @@ object DocumentMetadata {
       .withValue("identifier", metadata.identifier)
       .withValue("authors", metadata.authors)
       .withValue("language", metadata.language)
-      .withValue("date", metadata.date)
+      .withValue("datePublished", metadata.datePublished)
+      .withValue("dateModified", metadata.dateModified)
       .withValue("version", metadata.version)
       .build
   }

--- a/core/shared/src/test/scala/laika/config/ConfigCodecSpec.scala
+++ b/core/shared/src/test/scala/laika/config/ConfigCodecSpec.scala
@@ -63,7 +63,8 @@ class ConfigCodecSpec extends FunSuite {
         |  identifier = XX-33-FF-01
         |  authors = [ "Helen North", "Maria South" ]
         |  language = en
-        |  date = "2002-10-10T12:00:00"
+        |  datePublished = "2002-10-10T12:00:00"
+        |  dateModified = "2002-12-12T12:00:00"
         |}}
       """.stripMargin
     decode[DocumentMetadata](input, DocumentMetadata(
@@ -72,7 +73,8 @@ class ConfigCodecSpec extends FunSuite {
       Some("XX-33-FF-01"),
       Seq("Helen North", "Maria South"),
       Some("en"),
-      Some(PlatformDateTime.parse("2002-10-10T12:00:00").toOption.get)
+      Some(PlatformDateTime.parse("2002-10-10T12:00:00").toOption.get),
+      Some(PlatformDateTime.parse("2002-12-12T12:00:00").toOption.get)
     ))
   }
 
@@ -83,7 +85,7 @@ class ConfigCodecSpec extends FunSuite {
         |  identifier = XX-33-FF-01
         |  author = "Dorothea West"
         |  language = en
-        |  date = "2002-10-10T12:00:00"
+        |  datePublished = "2002-10-10T12:00:00"
         |}}
       """.stripMargin
     decode[DocumentMetadata](input, DocumentMetadata(
@@ -114,10 +116,10 @@ class ConfigCodecSpec extends FunSuite {
         |  identifier = XX-33-FF-01
         |  author = "Dorothea West"
         |  language = en
-        |  date = "2000-XX-01T00:00:00Z"
+        |  dateModified = "2000-XX-01T00:00:00Z"
         |}}
       """.stripMargin
-    failDecode[DocumentMetadata](input, "Error decoding 'laika.metadata.date': Invalid date format")
+    failDecode[DocumentMetadata](input, "Error decoding 'laika.metadata.dateModified': Invalid date format")
   }
 
 

--- a/docs/src/03-preparing-content/03-theme-settings.md
+++ b/docs/src/03-preparing-content/03-theme-settings.md
@@ -450,7 +450,7 @@ Helium.defaults
     identifier = Some("XSD-9876-XVT"),
     authors = Seq("Maria Green", "Helena Brown"),
     language = Some("de"),
-    date = Some(Instant.now),
+    datePublished = Some(Instant.now),
     version = Some("2.3.4") 
   )
 ```
@@ -459,6 +459,35 @@ When using the sbt plugin the `title`, `description` and `version` metadata will
 sbt settings `name`, `description` and `version` respectively. 
 When using the library API no medata will be defined by default.
 It is recommended to always define the language and title as the minimum set of metadata.
+
+
+Metadata for Individual Documents
+---------------------------------
+
+The API shown above specifies metadata globally which is most convenient for output formats like PDF or EPUB,
+which produce a single artefact.
+For site generation you may want to override some of these values per page.
+You can do that in a configuration header of your markup document:
+
+```laika-md
+{%
+laika.metadata {
+  authors = ["Helena North", "Maria South"]
+  datePublished = "2012-10-10T12:00:00"
+  dateModified = "2014-07-07T12:00:00"
+}
+%}
+```
+
+These values can then be used in templates like other substitution variables:
+
+```laika-html
+<meta itemprop="datePublished" content="${laika.metadata.datePublished}">
+```
+
+The page-level metadata is a core feature and available even when not using the Helium theme.
+Note that, at the moment, `dateModified` is not auto-populated from the file system and has to be set manually.
+In many cases this is desirable anyway, as not every file modification represents a meaningful change to the user.
 
 
 Navigation, Links & Favicons

--- a/docs/src/07-reference/02-substitution-variables.md
+++ b/docs/src/07-reference/02-substitution-variables.md
@@ -97,9 +97,13 @@ This is a complete list of values exposed in the `cursor` namespace:
 ### Laika Configuration Values
 
 These are usually not accessed in user templates and mostly intended for Laika's own internal processing, 
-but are nevertheless exposed like any other value in the configuration.
+but are nevertheless exposed like any other value in the configuration. 
+Follow the links for details about the available attributes for these keys.
 
-* `laika.<format>.metadata`: holds the [Metadata] specified in configuration.
+* `laika.<format>.metadata`: holds the [Metadata] specified in configuration (e.g. authors, dates, language).
+
+* `laika.metadata`: holds the default [Metadata] that is not specific to certain output formats.
+  Values not specified for individual formats will be inherited from these base values.
 
 * `laika.links`: holds navigation configuration for [Global Link Definitions], [Linking to API Documentation]
   and [Disabling Validation].
@@ -110,7 +114,7 @@ but are nevertheless exposed like any other value in the configuration.
 * `laika.pdf` and `laika.epub`: e-book configuration, see [E-Books (EPUB & PDF)] for details
 
 * `laika.titleDocuments`: configures the names of documents that should be treated as title documents.
-  See [Title Documents] for details.  
+  See [Title Documents] for details.
 
 
 User-Defined Values

--- a/io/src/main/scala/laika/format/EPUB.scala
+++ b/io/src/main/scala/laika/format/EPUB.scala
@@ -96,7 +96,7 @@ case object EPUB extends TwoPhaseRenderFormat[HTMLFormatter, BinaryPostProcessor
                         fonts: Seq[FontDefinition] = Nil,
                         coverImage: Option[Path] = None) {
     lazy val identifier: String = metadata.identifier.getOrElse(s"urn:uuid:${UUID.randomUUID.toString}")
-    lazy val date: OffsetDateTime = metadata.date.getOrElse(OffsetDateTime.now())
+    lazy val date: OffsetDateTime = metadata.dateModified.orElse(metadata.datePublished).getOrElse(OffsetDateTime.now())
     lazy val formattedDate: String = DateTimeFormatter.ISO_INSTANT.format(date.toInstant.truncatedTo(ChronoUnit.SECONDS))
     lazy val language: String = metadata.language.getOrElse(Locale.getDefault.toLanguageTag)
   }

--- a/io/src/main/scala/laika/helium/config/settings.scala
+++ b/io/src/main/scala/laika/helium/config/settings.scala
@@ -165,20 +165,22 @@ private[helium] trait CommonConfigOps {
     * When using the library API no medata will be defined by default.
     * It is recommended to always define the language and title as the minimum set of metadata.
     * 
-    * @param title       the title of the site and/or e-book
-    * @param description a short description of the site and/or e-book
-    * @param identifier  a unique identifier for the e-book, not used for site generation
-    * @param authors     one or more author names
-    * @param language    the language of the site and/or e-book, should always be defined
-    * @param date        the publication date as a UTC date-time
-    * @param version     the version string for the output
+    * @param title         the title of the site and/or e-book
+    * @param description   a short description of the site and/or e-book
+    * @param identifier    a unique identifier for the e-book, not used for site generation
+    * @param authors       one or more author names
+    * @param language      the language of the site and/or e-book, should always be defined
+    * @param datePublished the publication date as a UTC date-time
+    * @param dateModfieid  the modification date as a UTC date-time
+    * @param version       the version string for the output
     */
   def metadata (title: Option[String] = None,
                 description: Option[String] = None,
                 identifier: Option[String] = None,
                 authors: Seq[String] = Nil,
                 language: Option[String] = None,
-                date: Option[OffsetDateTime] = None,
+                datePublished: Option[OffsetDateTime] = None,
+                dateModified: Option[OffsetDateTime] = None,
                 version: Option[String] = None): Helium
 
   /** Adds a dedicated page for a table of content, in addition to the reader-native navigation structure.
@@ -249,9 +251,10 @@ private[helium] trait SingleConfigOps extends CommonConfigOps with ColorOps {
                 identifier: Option[String] = None,
                 authors: Seq[String] = Nil,
                 language: Option[String] = None,
-                date: Option[OffsetDateTime] = None,
+                datePublished: Option[OffsetDateTime] = None,
+                dateModified: Option[OffsetDateTime] = None,
                 version: Option[String] = None): Helium =
-    withMetadata(DocumentMetadata(title, description, identifier, authors, language, date, version))
+    withMetadata(DocumentMetadata(title, description, identifier, authors, language, datePublished, dateModified, version))
 }
 
 private[helium] trait AllFormatsOps extends CommonConfigOps {
@@ -301,10 +304,11 @@ private[helium] trait AllFormatsOps extends CommonConfigOps {
                 identifier: Option[String] = None,
                 authors: Seq[String] = Nil,
                 language: Option[String] = None,
-                date: Option[OffsetDateTime] = None,
+                datePublished: Option[OffsetDateTime] = None,
+                dateModified: Option[OffsetDateTime] = None,
                 version: Option[String] = None): Helium = formats.foldLeft(helium) {
     case (helium, format) =>
-      format(helium).metadata(title, description, identifier, authors, language, date, version)
+      format(helium).metadata(title, description, identifier, authors, language, datePublished, dateModified, version)
   }
   def tableOfContent (title: String, depth: Int): Helium = formats.foldLeft(helium) {
     case (helium, format) =>

--- a/io/src/test/scala/laika/render/epub/BookConfigSpec.scala
+++ b/io/src/test/scala/laika/render/epub/BookConfigSpec.scala
@@ -51,7 +51,7 @@ class BookConfigSpec extends FunSuite {
         |    identifier = XX-33-FF-01
         |    author = "Helen North"
         |    language = en
-        |    date = "2002-10-10T12:00:00"
+        |    datePublished = "2002-10-10T12:00:00"
         |  }
         |  fonts = [
         |    { family = Font-C, weight = normal, style = italic, webCSS = "http://fonts.com/font-c.css" }

--- a/io/src/test/scala/laika/render/epub/OPFRendererSpec.scala
+++ b/io/src/test/scala/laika/render/epub/OPFRendererSpec.scala
@@ -38,7 +38,7 @@ class OPFRendererSpec extends FunSuite {
   val identifier = s"urn:uuid:${new InputTreeBuilder{}.uuid}"
   val config: EPUB.BookConfig = EPUB.BookConfig(metadata = DocumentMetadata(
     identifier = Some(identifier),
-    date = Some(instant),
+    datePublished = Some(instant),
     language = Some(Locale.UK.toLanguageTag),
     authors = Seq("Mia Miller")
   ))

--- a/io/src/test/scala/laika/theme/ThemeConfigCodecSpec.scala
+++ b/io/src/test/scala/laika/theme/ThemeConfigCodecSpec.scala
@@ -47,7 +47,7 @@ class ThemeConfigCodecSpec extends FunSuite {
         |    identifier = XX-33-FF-01
         |    authors = [ "Helen North", "Maria South" ]
         |    language = en
-        |    date = "2002-10-10T12:00:00"
+        |    datePublished = "2002-10-10T12:00:00"
         |  }
         |  fonts = [
         |    { family = Font-A, weight = normal, style = normal, embedFile = /path/to/font-a.tff }

--- a/pdf/src/main/scala/laika/format/PDF.scala
+++ b/pdf/src/main/scala/laika/format/PDF.scala
@@ -111,7 +111,7 @@ object PDF extends TwoPhaseRenderFormat[FOFormatter, BinaryPostProcessorBuilder]
                         fonts: Seq[FontDefinition] = Nil,
                         coverImage: Option[Path] = None) {
     lazy val identifier: String = metadata.identifier.getOrElse(s"urn:uuid:${UUID.randomUUID.toString}")
-    lazy val date: OffsetDateTime = metadata.date.getOrElse(OffsetDateTime.now())
+    lazy val date: OffsetDateTime = metadata.dateModified.orElse(metadata.datePublished).getOrElse(OffsetDateTime.now())
     lazy val formattedDate: String = DateTimeFormatter.ISO_INSTANT.format(date.toInstant.truncatedTo(ChronoUnit.SECONDS))
     lazy val language: String = metadata.language.getOrElse(Locale.getDefault.toLanguageTag)
   }

--- a/pdf/src/main/scala/laika/render/pdf/PDFRenderer.scala
+++ b/pdf/src/main/scala/laika/render/pdf/PDFRenderer.scala
@@ -47,7 +47,7 @@ class PDFRenderer[F[_]: Async] (fopFactory: FopFactory, dispatcher: Dispatcher[F
   def render (foInput: String, output: BinaryOutput[F], metadata: DocumentMetadata, staticDocuments: Seq[BinaryInput[F]] = Nil): F[Unit] = {
 
     def applyMetadata (agent: FOUserAgent): F[Unit] = Sync[F].delay {
-      metadata.date.foreach(d => agent.setCreationDate(new java.util.Date(d.toInstant.toEpochMilli)))
+      metadata.dateModified.orElse(metadata.datePublished).foreach(d => agent.setCreationDate(new java.util.Date(d.toInstant.toEpochMilli)))
       metadata.authors.headOption.foreach(a => agent.setAuthor(a))
       metadata.title.foreach(t => agent.setTitle(t))
     }

--- a/pdf/src/test/scala/laika/render/BookConfigSpec.scala
+++ b/pdf/src/test/scala/laika/render/BookConfigSpec.scala
@@ -49,7 +49,7 @@ class BookConfigSpec extends FunSuite {
         |    identifier = XX-33-FF-01
         |    author = "Helen North"
         |    language = en
-        |    date = "2002-10-10T12:00:00"
+        |    datePublished = "2002-10-10T12:00:00"
         |  }
         |  fonts = [
         |    { family = Font-C, weight = normal, style = italic, webCSS = "http://fonts.com/font-c.css" }


### PR DESCRIPTION
The existing `date` metadata value could previously be set in a configuration header like this:
```
{%
  laika.metadata.date = "2012-10-10T12:00:00"
%}
```

and the value could be accessed in the AST like this:

```scala
val doc: Document = ???
doc.config.get[DocumentMetadata].map(_.date)
```

or used in templates like this:

```
Date published: ${laika.metadata.date}
```

This PR merely replaces the existing `date` attribute with `datePublished` and `dateModified` as this is a distinction used by many systems (e.g. when specifying structured data in JSON-LD format in the `<head>` section of an HTML page).

This is a breaking API change.