### PR TITLE
simplify TextInput and TextOutput as a preparation step for fs2 migration

### DIFF
--- a/io/src/main/scala/laika/io/config/ResourceLoader.scala
+++ b/io/src/main/scala/laika/io/config/ResourceLoader.scala
@@ -54,7 +54,7 @@ object ResourceLoader {
     
     def load: F[Either[ConfigResourceError, String]] = {
       val input = TextInput.fromFile[F](Root, DocumentType.Config, file, Codec.UTF8)
-      InputRuntime.readParserInput(input).attempt.map(_.bimap(
+      input.asDocumentInput.attempt.map(_.bimap(
         t => ConfigResourceError(s"Unable to load file '${file.getPath}': ${t.getMessage}"), 
         _.source.input
       ))
@@ -96,7 +96,7 @@ object ResourceLoader {
     } yield str
     
     val input = TextInput.fromStream[F](Root, DocumentType.Config, stream, Codec.UTF8, autoClose = true)
-    InputRuntime.readParserInput(input).attempt.map {
+    input.asDocumentInput.attempt.map {
       case Left(_: FileNotFoundException) => None
       case Left(t) => Some(Left(ConfigResourceError(s"Unable to load config from URL '${url.toString}': ${t.getMessage}")))
       case Right(res) => Some(Right(res.source.input))

--- a/io/src/main/scala/laika/io/runtime/InputRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/InputRuntime.scala
@@ -19,9 +19,6 @@ package laika.io.runtime
 import java.io._
 
 import cats.effect.{Sync, Resource}
-import laika.io.model._
-import laika.parse.SourceCursor
-import laika.parse.markup.DocumentParser.DocumentInput
 import cats.implicits._
 
 import scala.io.Codec
@@ -31,13 +28,6 @@ import scala.io.Codec
   * @author Jens Halm
   */
 object InputRuntime {
-
-  def readParserInput[F[_]: Sync] (doc: TextInput[F]): F[DocumentInput] = doc.input.use {
-    case PureReader(input) => 
-      Sync[F].pure(DocumentInput(doc.path, SourceCursor(input, doc.path)))
-    case StreamReader(reader, sizeHint) => 
-      readAll(reader, sizeHint).map(source => DocumentInput(doc.path, SourceCursor(source, doc.path)))
-  }
 
   def readAll[F[_]: Sync] (reader: Reader, sizeHint: Int): F[String] = {
     

--- a/io/src/main/scala/laika/io/runtime/OutputRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/OutputRuntime.scala
@@ -17,10 +17,8 @@
 package laika.io.runtime
 
 import java.io._
-
-import cats.effect.{Sync, Resource}
+import cats.effect.{Resource, Sync}
 import cats.implicits._
-import laika.io.model.{PureWriter, _}
 
 import scala.io.Codec
 
@@ -32,15 +30,11 @@ object OutputRuntime {
 
   /** Creates a Writer for the specified output model and writes the given string to it.
     */
-  def write[F[_]: Sync] (result: String, output: TextOutput[F]): F[Unit] = {
-    output.resource.use {
-      case PureWriter => Sync[F].unit
-      case StreamWriter(writer) => Sync[F].delay {
-        writer.write(result)
-        writer.flush()
-      }
+  def write[F[_]: Sync] (result: String, writer: Writer): F[Unit] =
+    Sync[F].delay {
+      writer.write(result)
+      writer.flush()
     }
-  }
 
   /** Creates a directory for the specified file, including parent directories of that file if they do not exist yet.
     */

--- a/io/src/main/scala/laika/io/runtime/ParserRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/ParserRuntime.scala
@@ -79,7 +79,7 @@ object ParserRuntime {
       }
       
       def parseDocument[D] (doc: TextInput[F], parse: DocumentInput => Either[ParserError, D], result: (D, Option[File]) => ParserResult): F[ParserResult] =
-        InputRuntime.readParserInput(doc).flatMap(in => Sync[F].fromEither(parse(in).map(result(_, doc.sourceFile))))
+        doc.asDocumentInput.flatMap(in => Sync[F].fromEither(parse(in).map(result(_, doc.sourceFile))))
       
       def parseConfig(input: DocumentInput): Either[ParserError, ConfigParser] =
         Right(op.config.configProvider.configDocument(input.source.input))

--- a/io/src/main/scala/laika/io/runtime/RendererRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/RendererRuntime.scala
@@ -102,7 +102,7 @@ object RendererRuntime {
           val pathTranslator = createPathTranslator(translatorConfig, document.path, lookup)
           val outputPath = pathTranslator.translate(document.path)
           val renderResult = renderer.render(document.content, outputPath, pathTranslator, styles)
-          OutputRuntime.write(renderResult, output(outputPath)).as {
+          output(outputPath).writer(renderResult).as {
             val result = RenderedDocument(outputPath, document.title, document.sections, renderResult, document.config)
             Right(result): RenderResult
           }
@@ -131,7 +131,7 @@ object RendererRuntime {
       
       op.output match {
         case StringTreeOutput => 
-          val renderOps = renderDocuments(finalRoot, styles, lookup, translatorConfig)(p => TextOutput.forString(p))
+          val renderOps = renderDocuments(finalRoot, styles, lookup, translatorConfig)(p => TextOutput.noOp(p))
           val copyOps = copyDocuments(staticDocs, None, pathTranslator)
           RenderOps(Nil, renderOps ++ copyOps)
         case DirectoryOutput(dir, codec) =>

--- a/io/src/test/scala/laika/io/FileIO.scala
+++ b/io/src/test/scala/laika/io/FileIO.scala
@@ -38,10 +38,8 @@ trait FileIO {
     input.asDocumentInput.map(_.source.input)
   }
 
-  def writeFile (f: File, content: String): IO[Unit] = {
-    val output = TextOutput.forFile[IO](Root, f, Codec.UTF8)
-    OutputRuntime.write(content, output)
-  }
+  def writeFile (f: File, content: String): IO[Unit] =
+    TextOutput.forFile[IO](Root, f, Codec.UTF8).writer(content)
 
   def newTempDirectory: IO[File] = {
     for {

--- a/io/src/test/scala/laika/io/FileIO.scala
+++ b/io/src/test/scala/laika/io/FileIO.scala
@@ -35,7 +35,7 @@ trait FileIO {
 
   def readFile (f: File, codec: Codec): IO[String] = {
     val input = TextInput.fromFile[IO](Root, DocumentType.Markup, f, codec)
-    InputRuntime.readParserInput(input).map(_.source.input)
+    input.asDocumentInput.map(_.source.input)
   }
 
   def writeFile (f: File, content: String): IO[Unit] = {


### PR DESCRIPTION
Both `TextInput` and `TextOutput` can be expressed in terms of `F[_]` instead of using the previous indirection with an interim model. This way the upcoming switch to fs2 becomes an implementation detail. There is also a small reduction in boilerplate.

Note that the same cannot be done for `BinaryInput` or `BinaryOutput` - those APIs will need to explicitly expose `fs2.Stream` for input and `fs2.Pipe` for output.

This is a breaking change, but it's in "public-internal" API, so most users will not be affected. Parts of those API might become package-private in 1.0 to reduce the public API surface when making stronger guarantees for binary compatibility.