### PR TITLE
lift some Sync requirements to Async to prepare for fs2 migration

### DIFF
--- a/io/src/main/scala/laika/helium/builder/HeliumInputBuilder.scala
+++ b/io/src/main/scala/laika/helium/builder/HeliumInputBuilder.scala
@@ -16,7 +16,7 @@
 
 package laika.helium.builder
 
-import cats.effect.Sync
+import cats.effect.Async
 import cats.implicits._
 import laika.ast.Path.Root
 import laika.config.{ConfigBuilder, LaikaKeys}
@@ -31,7 +31,7 @@ import laika.theme.config.{EmbeddedFontFile, EmbeddedFontResource}
   */
 private[helium] object HeliumInputBuilder {
 
-  def build[F[_]: Sync] (helium: Helium): F[InputTreeBuilder[F]] = {
+  def build[F[_]: Async] (helium: Helium): F[InputTreeBuilder[F]] = {
     
     import helium._
     

--- a/io/src/main/scala/laika/helium/builder/HeliumThemeBuilder.scala
+++ b/io/src/main/scala/laika/helium/builder/HeliumThemeBuilder.scala
@@ -16,7 +16,7 @@
 
 package laika.helium.builder
 
-import cats.effect.{Resource, Sync}
+import cats.effect.{Async, Resource}
 import laika.bundle.BundleOrigin
 import laika.directive.{Blocks, DirectiveRegistry, Links, Spans, Templates}
 import laika.format.{EPUB, HTML, XSLFO}
@@ -39,7 +39,7 @@ private[helium] class HeliumThemeBuilder (helium: Helium) extends ThemeProvider 
   }
   
   
-  def build[F[_]: Sync]: Resource[F, Theme[F]] = {
+  def build[F[_]: Async]: Resource[F, Theme[F]] = {
 
     import helium._
 

--- a/io/src/main/scala/laika/helium/generate/MergedCSSGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/MergedCSSGenerator.scala
@@ -16,14 +16,14 @@
 
 package laika.helium.generate
 
-import cats.effect.Sync
+import cats.effect.Async
 import cats.implicits._
 import laika.ast.Path.Root
 import laika.io.model.InputTree
 
 private[helium] object MergedCSSGenerator {
 
-  def mergeSiteCSS[F[_]: Sync](varBlock: String): F[String] = {
+  def mergeSiteCSS[F[_]: Async](varBlock: String): F[String] = {
 
     val inputTree = InputTree[F]
       .addClasspathResource("laika/helium/css/container.css", Root / "css" / "container.css")
@@ -39,7 +39,7 @@ private[helium] object MergedCSSGenerator {
     } yield varBlock + merged
   }
 
-  def mergeEPUBCSS[F[_]: Sync](varBlock: String): F[String] = {
+  def mergeEPUBCSS[F[_]: Async](varBlock: String): F[String] = {
     
     val importantVars = 
       (1 to 5).map("syntax-wheel" + _) ++ 

--- a/io/src/main/scala/laika/io/api/TreeParser.scala
+++ b/io/src/main/scala/laika/io/api/TreeParser.scala
@@ -17,27 +17,27 @@
 package laika.io.api
 
 import cats.data.NonEmptyList
-import cats.effect.{Resource, Sync}
+import cats.effect.{Async, Resource}
 import laika.api.MarkupParser
 import laika.api.builder.{OperationConfig, ParserBuilder}
 import laika.ast.{DocumentType, StyleDeclarationSet, TemplateDocument, TextDocumentType}
 import laika.io.descriptor.ParserDescriptor
 import laika.io.model.{InputTreeBuilder, ParsedTree}
 import laika.io.ops.InputOps
-import laika.io.runtime.{ParserRuntime, Batch}
-import laika.theme.{Theme, ThemeProvider}
+import laika.io.runtime.{Batch, ParserRuntime}
 import laika.parse.markup.DocumentParser
-import laika.parse.markup.DocumentParser.{ParserError, DocumentInput}
+import laika.parse.markup.DocumentParser.{DocumentInput, ParserError}
+import laika.theme.{Theme, ThemeProvider}
 
 /** Parser for a tree of input documents.
   *
   * @author Jens Halm
   */
-class TreeParser[F[_]: Sync: Batch] (parsers: NonEmptyList[MarkupParser], val theme: Theme[F]) extends InputOps[F] {
+class TreeParser[F[_]: Async: Batch] (parsers: NonEmptyList[MarkupParser], val theme: Theme[F]) extends InputOps[F] {
 
   type Result = TreeParser.Op[F]
 
-  val F: Sync[F] = Sync[F]
+  val F: Async[F] = Async[F]
 
   val docType: TextDocumentType = DocumentType.Markup
 
@@ -62,7 +62,7 @@ object TreeParser {
   /** Builder step that allows to specify the execution context
     * for blocking IO and CPU-bound tasks.
     */
-  case class Builder[F[_]: Sync: Batch] (parsers: NonEmptyList[MarkupParser], theme: ThemeProvider) {
+  case class Builder[F[_]: Async: Batch] (parsers: NonEmptyList[MarkupParser], theme: ThemeProvider) {
 
     /** Specifies an additional parser for text markup.
       * 
@@ -96,7 +96,7 @@ object TreeParser {
     * default runtime implementation or by developing a custom runner that performs
     * the parsing based on this operation's properties.
     */
-  case class Op[F[_]: Sync: Batch] (parsers: NonEmptyList[MarkupParser], theme: Theme[F], input: InputTreeBuilder[F]) {
+  case class Op[F[_]: Async: Batch] (parsers: NonEmptyList[MarkupParser], theme: Theme[F], input: InputTreeBuilder[F]) {
 
     /** The merged configuration of all markup parsers of this operation, including the theme extensions.
       */

--- a/io/src/main/scala/laika/io/api/TreeRenderer.scala
+++ b/io/src/main/scala/laika/io/api/TreeRenderer.scala
@@ -16,11 +16,10 @@
 
 package laika.io.api
 
-import cats.effect.{Resource, Sync}
+import cats.effect.{Async, Resource, Sync}
 import laika.api.Renderer
 import laika.api.builder.OperationConfig
 import laika.ast.DocumentTreeRoot
-import laika.io.api.BinaryTreeRenderer.Builder
 import laika.io.descriptor.RendererDescriptor
 import laika.io.model.{BinaryInput, ParsedTree, RenderedTreeRoot, TreeOutput}
 import laika.io.ops.TextOutputOps
@@ -31,7 +30,7 @@ import laika.theme.{Theme, ThemeProvider}
   *
   * @author Jens Halm
   */
-class TreeRenderer[F[_]: Sync: Batch] (renderer: Renderer, theme: Theme[F]) {
+class TreeRenderer[F[_]: Async: Batch] (renderer: Renderer, theme: Theme[F]) {
 
   /** Builder step that specifies the root of the document tree to render.
     */
@@ -52,7 +51,7 @@ object TreeRenderer {
 
   /** Builder step that allows to specify the execution context for blocking IO and CPU-bound tasks.
     */
-  class Builder[F[_]: Sync: Batch] (renderer: Renderer, theme: Resource[F, Theme[F]]) {
+  class Builder[F[_]: Async: Batch] (renderer: Renderer, theme: Resource[F, Theme[F]]) {
 
     /** Applies the specified theme to this renderer, overriding any previously specified themes.
       */
@@ -70,7 +69,7 @@ object TreeRenderer {
 
   /** Builder step that allows to specify the output to render to.
     */
-  case class OutputOps[F[_]: Sync: Batch] (renderer: Renderer,
+  case class OutputOps[F[_]: Async: Batch] (renderer: Renderer,
                                            theme: Theme[F],
                                            input: DocumentTreeRoot,
                                            staticDocuments: Seq[BinaryInput[F]]) extends TextOutputOps[F] {
@@ -92,7 +91,7 @@ object TreeRenderer {
     * It can be run by invoking the `render` method which delegates to the library's default runtime implementation
     * or by developing a custom runner that performs the rendering based on this operation's properties.
     */
-  case class Op[F[_]: Sync: Batch] (renderer: Renderer,
+  case class Op[F[_]: Async: Batch] (renderer: Renderer,
                                     theme: Theme[F],
                                     input: DocumentTreeRoot,
                                     output: TreeOutput,

--- a/io/src/main/scala/laika/io/api/TreeTransformer.scala
+++ b/io/src/main/scala/laika/io/api/TreeTransformer.scala
@@ -17,11 +17,10 @@
 package laika.io.api
 
 import cats.data.NonEmptyList
-import cats.effect.{Resource, Sync}
+import cats.effect.{Async, Resource, Sync}
 import laika.api.builder.{OperationConfig, ParserBuilder}
 import laika.api.{MarkupParser, Renderer}
 import laika.ast.{DocumentType, TextDocumentType}
-import laika.io.api.BinaryTreeRenderer.Builder
 import laika.io.api.BinaryTreeTransformer.TreeMapper
 import laika.io.descriptor.TransformerDescriptor
 import laika.io.model.{InputTreeBuilder, ParsedTree, RenderedTreeRoot, TreeOutput}
@@ -33,14 +32,14 @@ import laika.theme.{Theme, ThemeProvider}
   *
   * @author Jens Halm
   */
-class TreeTransformer[F[_]: Sync: Batch] (parsers: NonEmptyList[MarkupParser],
+class TreeTransformer[F[_]: Async: Batch] (parsers: NonEmptyList[MarkupParser],
                                           renderer: Renderer,
                                           theme: Theme[F],
                                           mapper: TreeMapper[F]) extends InputOps[F] {
 
   type Result = TreeTransformer.OutputOps[F]
 
-  val F: Sync[F] = Sync[F]
+  val F: Async[F] = Async[F]
 
   val docType: TextDocumentType = DocumentType.Markup
 
@@ -61,7 +60,7 @@ object TreeTransformer {
   /** Builder step that allows to specify the execution context
     * for blocking IO and CPU-bound tasks.
     */
-  case class Builder[F[_]: Sync: Batch] (parsers: NonEmptyList[MarkupParser],
+  case class Builder[F[_]: Async: Batch] (parsers: NonEmptyList[MarkupParser],
                                          renderer: Renderer,
                                          theme: ThemeProvider,
                                          mapper: TreeMapper[F]) extends TreeMapperOps[F] {
@@ -101,7 +100,7 @@ object TreeTransformer {
 
   /** Builder step that allows to specify the output to render to.
     */
-  case class OutputOps[F[_]: Sync: Batch] (parsers: NonEmptyList[MarkupParser],
+  case class OutputOps[F[_]: Async: Batch] (parsers: NonEmptyList[MarkupParser],
                                            renderer: Renderer,
                                            theme: Theme[F],
                                            input: InputTreeBuilder[F],
@@ -121,7 +120,7 @@ object TreeTransformer {
     * default runtime implementation or by developing a custom runner that performs
     * the transformation based on this operation's properties.
     */
-  case class Op[F[_]: Sync: Batch] (parsers: NonEmptyList[MarkupParser],
+  case class Op[F[_]: Async: Batch] (parsers: NonEmptyList[MarkupParser],
                                     renderer: Renderer,
                                     theme: Theme[F],
                                     input: InputTreeBuilder[F],

--- a/io/src/main/scala/laika/io/config/IncludeHandler.scala
+++ b/io/src/main/scala/laika/io/config/IncludeHandler.scala
@@ -18,8 +18,7 @@ package laika.io.config
 
 import java.io.File
 import java.net.URL
-
-import cats.effect.Sync
+import cats.effect.{Async, Sync}
 import cats.implicits._
 import laika.config.Config.IncludeMap
 import laika.config.{ConfigParser, ConfigResourceError}
@@ -45,7 +44,7 @@ object IncludeHandler {
     * be mapped to the requested resource as a `Left`. Successfully loaded and parsed
     * resources appear in the result map as a `Right`.
     */
-  def load[F[_]: Sync : Batch] (includes: Seq[RequestedInclude]): F[IncludeMap] = 
+  def load[F[_]: Async : Batch] (includes: Seq[RequestedInclude]): F[IncludeMap] = 
     
     if (includes.isEmpty) Sync[F].pure(Map.empty) else {
       

--- a/io/src/main/scala/laika/io/config/ResourceLoader.scala
+++ b/io/src/main/scala/laika/io/config/ResourceLoader.scala
@@ -18,14 +18,12 @@ package laika.io.config
 
 import java.io.{File, FileNotFoundException, InputStream}
 import java.net.URL
-
-import cats.effect.Sync
-import cats.implicits._
+import cats.effect.{Async, Sync}
+import cats.syntax.all._
 import laika.ast.DocumentType
 import laika.ast.Path.Root
 import laika.config.ConfigResourceError
 import laika.io.model.TextInput
-import laika.io.runtime.InputRuntime
 
 import scala.io.Codec
 
@@ -41,7 +39,7 @@ object ResourceLoader {
     * If it does exist, but fails to load or parse correctly the result will be `Some(Left(...))`,
     * successfully parsed resources will be returned as `Some(Right(...))`.
     */
-  def loadFile[F[_]: Sync] (file: String): F[Option[Either[ConfigResourceError, String]]] = 
+  def loadFile[F[_]: Async] (file: String): F[Option[Either[ConfigResourceError, String]]] = 
     loadFile(new File(file))
 
   /** Load the specified file (which may be a file on the file system or a classpath resource).
@@ -50,7 +48,7 @@ object ResourceLoader {
     * If it does exist, but fails to load or parse correctly the result will be `Some(Left(...))`,
     * successfully parsed resources will be returned as `Some(Right(...))`.
     */
-  def loadFile[F[_]: Sync] (file: File): F[Option[Either[ConfigResourceError, String]]] = {
+  def loadFile[F[_]: Async] (file: File): F[Option[Either[ConfigResourceError, String]]] = {
     
     def load: F[Either[ConfigResourceError, String]] = {
       val input = TextInput.fromFile[F](Root, DocumentType.Config, file, Codec.UTF8)
@@ -74,7 +72,7 @@ object ResourceLoader {
     * If it does exist, but fails to load or parse correctly the result will be `Some(Left(...))`,
     * successfully parsed resources will be returned as `Some(Right(...))`.
     */
-  def loadClasspathResource[F[_]: Sync] (resource: String): F[Option[Either[ConfigResourceError, String]]] = 
+  def loadClasspathResource[F[_]: Async] (resource: String): F[Option[Either[ConfigResourceError, String]]] = 
     Option(getClass.getClassLoader.getResource(resource)) match {
       case Some(url) => loadFile(url.getFile)
       case None => Sync[F].pure(None)

--- a/io/src/main/scala/laika/io/descriptor/TransformerDescriptor.scala
+++ b/io/src/main/scala/laika/io/descriptor/TransformerDescriptor.scala
@@ -16,9 +16,9 @@
 
 package laika.io.descriptor
 
-import cats.implicits._
 import cats.data.NonEmptyList
-import cats.effect.{Async, Sync}
+import cats.effect.Async
+import cats.implicits._
 import laika.ast.Path.Root
 import laika.ast.{DocumentTree, DocumentTreeRoot}
 import laika.io.api.{BinaryTreeRenderer, BinaryTreeTransformer, TreeParser, TreeRenderer, TreeTransformer}
@@ -72,7 +72,7 @@ object TransformerDescriptor {
       renderer.renderFormatted
     )
   
-  def create[F[_]: Sync: Batch] (op: TreeTransformer.Op[F]): F[TransformerDescriptor] = for {
+  def create[F[_]: Async: Batch] (op: TreeTransformer.Op[F]): F[TransformerDescriptor] = for {
     parserDesc <- ParserDescriptor.create(TreeParser.Op(op.parsers, op.theme, op.input))
     renderDesc <- RendererDescriptor.create(TreeRenderer.Op(op.renderer, op.theme, DocumentTreeRoot(DocumentTree(Root, Nil)), op.output, Nil))
   } yield apply(parserDesc, renderDesc)

--- a/io/src/main/scala/laika/io/implicits.scala
+++ b/io/src/main/scala/laika/io/implicits.scala
@@ -22,7 +22,7 @@ import laika.api.builder._
 import laika.factory.BinaryPostProcessorBuilder
 import laika.helium.Helium
 import laika.io.api._
-import laika.io.ops.{AsyncIOBuilderOps, SyncIOBuilderOps}
+import laika.io.ops.IOBuilderOps
 import laika.io.runtime.Batch
 
 /** Implicits that add `sequential[F[_]]` and `parallel[F[_]]` methods to all builder instances for parsers, 
@@ -68,35 +68,35 @@ import laika.io.runtime.Batch
   */
 object implicits {
 
-  implicit class ImplicitParserOps (val builder: ParserBuilder) extends SyncIOBuilderOps[TreeParser.Builder] {
+  implicit class ImplicitParserOps (val builder: ParserBuilder) extends IOBuilderOps[TreeParser.Builder] {
 
-    protected def build[F[_]: Sync: Batch]: TreeParser.Builder[F] =
+    protected def build[F[_]: Async: Batch]: TreeParser.Builder[F] =
       new TreeParser.Builder[F](NonEmptyList.of(builder.build), Helium.defaults.build)
   }
 
-  implicit class ImplicitTextRendererOps (val builder: RendererBuilder[_]) extends SyncIOBuilderOps[TreeRenderer.Builder] {
+  implicit class ImplicitTextRendererOps (val builder: RendererBuilder[_]) extends IOBuilderOps[TreeRenderer.Builder] {
 
-    protected def build[F[_]: Sync: Batch]: TreeRenderer.Builder[F] =
+    protected def build[F[_]: Async: Batch]: TreeRenderer.Builder[F] =
       new TreeRenderer.Builder[F](builder.build, Helium.defaults.build.build)
   }
 
-  implicit class ImplicitTextTransformerOps (val builder: TransformerBuilder[_]) extends SyncIOBuilderOps[TreeTransformer.Builder] {
+  implicit class ImplicitTextTransformerOps (val builder: TransformerBuilder[_]) extends IOBuilderOps[TreeTransformer.Builder] {
 
-    protected def build[F[_]: Sync: Batch]: TreeTransformer.Builder[F] = {
+    protected def build[F[_]: Async: Batch]: TreeTransformer.Builder[F] = {
       val transformer = builder.build
       new TreeTransformer.Builder[F](
         NonEmptyList.of(transformer.parser), transformer.renderer, Helium.defaults.build, Kleisli(Sync[F].pure))
     }
   }
 
-  implicit class ImplicitBinaryRendererOps (val builder: TwoPhaseRendererBuilder[_, BinaryPostProcessorBuilder]) extends AsyncIOBuilderOps[BinaryTreeRenderer.Builder] {
+  implicit class ImplicitBinaryRendererOps (val builder: TwoPhaseRendererBuilder[_, BinaryPostProcessorBuilder]) extends IOBuilderOps[BinaryTreeRenderer.Builder] {
 
     protected def build[F[_]: Async: Batch]: BinaryTreeRenderer.Builder[F] = {
       new BinaryTreeRenderer.Builder[F](builder.twoPhaseFormat, builder.config, Helium.defaults.build.build)
     }
   }
 
-  implicit class ImplicitBinaryTransformerOps (val builder: TwoPhaseTransformerBuilder[_, BinaryPostProcessorBuilder]) extends AsyncIOBuilderOps[BinaryTreeTransformer.Builder] {
+  implicit class ImplicitBinaryTransformerOps (val builder: TwoPhaseTransformerBuilder[_, BinaryPostProcessorBuilder]) extends IOBuilderOps[BinaryTreeTransformer.Builder] {
 
     protected def build[F[_]: Async: Batch]: BinaryTreeTransformer.Builder[F] = {
       val parser = new ParserBuilder(builder.markupFormat, builder.config).build

--- a/io/src/main/scala/laika/io/model/Output.scala
+++ b/io/src/main/scala/laika/io/model/Output.scala
@@ -18,7 +18,7 @@ package laika.io.model
 
 import java.io._
 import cats.Applicative
-import cats.effect.{Resource, Sync}
+import cats.effect.{Async, Resource, Sync}
 import laika.ast._
 import laika.io.runtime.OutputRuntime
 
@@ -42,7 +42,7 @@ object TextOutput {
   def noOp[F[_]: Applicative] (path: Path): TextOutput[F] =
     TextOutput[F](path, _ => Applicative[F].unit)
     
-  def forFile[F[_]: Sync] (path: Path, file: File, codec: Codec): TextOutput[F] =
+  def forFile[F[_]: Async] (path: Path, file: File, codec: Codec): TextOutput[F] =
     TextOutput[F](path, writeAll(OutputRuntime.textFileResource(file, codec)), Some(file))
     
   def forStream[F[_]: Sync] (path: Path, stream: F[OutputStream], codec: Codec, autoClose: Boolean): TextOutput[F] =

--- a/io/src/main/scala/laika/io/ops/IOBuilderOps.scala
+++ b/io/src/main/scala/laika/io/ops/IOBuilderOps.scala
@@ -23,44 +23,7 @@ import laika.io.runtime.Batch
   *
   * @author Jens Halm
   */
-abstract class SyncIOBuilderOps[T[_[_]]] {
-
-  /** Creates a builder for sequential execution.
-    */
-  def sequential[F[_]: Sync]: T[F] = {
-    implicit val runtime: Batch[F] = Batch.sequential
-    build
-  }
-
-  /** Creates a builder for parallel execution.
-    *
-    * This builder creates instances with a level of parallelism matching the available cores.
-    * For explicit control of parallelism use the other `parallel` method.
-    */
-  def parallel[F[_]: Async]: T[F] = parallel(Runtime.getRuntime.availableProcessors)
-
-  /** Creates a builder for parallel execution.
-    *
-    * This builder creates instances with the specified level of parallelism.
-    */
-  def parallel[F[_]: Async](parallelism: Int): T[F] = {
-    implicit val runtime: Batch[F] = Batch.parallel(parallelism)
-    build
-  }
-
-  protected def build[F[_]: Sync: Batch]: T[F]
-  
-}
-
-/** Builder step that allows to choose between sequential and parallel execution and specify the effect type.
-  * 
-  * This API has the additional requirement that even sequential execution requires `Async`,
-  * reflecting the needs of binary renderers which might integrate with impure tools that require
-  * the use of a `Dispatcher`.
-  *
-  * @author Jens Halm
-  */
-abstract class AsyncIOBuilderOps[T[_[_]]] {
+abstract class IOBuilderOps[T[_[_]]] {
 
   /** Creates a builder for sequential execution.
     */

--- a/io/src/main/scala/laika/io/ops/InputOps.scala
+++ b/io/src/main/scala/laika/io/ops/InputOps.scala
@@ -16,13 +16,11 @@
 
 package laika.io.ops
 
-import java.io.File
-
-import cats.effect.Sync
+import cats.effect.Async
 import laika.api.builder.OperationConfig
 import laika.io.model.{DirectoryInput, InputTree, InputTreeBuilder}
-import laika.io.runtime.DirectoryScanner
 
+import java.io.File
 import scala.io.Codec
 
 /** API for specifying the tree of character inputs for a parsing operation.
@@ -34,7 +32,7 @@ import scala.io.Codec
   */
 trait InputOps[F[_]] {
 
-  def F: Sync[F]
+  def F: Async[F]
 
   type FileFilter = File => Boolean
 

--- a/io/src/main/scala/laika/io/runtime/DirectoryScanner.scala
+++ b/io/src/main/scala/laika/io/runtime/DirectoryScanner.scala
@@ -16,8 +16,9 @@
 
 package laika.io.runtime
 
-import java.nio.file.{Files, Path => JPath}
+import cats.effect.kernel.Async
 
+import java.nio.file.{Files, Path => JPath}
 import cats.effect.{Resource, Sync}
 import cats.implicits._
 import laika.ast.DocumentType.Static
@@ -41,7 +42,7 @@ object DirectoryScanner {
   
   /** Scans the specified directory and transforms it into a generic InputCollection.
     */
-  def scanDirectories[F[_]: Sync] (input: DirectoryInput): F[InputTree[F]] = {
+  def scanDirectories[F[_]: Async] (input: DirectoryInput): F[InputTree[F]] = {
     val sourcePaths: Seq[String] = input.directories map (_.getAbsolutePath)
     join(input.directories.map(d => scanDirectory[F, InputTree[F]](d.toPath)(asInputCollection(input.mountPoint, input))))
       .map(_.copy(sourcePaths = sourcePaths))
@@ -52,7 +53,7 @@ object DirectoryScanner {
     .sequence
     .map(_.reduceLeftOption(_ ++ _).getOrElse(InputTree.empty))
 
-  private def asInputCollection[F[_]: Sync] (path: Path, input: DirectoryInput)(entries: Seq[JPath]): F[InputTree[F]] = {
+  private def asInputCollection[F[_]: Async] (path: Path, input: DirectoryInput)(entries: Seq[JPath]): F[InputTree[F]] = {
 
     def toCollection (filePath: JPath): F[InputTree[F]] = {
 

--- a/io/src/main/scala/laika/io/runtime/ParserRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/ParserRuntime.scala
@@ -17,9 +17,8 @@
 package laika.io.runtime
 
 import java.io.File
-
 import cats.data.{NonEmptyList, ValidatedNel}
-import cats.effect.Sync
+import cats.effect.{Async, Sync}
 import cats.implicits._
 import laika.api.MarkupParser
 import laika.ast.Path.Root
@@ -31,7 +30,7 @@ import laika.io.config.IncludeHandler
 import laika.io.config.IncludeHandler.RequestedInclude
 import laika.io.model.{InputTree, ParsedTree, TextInput}
 import laika.parse.hocon.{IncludeFile, IncludeResource, ValidStringValue}
-import laika.parse.markup.DocumentParser.{InvalidDocuments, ParserError, DocumentInput}
+import laika.parse.markup.DocumentParser.{DocumentInput, InvalidDocuments, ParserError}
 
 /** Internal runtime for parser operations, for parallel and sequential execution. 
   * 
@@ -41,7 +40,7 @@ object ParserRuntime {
   
   /** Run the specified parser operation for an entire input tree, producing an AST tree.
     */
-  def run[F[_]: Sync: Batch] (op: TreeParser.Op[F]): F[ParsedTree[F]] = {
+  def run[F[_]: Async: Batch] (op: TreeParser.Op[F]): F[ParsedTree[F]] = {
     
     import DocumentType.{Config => ConfigType, _}
     import TreeResultBuilder._

--- a/io/src/main/scala/laika/io/runtime/RendererRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/RendererRuntime.scala
@@ -42,10 +42,10 @@ object RendererRuntime {
 
   /** Process the specified render operation for an entire input tree and a character output format.
     */
-  def run[F[_]: Sync: Batch] (op: TreeRenderer.Op[F]): F[RenderedTreeRoot[F]] = 
+  def run[F[_]: Async: Batch] (op: TreeRenderer.Op[F]): F[RenderedTreeRoot[F]] = 
     run(op, op.theme.inputs, TemplateContext(op.renderer.format.fileSuffix, op.renderer.format.description.toLowerCase))
 
-  private def run[F[_]: Sync: Batch] (op: TreeRenderer.Op[F], themeInputs: InputTree[F], context: TemplateContext): F[RenderedTreeRoot[F]] = {  
+  private def run[F[_]: Async: Batch] (op: TreeRenderer.Op[F], themeInputs: InputTree[F], context: TemplateContext): F[RenderedTreeRoot[F]] = {  
     
     def validatePaths (staticDocs: Seq[BinaryInput[F]]): F[Unit] = {
       val paths = op.input.allDocuments.map(_.path) ++ staticDocs.map(_.path)

--- a/io/src/main/scala/laika/io/runtime/TransformerRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/TransformerRuntime.scala
@@ -16,17 +16,17 @@
 
 package laika.io.runtime
 
-import java.io.File
-
 import cats.Monad
-import cats.effect.{Async, Sync}
+import cats.effect.Async
 import cats.implicits._
 import laika.bundle.ExtensionBundle
 import laika.factory.Format
 import laika.io.api.{BinaryTreeRenderer, BinaryTreeTransformer, TreeParser, TreeRenderer, TreeTransformer}
-import laika.io.model.{DirectoryInput, DirectoryOutput, InputTree, ParsedTree, RenderedTreeRoot, TreeOutput}
+import laika.io.model.{DirectoryInput, DirectoryOutput, InputTree, RenderedTreeRoot, TreeOutput}
 import laika.theme.Theme
 import laika.theme.Theme.TreeProcessor
+
+import java.io.File
 
 /** Internal runtime for transform operations, for text and binary output as well
   * as parallel and sequential execution. 
@@ -48,7 +48,7 @@ object TransformerRuntime {
 
   /** Process the specified transform operation for an entire input tree and a character output format.
     */
-  def run[F[_]: Sync: Batch] (op: TreeTransformer.Op[F]): F[RenderedTreeRoot[F]] = for {
+  def run[F[_]: Async: Batch] (op: TreeTransformer.Op[F]): F[RenderedTreeRoot[F]] = for {
     tree       <- TreeParser.Op(op.parsers, op.theme, op.input.withFileFilter(fileFilterFor(op.output))).parse
     mappedTree <- op.mapper.run(tree)
     res        <- TreeRenderer.Op(op.renderer, themeWithoutInputs(op.theme), mappedTree.root, op.output, mappedTree.staticDocuments).render

--- a/io/src/main/scala/laika/io/runtime/VersionedLinkTargets.scala
+++ b/io/src/main/scala/laika/io/runtime/VersionedLinkTargets.scala
@@ -17,7 +17,7 @@
 package laika.io.runtime
 
 import cats.data.NonEmptyChain
-import cats.effect.Sync
+import cats.effect.{Async, Sync}
 import cats.syntax.all._
 import laika.collection.TransitionalCollectionOps._
 import laika.ast.DocumentType.{Ignored, Static}
@@ -33,7 +33,7 @@ import scala.io.Codec
 
 private[runtime] object VersionedLinkTargets {
 
-  private def scanTargetDirectory[F[_]: Sync] (versions: Versions, config: VersionScannerConfig): F[Map[String, Seq[Path]]] = {
+  private def scanTargetDirectory[F[_]: Async] (versions: Versions, config: VersionScannerConfig): F[Map[String, Seq[Path]]] = {
     val existingVersions = (versions.newerVersions ++ versions.olderVersions).map(_.pathSegment).toSet
     val excluded = config.exclude.flatMap { exclude =>
       existingVersions.toSeq.map(v => Root / v / exclude.relative)
@@ -86,7 +86,7 @@ private[runtime] object VersionedLinkTargets {
       }
   }
   
-  def gatherTargets[F[_]: Sync] (versions: Versions, staticDocs: Seq[BinaryInput[F]]): F[Map[String, Seq[Path]]] =
+  def gatherTargets[F[_]: Async] (versions: Versions, staticDocs: Seq[BinaryInput[F]]): F[Map[String, Seq[Path]]] =
     (staticDocs.find(_.path == VersionInfoGenerator.path), versions.scannerConfig) match {
       case (Some(info), _)   => loadVersionInfo(info)
       case (_, Some(config)) => scanTargetDirectory(versions, config)

--- a/io/src/main/scala/laika/theme/Theme.scala
+++ b/io/src/main/scala/laika/theme/Theme.scala
@@ -17,7 +17,7 @@
 package laika.theme
 
 import cats.data.Kleisli
-import cats.effect.Sync
+import cats.effect.Async
 import laika.bundle.ExtensionBundle
 import laika.factory.Format
 import laika.io.model.{InputTree, ParsedTree}
@@ -86,7 +86,7 @@ object Theme {
     * right into the input directories.
     */
   def empty: ThemeProvider = new ThemeProvider {
-    def build[F[_]: Sync] = ThemeBuilder("Empty Theme").build
+    def build[F[_]: Async] = ThemeBuilder("Empty Theme").build
   }
 
 }

--- a/io/src/main/scala/laika/theme/ThemeBuilder.scala
+++ b/io/src/main/scala/laika/theme/ThemeBuilder.scala
@@ -16,12 +16,12 @@
 
 package laika.theme
 
-import cats.implicits._
 import cats.Monad
 import cats.data.Kleisli
-import cats.effect.{Resource, Sync}
+import cats.effect.{Async, Resource}
+import cats.implicits._
+import laika.ast.RewriteRules
 import laika.ast.RewriteRules.RewriteRulesBuilder
-import laika.ast.{DocumentCursor, RewriteRules}
 import laika.bundle.{BundleOrigin, ExtensionBundle, RenderOverrides}
 import laika.config.Config
 import laika.factory.Format
@@ -170,7 +170,7 @@ object ThemeBuilder {
     * The theme name is used in logging or the data returned by the `describe` method of the parser,
     * renderer and transformer APIs.
     */
-  def apply[F[_] : Sync] (themeName: String): ThemeBuilder[F] = 
-    new ThemeBuilder[F](themeName, Sync[F].pure(InputTree[F]), Nil, BundleBuilder(themeName), Nil)
+  def apply[F[_] : Async] (themeName: String): ThemeBuilder[F] = 
+    new ThemeBuilder[F](themeName, Async[F].pure(InputTree[F]), Nil, BundleBuilder(themeName), Nil)
 
 }

--- a/io/src/main/scala/laika/theme/ThemeProvider.scala
+++ b/io/src/main/scala/laika/theme/ThemeProvider.scala
@@ -16,7 +16,7 @@
 
 package laika.theme
 
-import cats.effect.{Resource, Sync}
+import cats.effect.{Async, Resource}
 import laika.bundle.ExtensionBundle
 import laika.factory.Format
 import laika.io.model.InputTree
@@ -37,7 +37,7 @@ trait ThemeProvider { self =>
     * For convenience, implementations of this method usually utilize a [[laika.theme.ThemeBuilder]] to construct
     * `Theme` instances, but this is not mandatory.
     */
-  def build[F[_]: Sync]: Resource[F, Theme[F]]
+  def build[F[_]: Async]: Resource[F, Theme[F]]
 
   /** Creates a new theme using this instance as a base and the provided instance as the extension.
     * 
@@ -53,7 +53,7 @@ trait ThemeProvider { self =>
     *   if present.
     */
   def extendWith (extensions: ThemeProvider): ThemeProvider = new ThemeProvider {
-    def build[F[_]: Sync] = for {
+    def build[F[_]: Async] = for {
       base <- self.build
       ext  <- extensions.build
     } yield {

--- a/io/src/test/scala/laika/io/TreeParserFileIOSpec.scala
+++ b/io/src/test/scala/laika/io/TreeParserFileIOSpec.scala
@@ -16,7 +16,7 @@
 
 package laika.io
 
-import cats.effect.{IO, Resource, Sync}
+import cats.effect.{Async, IO, Resource, Sync}
 import laika.ast.DocumentType.Ignored
 import laika.ast.{/, Document, DocumentTree, DocumentTreeRoot, Paragraph, Path, RootElement, TemplateDocument, TemplateRoot, TemplateString}
 import laika.ast.Path.Root
@@ -153,12 +153,12 @@ class TreeParserFileIOSpec
              extraCheck: DocumentTreeRoot => Unit = _ => ()): IO[Unit] = {
       
       val themeInputs: TestThemeBuilder.Inputs = new TestThemeBuilder.Inputs {
-        def build[G[_]: Sync] = builder.addDoc(InputTree[G])
+        def build[G[_]: Async] = builder.addDoc(InputTree[G])
       }
       val baseTheme = TestThemeBuilder.forInputs(themeInputs)
       val theme = themeExtension.fold(baseTheme) { extBuilder =>
         val themeExtInputs: TestThemeBuilder.Inputs = new TestThemeBuilder.Inputs {
-          def build[G[_]: Sync] = extBuilder.addDoc(InputTree[G])
+          def build[G[_]: Async] = extBuilder.addDoc(InputTree[G])
         }
         baseTheme.extendWith(TestThemeBuilder.forInputs(themeExtInputs))
       }

--- a/io/src/test/scala/laika/io/helper/TestThemeBuilder.scala
+++ b/io/src/test/scala/laika/io/helper/TestThemeBuilder.scala
@@ -16,7 +16,7 @@
 
 package laika.io.helper
 
-import cats.effect.Sync
+import cats.effect.Async
 import laika.ast.Document
 import laika.bundle.ExtensionBundle
 import laika.factory.Format
@@ -27,29 +27,29 @@ import laika.theme.{ThemeBuilder, ThemeProvider, TreeProcessorBuilder}
 object TestThemeBuilder {
   
   trait Inputs {
-    def build[F[_]: Sync]: InputTreeBuilder[F]
+    def build[F[_]: Async]: InputTreeBuilder[F]
   }
   
   def forInputs (themeInputs: Inputs): ThemeProvider = new ThemeProvider {
-    def build[F[_]: Sync] = ThemeBuilder("test").addInputs(themeInputs.build).build
+    def build[F[_]: Async] = ThemeBuilder("test").addInputs(themeInputs.build).build
   }
 
   def forBundle (bundle: ExtensionBundle): ThemeProvider = new ThemeProvider {
-    def build[F[_]: Sync] = ThemeBuilder("test").addExtensions(bundle).build
+    def build[F[_]: Async] = ThemeBuilder("test").addExtensions(bundle).build
   }
 
   def forBundles (bundles: Seq[ExtensionBundle]): ThemeProvider = new ThemeProvider {
-    def build[F[_]: Sync] = ThemeBuilder("test").addExtensions(bundles:_*).build
+    def build[F[_]: Async] = ThemeBuilder("test").addExtensions(bundles:_*).build
   }
   
   def forDocumentMapper (f: Document => Document): ThemeProvider = new ThemeProvider {
-    def build[F[_]: Sync] = ThemeBuilder("test")
+    def build[F[_]: Async] = ThemeBuilder("test")
       .processTree { case _ => TreeProcessorBuilder[F].mapDocuments(f) }
       .build
   }
 
   def forDocumentMapper (format: Format)(f: Document => Document): ThemeProvider = new ThemeProvider {
-    def build[F[_]: Sync] = {
+    def build[F[_]: Async] = {
       ThemeBuilder("test")
         .processTree(TreeProcessorBuilder[F].mapDocuments(f), format)
         .build


### PR DESCRIPTION
This is a trivial PR that merely exists to make subsequent PRs for fs2 migration easier to review without all the noise of the type signature changes. They are needed as fs2's `Files` type requires an `Async` instance.

Only interesting change here is that the distinction between `SyncIOBuilderOps` and `AsyncIOBuilderOps` became obsolete, so that there is now only an `IOBuilderOps` trait, 