### PR TITLE
Introduce FilePath API and restructure VirtualPath API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,6 +65,7 @@ val munit      = "org.scalameta"          %% "munit"       % versions.munit     
 val jTidy      = "net.sf.jtidy"           %  "jtidy"       % versions.jTidy     % "test"
 
 val catsEffect = "org.typelevel"          %% "cats-effect"         % versions.catsEffect
+val fs2IO      = "co.fs2"                 %% "fs2-io"              % versions.fs2
 val munitCE3   = "org.typelevel"          %% "munit-cats-effect-3" % versions.munitCE3 % "test"
 
 val fop        = "org.apache.xmlgraphics" %  "fop"         % versions.fop
@@ -123,7 +124,7 @@ lazy val io = project.in(file("io"))
   .settings(publishSettings)
   .settings(
     name := "laika-io",
-    libraryDependencies ++= Seq(catsEffect, munit, munitCE3)
+    libraryDependencies ++= Seq(catsEffect, fs2IO, munit, munitCE3)
   )
   
 lazy val pdf = project.in(file("pdf"))

--- a/core/jvm/src/test/scala/laika/markdown/MarkdownToHTMLSpec.scala
+++ b/core/jvm/src/test/scala/laika/markdown/MarkdownToHTMLSpec.scala
@@ -17,7 +17,7 @@
 package laika.markdown
 
 import laika.api.Transformer
-import laika.ast.{ExternalTarget, Header, Id, InvalidSpan, LinkPathReference, Literal, MessageFilter, NoOpt, PathBase, QuotedBlock, RelativePath, Replace, SpanLink, Target, Text, Title}
+import laika.ast.{ExternalTarget, Header, Id, InvalidSpan, LinkPathReference, Literal, MessageFilter, NoOpt, VirtualPath, QuotedBlock, RelativePath, Replace, SpanLink, Target, Text, Title}
 import laika.file.FileIO
 import laika.format.{HTML, Markdown}
 import laika.html.TidyHTML
