### PR TITLE
add canonicalLink attribute to page metadata

### DIFF
--- a/core/shared/src/main/scala/laika/ast/DocumentMetadata.scala
+++ b/core/shared/src/main/scala/laika/ast/DocumentMetadata.scala
@@ -19,6 +19,8 @@ package laika.ast
 import laika.config.{ConfigDecoder, ConfigEncoder, DefaultKey, LaikaKeys}
 import laika.time.PlatformDateTime
 
+import java.net.URI
+
 /** Metadata associated with a document.
   * 
   * @author Jens Halm
@@ -30,7 +32,8 @@ case class DocumentMetadata (title: Option[String] = None,
                              language: Option[String] = None,
                              datePublished: Option[PlatformDateTime.Type] = None,
                              dateModified: Option[PlatformDateTime.Type] = None,
-                             version: Option[String] = None) {
+                             version: Option[String] = None,
+                             canonicalLink: Option[URI] = None) {
 
   /** Populates all empty Options in this instance with the provided defaults in case they are non-empty
     */
@@ -42,7 +45,8 @@ case class DocumentMetadata (title: Option[String] = None,
     language.orElse(defaults.language),
     datePublished.orElse(defaults.datePublished),
     dateModified.orElse(defaults.dateModified),
-    version.orElse(defaults.version)
+    version.orElse(defaults.version),
+    canonicalLink.orElse(defaults.canonicalLink)
   )
   
   override def equals (obj: Any): Boolean = obj match {
@@ -53,8 +57,9 @@ case class DocumentMetadata (title: Option[String] = None,
         other.authors == authors &&
         other.language == language &&
         other.datePublished.toString == datePublished.toString && // equals does not work properly on js.Date
-        other.dateModified.toString == dateModified.toString && // equals does not work properly on js.Date
-        other.version == version
+        other.dateModified.toString == dateModified.toString &&
+        other.version == version &&
+        other.canonicalLink == canonicalLink
     case _ => false
   } 
 
@@ -73,8 +78,10 @@ object DocumentMetadata {
       datePublished <- config.getOpt[PlatformDateTime.Type]("datePublished")
       dateModified  <- config.getOpt[PlatformDateTime.Type]("dateModified")
       version       <- config.getOpt[String]("version")
+      canonicalLink <- config.getOpt[URI]("canonicalLink")
     } yield {
-      DocumentMetadata(title, description, identifier, authors ++ author.toSeq, lang, datePublished, dateModified, version)
+      DocumentMetadata(title, description, identifier, authors ++ author.toSeq, 
+        lang, datePublished, dateModified, version, canonicalLink)
     }
   }
   implicit val encoder: ConfigEncoder[DocumentMetadata] = ConfigEncoder[DocumentMetadata] { metadata =>
@@ -87,6 +94,7 @@ object DocumentMetadata {
       .withValue("datePublished", metadata.datePublished)
       .withValue("dateModified", metadata.dateModified)
       .withValue("version", metadata.version)
+      .withValue("canonicalLink", metadata.canonicalLink)
       .build
   }
 

--- a/core/shared/src/main/scala/laika/config/ConfigDecoder.scala
+++ b/core/shared/src/main/scala/laika/config/ConfigDecoder.scala
@@ -16,13 +16,13 @@
 
 package laika.config
 
-import java.util.Date
 import cats.data.NonEmptyChain
 import cats.implicits._
 import laika.ast.RelativePath.CurrentDocument
 import laika.ast.{ExternalTarget, InternalTarget, Path, PathBase, RelativePath, Target}
 import laika.time.PlatformDateTime
 
+import java.net.URI
 import scala.util.Try
 
 /** A type class that can decode a ConfigValue to an instance of T.
@@ -117,6 +117,10 @@ object ConfigDecoder {
 
   implicit lazy val date: ConfigDecoder[PlatformDateTime.Type] = string.flatMap { dateString =>
     PlatformDateTime.parse(dateString).left.map(err => DecodingError(s"Invalid date format: $err"))
+  }
+
+  implicit lazy val uri: ConfigDecoder[URI] = string.flatMap { uriString =>
+    Try(new URI(uriString)).toEither.left.map(err => DecodingError(s"Invalid URI format: $err"))
   }
 
   implicit def seq[T] (implicit elementDecoder: ConfigDecoder[T]): ConfigDecoder[Seq[T]] = new ConfigDecoder[Seq[T]] {

--- a/core/shared/src/main/scala/laika/config/ConfigEncoder.scala
+++ b/core/shared/src/main/scala/laika/config/ConfigEncoder.scala
@@ -16,11 +16,11 @@
 
 package laika.config
 
-import java.util.Date
-
 import cats.data.NonEmptyChain
 import laika.ast.{Element, Path}
 import laika.time.PlatformDateTime
+
+import java.net.URI
 
 /** A type class that can encode a value of type T as a ConfigValue.
   * 
@@ -60,6 +60,10 @@ object ConfigEncoder {
   implicit val date: ConfigEncoder[PlatformDateTime.Type] = new ConfigEncoder[PlatformDateTime.Type] {
     def apply (value: PlatformDateTime.Type) = 
       StringValue(PlatformDateTime.format(value, "yyyy-MM-dd'T'HH:mm:ss").getOrElse(value.toString))
+  }
+
+  implicit val uri: ConfigEncoder[URI] = new ConfigEncoder[URI] {
+    def apply (value: URI) = StringValue(value.toString)
   }
 
   implicit val astValue: ConfigEncoder[Element] = new ConfigEncoder[Element] {

--- a/docs/src/03-preparing-content/03-theme-settings.md
+++ b/docs/src/03-preparing-content/03-theme-settings.md
@@ -475,6 +475,7 @@ laika.metadata {
   authors = ["Helena North", "Maria South"]
   datePublished = "2012-10-10T12:00:00"
   dateModified = "2014-07-07T12:00:00"
+  canonicalLink = "http://foo.org/page.html"
 }
 %}
 ```
@@ -485,9 +486,14 @@ These values can then be used in templates like other substitution variables:
 <meta itemprop="datePublished" content="${laika.metadata.datePublished}">
 ```
 
-The page-level metadata is a core feature and available even when not using the Helium theme.
+The `canonicalLink` property will automatically render as a `link rel="canonical"...` tag in the HTML output
+when using the Helium theme.
+
+Otherwise the page-level metadata is a core feature and available even when not using the Helium theme.
 Note that, at the moment, `dateModified` is not auto-populated from the file system and has to be set manually.
 In many cases this is desirable anyway, as not every file modification represents a meaningful change to the user.
+
+
 
 
 Navigation, Links & Favicons

--- a/io/src/main/resources/laika/helium/templates/default.template.html
+++ b/io/src/main/resources/laika/helium/templates/default.template.html
@@ -12,6 +12,9 @@
     @:for(laika.site.metadata.description)
       <meta name="description" content="${_}"/>
     @:@
+    @:for(laika.metadata.canonicalLink)
+      <link rel="canonical" href="${_}"/>
+    @:@
     @:for(helium.favIcons)
       <link rel="icon" @:attribute(sizes, _.sizes) @:attribute(type, _.type) href="@:target(_.target)"/>
     @:@

--- a/io/src/test/scala/laika/helium/HeliumHTMLHeadSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumHTMLHeadSpec.scala
@@ -64,6 +64,14 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
   val singleDoc = Seq(
     Root / "name.md" -> "text"
   )
+  val docWithCanonicalLink = Seq(
+    Root / "name.md" ->
+      """{%
+        |  laika.metadata.canonicalLink = "http://very.canonical/"
+        |%}
+        |
+        |content""".stripMargin
+  )
   val singleVersionedDoc = Seq(
     Root / "name.md" -> "text",
     Root / "directory.conf" -> "laika.versioned = true",
@@ -202,6 +210,20 @@ class HeliumHTMLHeadSpec extends CatsEffectSuite with InputBuilder with ResultEx
       language = Some("de")
     )
     transformAndExtract(singleDoc, helium, "<html ", ">").assertEquals("""lang="de"""")
+  }
+
+  test("metadata (canonical link)") {
+    val helium = Helium.defaults
+    val expected = meta ++ """
+                             |<title></title>
+                             |<link rel="canonical" href="http://very.canonical/"/>
+                             |<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
+                             |<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/tonsky/FiraCode@1.207/distr/fira_code.css">
+                             |<link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
+                             |<link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
+                             |<script src="helium/laika-helium.js"></script>
+                             |<script> /* for avoiding page load transitions */ </script>""".stripMargin
+    transformAndExtractHead(docWithCanonicalLink, helium).assertEquals(expected)
   }
 
   test("favicons") {


### PR DESCRIPTION
This addresses part of the request in #264, but not yet the aspect of automatically setting the attribute for versioned pages.

* adds a `ConfigDecoder` and `ConfigEncoder` for `java.net.URI`.
* adds a new `canonicalLink: URI` property to the `DocumentMetadata` class
* the default theme in Helium now renders a `<link rel="canonical"...` element when this attribute is set on a page

Like all attributes in `DocumentMetadata` it is most commonly set in a configuration header in markup documents:

```
{%
    laika.metadata.canonicalLink = "http://foo.org/page.html"
%}
```