@@ -48,7 +48,7 @@ class MarkdownToHTMLSpec extends FunSuite {
   }
 
   def transformAndCompare (name: String): Unit = {
-    def renderPath(relPath: PathBase): Target = 
+    def renderPath(relPath: VirtualPath): Target = 
       if (relPath == RelativePath.CurrentDocument()) ExternalTarget("") else ExternalTarget(relPath.toString)
     val path = FileIO.classPathResourcePath("/markdownTestSuite") + "/" + name
     val input = FileIO.readFile(path + ".md")

--- a/core/shared/src/main/scala/laika/ast/Target.scala
+++ b/core/shared/src/main/scala/laika/ast/Target.scala
@@ -50,7 +50,7 @@ object Target {
     */
   def parse (url: String): Target = 
     if (recognizedProtocols.exists(url.startsWith)) ExternalTarget(url.stripPrefix(pseudoProtocol))
-    else InternalTarget(PathBase.parse(url))
+    else InternalTarget(VirtualPath.parse(url))
 
 }
 
@@ -68,7 +68,7 @@ trait InternalTarget extends Target {
   /** The underlying path reference, which is either a relative or absolute path,
     * depending on the implementation of this trait.
     */
-  def underlying: PathBase = this match {
+  def underlying: VirtualPath = this match {
     case t: ResolvedInternalTarget => t.absolutePath
     case t: AbsoluteInternalTarget => t.path
     case t: RelativeInternalTarget => t.path
@@ -79,7 +79,7 @@ object InternalTarget {
 
   /** Creates an internal target based on the specified relative or absolute path.
     */
-  def apply (path: PathBase): InternalTarget = path match {
+  def apply (path: VirtualPath): InternalTarget = path match {
     case p: RelativePath => RelativeInternalTarget(p)
     case p: Path => AbsoluteInternalTarget(p)
   }

--- a/core/shared/src/main/scala/laika/ast/links.scala
+++ b/core/shared/src/main/scala/laika/ast/links.scala
@@ -116,13 +116,13 @@ object RawLink {
     * The string value represents a virtual path into the input tree of a transformation
     * and may be absolute (starting with '/') or relative.
     */
-  def internal (path: String): RawLink = internal(PathBase.parse(path))
+  def internal (path: String): RawLink = internal(VirtualPath.parse(path))
 
   /** Creates a new instance for the specified internal link.
     * The path value represents a virtual path into the input tree of a transformation
     * and may be absolute or relative.
     */
-  def internal (path: PathBase): RawLink = apply(InternalTarget(path))
+  def internal (path: VirtualPath): RawLink = apply(InternalTarget(path))
 
   /** Creates a new instance for the specified external URL.
     */
@@ -151,13 +151,13 @@ object SpanLink {
    *  The string value represents a virtual path into the input tree of a transformation
    *  and may be absolute (starting with '/') or relative.
    */
-  def internal (path: String): Companion = internal(PathBase.parse(path))
+  def internal (path: String): Companion = internal(VirtualPath.parse(path))
 
   /** Creates a new instance for the specified internal link.
    *  The path value represents a virtual path into the input tree of a transformation
    *  and may be absolute or relative.
    */
-  def internal (path: PathBase): Companion = apply(InternalTarget(path))
+  def internal (path: VirtualPath): Companion = apply(InternalTarget(path))
 
   /** Creates a new instance for the specified external URL.
    */
@@ -210,7 +210,7 @@ object Image {
     * The path value represents a virtual path into the input tree of a transformation
     * and may be absolute or relative.
     */
-  def internal (path: PathBase, width: Option[Length] = None, height: Option[Length] = None,
+  def internal (path: VirtualPath, width: Option[Length] = None, height: Option[Length] = None,
                 alt: Option[String] = None, title: Option[String] = None): Image =
     apply(InternalTarget(path), width, height, alt, title)
 
@@ -275,13 +275,13 @@ object SVGSymbolIcon {
     * The string value represents a virtual path into the input tree of a transformation
     * and may be absolute (starting with '/') or relative.
     */
-  def internal (path: String): SVGSymbolIcon = internal(PathBase.parse(path))
+  def internal (path: String): SVGSymbolIcon = internal(VirtualPath.parse(path))
 
   /** Creates a new instance for the specified internal link.
     * The path value represents a virtual path into the input tree of a transformation
     * and may be absolute or relative.
     */
-  def internal (path: PathBase): SVGSymbolIcon = apply(InternalTarget(path))
+  def internal (path: VirtualPath): SVGSymbolIcon = apply(InternalTarget(path))
 
   /** Creates a new instance for the specified external URL.
     */
@@ -351,7 +351,7 @@ object LinkDefinition {
   */
 trait PathReference extends Reference {
   /** The content (section or document or image) this reference points to. */
-  def path: PathBase
+  def path: VirtualPath
   /** Creates the final AST element based on the resolved target. */
   def resolve(target: Target): Link
 }
@@ -362,7 +362,7 @@ trait PathReference extends Reference {
   * differ in more than just the file suffix, depending on configuration.
   */
 case class LinkPathReference(content: Seq[Span],
-                             path: PathBase,
+                             path: VirtualPath,
                              source: SourceFragment,
                              title: Option[String] = None,
                              options: Options = NoOpt) extends PathReference with SpanContainer {
@@ -378,7 +378,7 @@ case class LinkPathReference(content: Seq[Span],
   * replace the source path with the final target path of the output document, resolving any
   * relative path references in the process.
   */
-case class ImagePathReference (path: PathBase,
+case class ImagePathReference (path: VirtualPath,
                                source: SourceFragment,
                                width: Option[Length] = None,
                                height: Option[Length] = None,

--- a/core/shared/src/main/scala/laika/ast/paths.scala
+++ b/core/shared/src/main/scala/laika/ast/paths.scala
@@ -31,7 +31,7 @@ import scala.annotation.tailrec
   * This trait is the only one within the Path API that is not sealed,
   * to allow for implementations in other modules (e.g. `FilePath` in `laika-io`).
   */
-trait GenericPath extends Product with Serializable {
+trait GenericPath {
 
   type Self <: GenericPath
 
@@ -99,7 +99,7 @@ trait GenericPath extends Product with Serializable {
   * e.g. from two different directories merged into a single virtual tree in memory
   * with some additional documents added programmatically without any file system reference.
   */
-sealed trait VirtualPath extends GenericPath {
+sealed trait VirtualPath extends GenericPath with Product with Serializable {
   
   type Self <: VirtualPath
 

--- a/core/shared/src/main/scala/laika/config/ConfigDecoder.scala
+++ b/core/shared/src/main/scala/laika/config/ConfigDecoder.scala
@@ -20,7 +20,7 @@ import java.util.Date
 import cats.data.NonEmptyChain
 import cats.implicits._
 import laika.ast.RelativePath.CurrentDocument
-import laika.ast.{ExternalTarget, InternalTarget, Path, PathBase, RelativePath, Target}
+import laika.ast.{ExternalTarget, InternalTarget, Path, VirtualPath, RelativePath, Target}
 import laika.time.PlatformDateTime
 
 import scala.util.Try
@@ -97,7 +97,7 @@ object ConfigDecoder {
     def apply (value: Traced[ConfigValue]) = valueDecoder(value).map(res => value.copy(value = res))
   }
   
-  private def resolvePath (path: PathBase, origin: Origin): Path =
+  private def resolvePath (path: VirtualPath, origin: Origin): Path =
     path match {
       case c: CurrentDocument => origin.path / c
       case p: RelativePath    => origin.path.parent / p
@@ -105,7 +105,7 @@ object ConfigDecoder {
     }
 
   implicit lazy val path: ConfigDecoder[Path] = tracedValue[String].map { tracedValue =>
-    resolvePath(PathBase.parse(tracedValue.value), tracedValue.origin)
+    resolvePath(VirtualPath.parse(tracedValue.value), tracedValue.origin)
   }
 
   implicit lazy val target: ConfigDecoder[Target] = tracedValue[String].map { tracedValue =>

--- a/core/shared/src/main/scala/laika/directive/std/ImageDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/ImageDirectives.scala
@@ -17,7 +17,7 @@
 package laika.directive.std
 
 import cats.syntax.all._
-import laika.ast.{BlockSequence, Image, InternalTarget, LengthUnit, PathBase, SpanSequence, Styles}
+import laika.ast.{BlockSequence, Image, InternalTarget, LengthUnit, VirtualPath, SpanSequence, Styles}
 import laika.directive.{Blocks, Spans}
 
 /** Provides the implementation for the image directives included in Laika.
@@ -56,7 +56,7 @@ object ImageDirectives {
       attribute("title").as[String].optional,
       cursor).mapN { (src, width, height, style, alt, title, cursor) =>
       val img = Image(
-        InternalTarget(PathBase.parse(src)).relativeTo(cursor.path),
+        InternalTarget(VirtualPath.parse(src)).relativeTo(cursor.path),
         width.map(LengthUnit.px(_)),
         height.map(LengthUnit.px(_)),
         alt,
@@ -92,7 +92,7 @@ object ImageDirectives {
       cursor).mapN { (src, width, height, style, alt, title, cursor) =>
       val options = Styles(style.getOrElse("default-image-span"))
       Image(
-        InternalTarget(PathBase.parse(src)).relativeTo(cursor.path),
+        InternalTarget(VirtualPath.parse(src)).relativeTo(cursor.path),
         width.map(LengthUnit.px(_)),
         height.map(LengthUnit.px(_)),
         alt,

--- a/core/shared/src/main/scala/laika/directive/std/NavigationTreeDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/NavigationTreeDirectives.scala
@@ -18,7 +18,7 @@ package laika.directive.std
 
 import cats.syntax.all._
 import cats.data.ValidatedNec
-import laika.ast.{Block, BlockResolver, DocumentCursor, ExternalTarget, InternalTarget, InvalidBlock, NavigationBuilderContext, NavigationItem, NavigationLink, NavigationList, NoOpt, Options, PathBase, SpanSequence, TemplateElement}
+import laika.ast.{Block, BlockResolver, DocumentCursor, ExternalTarget, InternalTarget, InvalidBlock, NavigationBuilderContext, NavigationItem, NavigationLink, NavigationList, NoOpt, Options, VirtualPath, SpanSequence, TemplateElement}
 import laika.config.{ConfigDecoder, ConfigError, Key}
 import laika.directive.{Blocks, Templates}
 import laika.parse.{GeneratedSource, SourceFragment}
@@ -153,7 +153,7 @@ object NavigationTreeDirectives {
           ManualNavigationNode(SpanSequence(title), externalTarget, children)
         }
 
-        def createGeneratedNode (internalTarget: PathBase): Either[ConfigError, NavigationNodeConfig] = for {
+        def createGeneratedNode (internalTarget: VirtualPath): Either[ConfigError, NavigationNodeConfig] = for {
           title           <- config.getOpt[String]("title")
           depth           <- config.getOpt[Int]("depth")
           excludeRoot     <- config.getOpt[Boolean]("excludeRoot")
@@ -167,7 +167,7 @@ object NavigationTreeDirectives {
           if (targetStr.startsWith("http:") || targetStr.startsWith("https:") || targetStr.startsWith("mailto:"))
             createManualNode(Some(ExternalTarget(targetStr)))
           else
-            createGeneratedNode(PathBase.parse(targetStr))
+            createGeneratedNode(VirtualPath.parse(targetStr))
         }
       }
     }
@@ -182,7 +182,7 @@ object NavigationTreeDirectives {
     * @param excludeRoot indicates whether the root node should be excluded in which case the first-level children will be inserted into the parent node
     * @param excludeSections indicates whether sections within documents should be excluded in automatic entries
     */
-  case class GeneratedNavigationNode (target: PathBase,
+  case class GeneratedNavigationNode (target: VirtualPath,
                                       title: Option[SpanSequence] = None,
                                       depth: Option[Int] = None,
                                       excludeRoot: Option[Boolean] = None,

--- a/core/shared/src/main/scala/laika/rewrite/link/LinkResolver.scala
+++ b/core/shared/src/main/scala/laika/rewrite/link/LinkResolver.scala
@@ -86,7 +86,7 @@ class LinkResolver (root: DocumentTreeRoot, slugBuilder: String => String) exten
     def resolveLocal (ref: Reference, selector: Selector, msg: => String): RewriteAction[Span] =
       resolveWith(ref, targets.select(cursor.path, selector), msg)
 
-    def resolvePath (ref: Reference, path: PathBase, msg: => String): RewriteAction[Span] = {
+    def resolvePath (ref: Reference, path: VirtualPath, msg: => String): RewriteAction[Span] = {
       val selector = PathSelector(InternalTarget(path).relativeTo(cursor.path).absolutePath)
       resolveWith(ref, targets.select(Root, selector), msg)
     }

--- a/core/shared/src/main/scala/laika/rewrite/link/TargetResolver.scala
+++ b/core/shared/src/main/scala/laika/rewrite/link/TargetResolver.scala
@@ -58,7 +58,7 @@ object ReferenceResolver {
     case LinkSource(LinkIdReference (content, _, _, opt), sourcePath) =>
       SpanLink(content, InternalTarget(target).relativeTo(sourcePath), None, opt)
   }
-  def resolveTarget (target: PathBase, refPath: Path): Target = target match {
+  def resolveTarget (target: VirtualPath, refPath: Path): Target = target match {
       /* If an internal target point upwards beyond the virtual root of the processed tree, 
          it is treated as an external target and does not get validated. */
     case rp: RelativePath if (rp.parentLevels >= refPath.depth) => ExternalTarget(target.toString)

--- a/core/shared/src/test/scala/laika/ast/PathAPISpec.scala
+++ b/core/shared/src/test/scala/laika/ast/PathAPISpec.scala
@@ -39,11 +39,11 @@ class PathAPISpec extends FunSuite {
   def decoder (testName: String)(body: Any): Unit = test(s"decoder - $testName")(body)
   def parent (testName: String)(body: Any): Unit = test(s"parent - $testName")(body)
   def depth (testName: String)(body: Any): Unit = test(s"depth - $testName")(body)
-  def basename (testName: String, actual: PathBase, expected: String): Unit = 
+  def basename (testName: String, actual: VirtualPath, expected: String): Unit = 
     test(s"basename - $testName") {
       assertEquals(actual.basename, expected)
     }
-  def withBasename (testName: String, pathUnderTest: PathBase)(
+  def withBasename (testName: String, pathUnderTest: VirtualPath)(
     expectedToString: String,
     expectedName: String,
     expectedBasename: String
@@ -54,11 +54,11 @@ class PathAPISpec extends FunSuite {
       assertEquals(pathUnderTest.basename, expectedBasename)
     }
   }
-  def suffix (testName: String, actual: PathBase, expected: Option[String]): Unit =
+  def suffix (testName: String, actual: VirtualPath, expected: Option[String]): Unit =
     test(s"suffix - $testName") {
       assertEquals(actual.suffix, expected)
     }
-  def withSuffix (testName: String, pathUnderTest: PathBase)(
+  def withSuffix (testName: String, pathUnderTest: VirtualPath)(
     expectedToString: String,
     expectedName: String,
     expectedSuffix: String
@@ -69,11 +69,11 @@ class PathAPISpec extends FunSuite {
       assertEquals(pathUnderTest.suffix, Some(expectedSuffix))
     }
   }
-  def fragment (testName: String, actual: PathBase, expected: Option[String]): Unit =
+  def fragment (testName: String, actual: VirtualPath, expected: Option[String]): Unit =
     test(s"fragment - $testName") {
       assertEquals(actual.fragment, expected)
     }
-  def withFragment (testName: String, pathUnderTest: PathBase)(
+  def withFragment (testName: String, pathUnderTest: VirtualPath)(
     expectedToString: String,
     expectedName: String,
     expectedFragment: String
@@ -90,7 +90,7 @@ class PathAPISpec extends FunSuite {
   def concatRel (testName: String, actual: RelativePath, expected: RelativePath): Unit =
     test(s"path concatenation for relative paths - $testName") { assertEquals(actual, expected) }
 
-  def relativeTo (testName: String, actual: PathBase, expected: PathBase)(implicit loc: Location): Unit =
+  def relativeTo (testName: String, actual: VirtualPath, expected: VirtualPath)(implicit loc: Location): Unit =
     test(s"relativeTo - $testName") { assertEquals(actual, expected) }
 
   def isSubPath (testName: String, actual: Boolean, expected: Boolean)(implicit loc: Location): Unit =
@@ -98,75 +98,75 @@ class PathAPISpec extends FunSuite {
   
   
   decoder("absolute path with three segments") {
-    assertEquals(PathBase.parse("/foo/bar/baz"), Root / "foo" / "bar" / "baz")
+    assertEquals(VirtualPath.parse("/foo/bar/baz"), Root / "foo" / "bar" / "baz")
   }
 
   decoder("absolute path with one segment") {
-    assertEquals(PathBase.parse("/foo"), Root / "foo")
+    assertEquals(VirtualPath.parse("/foo"), Root / "foo")
   }
 
   decoder("ignore trailing slashes for absolute paths") {
-    assertEquals(PathBase.parse("/foo/"), Root / "foo")
+    assertEquals(VirtualPath.parse("/foo/"), Root / "foo")
   }
   
   decoder("root path from a single slash") {
-    assertEquals(PathBase.parse("/"), Root)
+    assertEquals(VirtualPath.parse("/"), Root)
   }
 
   decoder("relative path with three segments") {
-    assertEquals(PathBase.parse("foo/bar/baz"), CurrentTree / "foo" / "bar" / "baz")
+    assertEquals(VirtualPath.parse("foo/bar/baz"), CurrentTree / "foo" / "bar" / "baz")
   }
 
   decoder("relative path with one segment") {
-    assertEquals(PathBase.parse("foo/"), CurrentTree / "foo")
+    assertEquals(VirtualPath.parse("foo/"), CurrentTree / "foo")
   }
 
   decoder("ignore trailing slashes for relative paths") {
-    assertEquals(PathBase.parse("foo/"), CurrentTree / "foo")
+    assertEquals(VirtualPath.parse("foo/"), CurrentTree / "foo")
   }
 
   decoder("current document from the empty string") {
-    assertEquals(PathBase.parse(""), CurrentDocument())
+    assertEquals(VirtualPath.parse(""), CurrentDocument())
   }
 
   decoder("current document from a hash") {
-    assertEquals(PathBase.parse("#"), CurrentDocument())
+    assertEquals(VirtualPath.parse("#"), CurrentDocument())
   }
 
   decoder("current relative path from a dot") {
-    assertEquals(PathBase.parse("."), CurrentTree)
+    assertEquals(VirtualPath.parse("."), CurrentTree)
   }
 
   decoder("fragment of the current document") {
-    assertEquals(PathBase.parse("#ref"), CurrentDocument("ref"))
+    assertEquals(VirtualPath.parse("#ref"), CurrentDocument("ref"))
   }
 
   decoder("relative path to parent with three segments") {
-    assertEquals(PathBase.parse("../foo/bar/baz"), Parent(1) / "foo" / "bar" / "baz")
+    assertEquals(VirtualPath.parse("../foo/bar/baz"), Parent(1) / "foo" / "bar" / "baz")
   }
   
   decoder("relative path to parent with one segment") {
-    assertEquals(PathBase.parse("../foo/"), Parent(1) / "foo")
+    assertEquals(VirtualPath.parse("../foo/"), Parent(1) / "foo")
   }
 
   decoder("relative path to parent three levels up") {
-    assertEquals(PathBase.parse("../../../foo/"), Parent(3) / "foo")
+    assertEquals(VirtualPath.parse("../../../foo/"), Parent(3) / "foo")
   }
 
   decoder("relative path to parent two levels up without any path segments") {
-    assertEquals(PathBase.parse("../../"), Parent(2))
+    assertEquals(VirtualPath.parse("../../"), Parent(2))
   }
 
   decoder("relative path to parent one level up without any path segments") {
-    assertEquals(PathBase.parse("../"), Parent(1))
+    assertEquals(VirtualPath.parse("../"), Parent(1))
   }
 
   decoder("relative path to parent two levels up without trailing slash") {
-    assertEquals(PathBase.parse("../.."), Parent(2))
+    assertEquals(VirtualPath.parse("../.."), Parent(2))
   }
 
   decoder("relative path to parent one level up without trailing slash") {
-    assertEquals(PathBase.parse(".."), Parent(1))
+    assertEquals(VirtualPath.parse(".."), Parent(1))
   }
   
   decoder("ignore leading slashes when RelativePath.parse is invoked directly") {

--- a/core/shared/src/test/scala/laika/ast/PathAPISpec.scala
+++ b/core/shared/src/test/scala/laika/ast/PathAPISpec.scala
@@ -63,7 +63,7 @@ class PathAPISpec extends FunSuite {
     expectedName: String,
     expectedSuffix: String
   ): Unit = {
-    test(s"withBasename - $testName") {
+    test(s"withSuffix - $testName") {
       assertEquals(pathUnderTest.toString, expectedToString)
       assertEquals(pathUnderTest.name, expectedName)
       assertEquals(pathUnderTest.suffix, Some(expectedSuffix))

--- a/io/src/main/scala/laika/io/model/FilePath.scala
+++ b/io/src/main/scala/laika/io/model/FilePath.scala
@@ -92,7 +92,7 @@ class FilePath private (private val root: String, private val underlying: Path) 
   override def toString: String = toNioPath.toString
 
   override def equals (other: Any): Boolean = other match {
-    case fp: FilePath => fp.underlying == underlying
+    case fp: FilePath => fp.root == root && fp.underlying == underlying
     case _ => false
   }
 

--- a/io/src/main/scala/laika/io/model/FilePath.scala
+++ b/io/src/main/scala/laika/io/model/FilePath.scala
@@ -1,0 +1,112 @@
+/*
+* Copyright 2012-2022 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package laika.io.model
+
+import cats.data.NonEmptyChain
+import laika.ast.Path.Root
+import laika.ast.{GenericPath, Path, RelativePath, SegmentedPath}
+import laika.collection.TransitionalCollectionOps.JIteratorWrapper
+
+import java.nio.file.Paths
+
+/** Represents a path on the file system, pointing to a file or directory that may or may not exist.
+  * 
+  * This type has a lot of shared API with the `VirtualPath` abstraction in `laika-core` via their
+  * common super-trait `GenericPath`.
+  * 
+  * However, it differs in two ways from the virtual path abstraction: semantically, as the latter
+  * is never intended to represent an actual file and instead just describes a tree structure
+  * of inputs (and AST documents after parsing). 
+  * 
+  * Secondly, it comes with additional APIs to convert to and from other path representations,
+  * namely `java.io.File`, `java.nio.file.Path` and `fs2.io.file.Path`.
+  * 
+  * @author Jens Halm
+  */
+class FilePath private (private val underlying: Path) extends GenericPath {
+
+  type Self = FilePath
+  
+  def name: String = underlying.name
+
+  def suffix: Option[String] = underlying.suffix
+
+  def fragment: Option[String] = underlying.fragment
+
+  protected def copyWith (basename: String, suffix: Option[String], fragment: Option[String]) =
+    underlying match {
+      case Root => new FilePath(Root)
+      case sp: SegmentedPath => new FilePath(sp.copy(
+        segments = NonEmptyChain.fromChainAppend(sp.segments.init, basename),
+        suffix = suffix,
+        fragment = fragment
+      ))
+    }
+
+  def / (path: RelativePath): FilePath = new FilePath(underlying / path)
+
+  /** Converts this `FilePath` to a `java.nio.file.Path`.
+    */
+  def toNioPath: java.nio.file.Path = underlying match {
+    case Root => Paths.get("/")
+    case sp: SegmentedPath => Paths.get(sp.segments.head, sp.segments.tail.toList:_*)
+  }
+
+  /** Converts this `FilePath` to an `fs2.io.file.Path`.
+    */
+  def toFS2Path: fs2.io.file.Path = fs2.io.file.Path.fromNioPath(toNioPath)
+
+  /** Converts this `FilePath` to an `java.io.File` instance.
+    */
+  def toJavaFile: java.io.File = toNioPath.toFile
+  
+  override def toString: String = underlying.toString
+
+  override def equals (other: Any): Boolean = other match {
+    case fp: FilePath => fp.underlying == underlying
+    case _ => false
+  }
+
+  override def hashCode (): Int = underlying.hashCode()
+  
+}
+
+/** Companion for parsing path strings or creating `FilePath` instances from other
+  * path representations.
+  */
+object FilePath {
+
+  /** Creates a new `FilePath` from the specified NIO path after normalizing it.
+    */
+  def fromNioPath (path: java.nio.file.Path): FilePath = {
+    val segments = JIteratorWrapper(path.normalize().iterator()).toList.map(_.toString)
+    new FilePath(Path.apply(segments))
+  }
+
+  /** Creates a new `FilePath` from the specified fs2 path after normalizing it.
+    */
+  def fromFS2Path (path: fs2.io.file.Path): FilePath = fromNioPath(path.toNioPath)
+
+  /** Creates a new `FilePath` from the specified File instance after normalizing its path.
+    */
+  def fromJavaFile (file: java.io.File): FilePath = fromNioPath(file.toPath)
+
+  /** Creates a new `FilePath` by parsing the specified path string in a platform-specific manner.
+    */
+  def parse (path: String): FilePath = fromNioPath(Paths.get(path))
+  
+}

--- a/io/src/main/scala/laika/io/model/FilePath.scala
+++ b/io/src/main/scala/laika/io/model/FilePath.scala
@@ -23,7 +23,7 @@ import laika.collection.TransitionalCollectionOps.JIteratorWrapper
 
 import java.nio.file.{InvalidPathException, Paths}
 
-/** Represents a path on the file system, pointing to a file or directory that may or may not exist.
+/** Represents an absolute path on the file system, pointing to a file or directory that may or may not exist.
   * 
   * This type has a lot of shared API with the `VirtualPath` abstraction in `laika-core` via their
   * common super-trait `GenericPath`.
@@ -106,6 +106,7 @@ class FilePath private (private val root: String, private val underlying: Path) 
 object FilePath {
 
   /** Creates a new `FilePath` from the specified NIO path after normalizing it.
+    * The provided path needs to be absolute, for relative paths use `laika.ast.RelativePath`.
     */
   def fromNioPath (path: java.nio.file.Path): FilePath = {
     if (!path.isAbsolute) throw new InvalidPathException(path.toString, "File paths must be absolute")
@@ -115,14 +116,17 @@ object FilePath {
   }
 
   /** Creates a new `FilePath` from the specified fs2 path after normalizing it.
+    * The provided path needs to be absolute, for relative paths use `laika.ast.RelativePath`.
     */
   def fromFS2Path (path: fs2.io.file.Path): FilePath = fromNioPath(path.toNioPath)
 
   /** Creates a new `FilePath` from the specified File instance after normalizing its path.
+    * The provided file needs to be absolute, for relative paths use `laika.ast.RelativePath`.
     */
   def fromJavaFile (file: java.io.File): FilePath = fromNioPath(file.toPath)
 
   /** Creates a new `FilePath` by parsing the specified path string in a platform-specific manner.
+    * The provided path string needs to be absolute, for relative paths use `laika.ast.RelativePath`.
     */
   def parse (path: String): FilePath = fromNioPath(Paths.get(path))
   

--- a/io/src/main/scala/laika/theme/config/Font.scala
+++ b/io/src/main/scala/laika/theme/config/Font.scala
@@ -19,7 +19,7 @@ package laika.theme.config
 import java.io.File
 
 import laika.ast.Path.Root
-import laika.ast.{Path, PathBase}
+import laika.ast.{Path, VirtualPath}
 import laika.config._
 
 /** Represents a font resource, either based on a local classpath or file system resource,
@@ -113,7 +113,7 @@ case class EmbeddedFontFile (file: File) extends EmbeddedFont {
 /** Represent a font files as a classpath resource.
   */
 case class EmbeddedFontResource (name: String) extends EmbeddedFont {
-  val path: Path = Root / "laika" / "fonts" / PathBase.parse(name).name
+  val path: Path = Root / "laika" / "fonts" / VirtualPath.parse(name).name
 }
 
 /** Enumeration for the valid font weights that can be assigned to a font resource, compatible with CSS properties.

--- a/io/src/test/scala/laika/io/model/FilePathSpec.scala
+++ b/io/src/test/scala/laika/io/model/FilePathSpec.scala
@@ -19,30 +19,34 @@ package laika.io.model
 import munit.FunSuite
 
 import java.io.File
-import java.nio.file.Paths
+import java.nio.file.{FileSystems, Paths}
 
 class FilePathSpec extends FunSuite {
-  
-  val testPathString = "/foo/bar/../baz.jpg"
+
+  private val platformSeparator = FileSystems.getDefault.getSeparator
+  private val platformRoot = Paths.get(System.getProperty("user.dir")).getRoot.toString
+
+  private val testPathString = platformRoot + List("foo", "bar", "..", "baz.jpg").mkString(platformSeparator)
+  private val expectedPath = platformRoot + List("foo", "baz.gif").mkString(platformSeparator)
 
   test("create and modify normalized FilePath from NIO path") {
     val path = FilePath.fromNioPath(Paths.get(testPathString))
-    assertEquals(path.withSuffix("gif").toString, "/foo/baz.gif")
+    assertEquals(path.withSuffix("gif").toString, expectedPath)
   }
 
   test("create and modify normalized FilePath from fs2 path") {
     val path = FilePath.fromFS2Path(fs2.io.file.Path.fromNioPath(Paths.get(testPathString)))
-    assertEquals(path.withSuffix("gif").toString, "/foo/baz.gif")
+    assertEquals(path.withSuffix("gif").toString, expectedPath)
   }
 
   test("create and modify normalized FilePath from Java File") {
-    val path = FilePath.fromJavaFile(new File("/foo/bar", "../baz.jpg"))
-    assertEquals(path.withSuffix("gif").toString, "/foo/baz.gif")
+    val path = FilePath.fromJavaFile(new File(testPathString))
+    assertEquals(path.withSuffix("gif").toString, expectedPath)
   }
 
   test("create and modify normalized FilePath from parsed string") {
     val path = FilePath.parse(testPathString)
-    assertEquals(path.withSuffix("gif").toString, "/foo/baz.gif")
+    assertEquals(path.withSuffix("gif").toString, expectedPath)
   }
 
   test("round trip FilePath from and to NIO path") {
@@ -58,7 +62,7 @@ class FilePathSpec extends FunSuite {
   }
 
   test("round trip FilePath from and to Java file") {
-    val inPath = new File("/foo/bar", "../baz.jpg")
+    val inPath = new File(testPathString)
     val outPath = FilePath.fromJavaFile(inPath).toJavaFile
     assertEquals(outPath, inPath.getCanonicalFile)
   }

--- a/io/src/test/scala/laika/io/model/FilePathSpec.scala
+++ b/io/src/test/scala/laika/io/model/FilePathSpec.scala
@@ -1,0 +1,66 @@
+/*
+* Copyright 2012-2022 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package laika.io.model
+
+import munit.FunSuite
+
+import java.io.File
+import java.nio.file.Paths
+
+class FilePathSpec extends FunSuite {
+  
+  val testPathString = "/foo/bar/../baz.jpg"
+
+  test("create and modify normalized FilePath from NIO path") {
+    val path = FilePath.fromNioPath(Paths.get(testPathString))
+    assertEquals(path.withSuffix("gif").toString, "/foo/baz.gif")
+  }
+
+  test("create and modify normalized FilePath from fs2 path") {
+    val path = FilePath.fromFS2Path(fs2.io.file.Path.fromNioPath(Paths.get(testPathString)))
+    assertEquals(path.withSuffix("gif").toString, "/foo/baz.gif")
+  }
+
+  test("create and modify normalized FilePath from Java File") {
+    val path = FilePath.fromJavaFile(new File("/foo/bar", "../baz.jpg"))
+    assertEquals(path.withSuffix("gif").toString, "/foo/baz.gif")
+  }
+
+  test("create and modify normalized FilePath from parsed string") {
+    val path = FilePath.parse(testPathString)
+    assertEquals(path.withSuffix("gif").toString, "/foo/baz.gif")
+  }
+
+  test("round trip FilePath from and to NIO path") {
+    val inPath = Paths.get(testPathString)
+    val outPath = FilePath.fromNioPath(inPath).toNioPath
+    assertEquals(outPath, inPath.normalize())
+  }
+
+  test("round trip FilePath from and to fs2 path") {
+    val inPath = fs2.io.file.Path.fromNioPath(Paths.get(testPathString))
+    val outPath = FilePath.fromFS2Path(inPath).toFS2Path
+    assertEquals(outPath, inPath.normalize)
+  }
+
+  test("round trip FilePath from and to Java file") {
+    val inPath = new File("/foo/bar", "../baz.jpg")
+    val outPath = FilePath.fromJavaFile(inPath).toJavaFile
+    assertEquals(outPath, inPath.getCanonicalFile)
+  }
+  
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,6 +9,7 @@ object Dependencies {
 
     val catsCore   = "2.7.0"
     val catsEffect = "3.3.5"
+    val fs2        = "3.2.7"
     val http4s     = "0.23.10"
     
     val munit      = "0.7.29"


### PR DESCRIPTION
This PR introduces a new `FilePath` API and restructures parts of the existing Path API to make the overall naming more consistent and intuitive.

* Renames the existing base trait `PathBase` to `VirtualPath` for a better distinction to the new `FilePath` API. Most user code will be against the concrete sub-types `laika.ast.Path` or `laika.ast.RelativePath` and won't be affected.

* Adds a new non-sealed base trait `GenericPath` above `VirtualPath` to serve as the common super-trait for `VirtualPath` and `FilePath`.

* Promotes several methods from concrete types to the base trait to increase the surface of the common API

* Finally introduces the new `FilePath` abstraction.

The new type is not used anywhere in the APIs yet, this step will happen after the fs2 migration is complete where APIs using `java.io.File` will be deprecated in favour of this new API.

Despite sharing a lot of API, `FilePath` differs from `VirtualPath`in three ways:

 * Semantically, as`VirtualPath` was never intended to represent an actual file or directory and instead just describes a tree structure of inputs (and AST documents after parsing).
 
* `FilePath` comes with additional APIs to convert to and from other path representations, namely `java.io.File`, `java.nio.file.Path` and `fs2.io.file.Path`.
  
* Finally, the `toString` method for this new type returns a platform-dependent string representation by using the file separator of the underlying file system. Laika's virtual path abstractions on the other hand always uses a forward slash `/` as the separator.

The option of using the existing `fs2.io.file.Path` abstraction instead was discarded for three reasons:

* It would introduce API inconsistencies between `VirtualPath` and `FilePath`, and the former has to stay for a range of reasons (one of them being the simple fact that `laika-core` has no dependency on fs2).

* Laika's path APIs have convenient methods for querying and modifying suffix and fragment components of paths, a common requirement when processing internal links for example.

* Some user-facing APIs accept two path arguments, a file path and a virtual "mount point" where this file will be linked into during a transformation. Having two `Path` types which only differ in package name would be confusing and force users to manually override/rename one of the imports, which is always tedious.