### PR TITLE
use fs2 for creating / scanning directories and for classpath resources

### DIFF
--- a/io/src/main/scala/laika/io/model/Input.scala
+++ b/io/src/main/scala/laika/io/model/Input.scala
@@ -30,7 +30,7 @@ import laika.io.runtime.TreeResultBuilder.{ConfigResult, DocumentResult, ParserR
 import laika.parse.markup.DocumentParser.DocumentInput
 import laika.rewrite.nav.TargetFormats
 
-import java.io.{File, IOException, InputStream}
+import java.io.{File, InputStream}
 import scala.io.Codec
 
 /** A binary input stream and its virtual path within the input tree.
@@ -56,6 +56,12 @@ object BinaryInput {
     val input = fs2.io.readInputStream(stream, 64 * 1024, autoClose)
     BinaryInput(path, input, targetFormats)
   }
+
+  def fromClasspath[F[_]: Async] (name: String, path: Path, targetFormats: TargetFormats = TargetFormats.All, classLoader: ClassLoader = getClass.getClassLoader): BinaryInput[F] = {
+    val input = fs2.io.readClassLoaderResource(name, classLoader = classLoader)
+    BinaryInput[F](path, input, targetFormats)
+  }
+  
 }
 
 /** Character input for the various parsers of this library.
@@ -85,6 +91,11 @@ object TextInput {
 
   def fromStream[F[_]: Async] (path: Path, docType: TextDocumentType, stream: F[InputStream], codec: Codec, autoClose: Boolean): TextInput[F] = {
     val input = readAll(fs2.io.readInputStream(stream, 64 * 1024, autoClose), codec)
+    TextInput[F](path, docType, input)
+  }
+  
+  def fromClasspath[F[_]: Async] (name: String, path: Path, docType: TextDocumentType, classLoader: ClassLoader = getClass.getClassLoader)(implicit codec: Codec): TextInput[F] = {
+    val input = readAll(fs2.io.readClassLoaderResource(name, classLoader = classLoader), codec)
     TextInput[F](path, docType, input)
   }
 }
@@ -285,17 +296,20 @@ class InputTreeBuilder[F[_]](private[laika] val exclude: File => Boolean,
 
   /** Adds the specified classpath resource to the input tree, placing it at the specified mount point in the virtual tree.
     * The specified name must be compatible with Java's `ClassLoader.getResource`.
-    * 
+    * The optional `ClassLoader` argument can be used to ensure the resource is found in an application or plugin
+    * that uses multiple class loaders. 
+    * If the call site is in the same module as the classpath resource, simply using `getClass.getClassLoader` should suffice. 
+    *
     * The content type of the stream will be determined by the suffix of the virtual path, e.g.
     * `doc.md` would be passed to the markup parser, `doc.template.html` to the template parser, and so on.
     */
-  def addClasspathResource (name: String, mountPoint: Path)(implicit codec: Codec): InputTreeBuilder[F] = {
-    val streamF = F.delay(getClass.getClassLoader.getResourceAsStream(name)).flatMap[InputStream] {
-      case null   => F.raiseError(new IOException(s"Classpath resource '$name' does not exist"))
-      case stream => F.pure(stream)
+  def addClasspathResource (name: String, mountPoint: Path, classLoader: ClassLoader = getClass.getClassLoader)(implicit codec: Codec): InputTreeBuilder[F] =
+    addStep(mountPoint) {
+      case DocumentType.Static(formats) =>
+        _ + BinaryInput.fromClasspath(name, mountPoint, formats, classLoader)
+      case docType: TextDocumentType =>
+        _ + TextInput.fromClasspath(name, mountPoint, docType, classLoader)
     }
-    addStream(streamF, mountPoint)
-  }
 
   /** Adds the specified input stream to the input tree, placing it at the specified mount point in the virtual tree.
     * 

--- a/io/src/main/scala/laika/io/runtime/RendererRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/RendererRuntime.scala
@@ -129,9 +129,7 @@ object RendererRuntime {
       val styles =  finalRoot.styles(fileSuffix) ++ getThemeStyles(themeInputs.parsedResults)
       val pathTranslator = createPathTranslator(translatorConfig, Root / "dummy", lookup).translate(_:Path)
 
-      def createDirectory (file: File): F[Unit] =
-        Sync[F].delay(file.exists || file.mkdirs()).flatMap(if (_) Sync[F].unit
-        else Sync[F].raiseError(new IOException(s"Unable to create directory ${file.getAbsolutePath}")))
+      def createDirectory (file: File): F[Unit] = Files[F].createDirectories(fs2.io.file.Path.fromNioPath(file.toPath))
       
       op.output match {
         case StringTreeOutput => 

--- a/io/src/test/scala/laika/io/FileIO.scala
+++ b/io/src/test/scala/laika/io/FileIO.scala
@@ -17,12 +17,12 @@
 package laika.io
 
 import cats.effect.IO
+import fs2.io.file.Files
 import laika.ast.DocumentType
 import laika.ast.Path.Root
 import laika.io.model.{TextInput, TextOutput}
 
 import java.io.{ByteArrayOutputStream, File}
-import java.util.UUID
 import scala.io.Codec
 
 trait FileIO {
@@ -39,33 +39,17 @@ trait FileIO {
   def writeFile (f: File, content: String): IO[Unit] =
     TextOutput.forFile[IO](Root, f, Codec.UTF8).writer(content)
 
-  def newTempDirectory: IO[File] = {
-    for {
-      baseDir <- IO(System.getProperty("java.io.tmpdir")).map(new File(_))
-      uuid    <- IO(UUID.randomUUID)
-      tempDir =  new File(baseDir, s"temp-$uuid")
-      res     <- IO(tempDir.mkdir())
-      _       <- if (res) IO.unit else IO.raiseError(new RuntimeException("Unable to create temp directory"))
-    } yield tempDir
-  }
+  def newTempDirectory: IO[File] = Files[IO].createTempDirectory.map(_.toNioPath.toFile)
 
-  def newTempFile: IO[File] =
-    for {
-      uuid <- IO(UUID.randomUUID)
-      file <- IO(File.createTempFile(s"temp-$uuid", null))
-    } yield file
+  def newTempFile: IO[File] = Files[IO].createTempFile.map(_.toNioPath.toFile)
   
-  def mkDir (f: File): IO[Unit] = for {
-    res     <- IO(f.mkdir())
-    _       <- if (res) IO.unit else IO.raiseError(new RuntimeException(s"Unable to create directory '${f.getPath}'"))
-  } yield ()
+  def fs2Path(f: File): fs2.io.file.Path = fs2.io.file.Path.fromNioPath(f.toPath)
+  
+  def mkDir (f: File): IO[Unit] = Files[IO].createDirectory(fs2Path(f))
 
-  def delete (f: File): IO[Unit] = for {
-    res     <- IO(f.delete())
-    _       <- if (res) IO.unit else IO.raiseError(new RuntimeException(s"Unable to delete file '${f.getPath}'"))
-  } yield ()
+  def delete (f: File): IO[Unit] = Files[IO].delete(fs2Path(f))
   
-  def exists (f: File): IO[Boolean] = IO(f.exists())
+  def exists (f: File): IO[Boolean] = Files[IO].exists(fs2Path(f))
 
   def withByteArrayTextOutput (charSet: String)(f: ByteArrayOutputStream => IO[Unit]): IO[String] =
     for {

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -860,18 +860,18 @@ class TreeRendererSpec extends CatsEffectSuite
     import VersionInfoSetup._
       
     def mkDirs (dir: File): IO[Unit] = 
-      List("0.1/tree-1", "0.1/tree-2", "0.2/tree-1", "0.2/tree-2", "0.3/tree-1", "0.3/tree-2").map { name =>
+      List("0.1/tree-1", "0.1/tree-2", "0.2/tree-1", "0.2/tree-2", "0.3/tree-1", "0.3/tree-2").traverse { name =>
         Files[IO].createDirectories(fs2.io.file.Path.fromNioPath(new File(dir, name).toPath))
-      }.sequence.void
+      }.void
 
     def writeExistingVersionedFiles (root: DocumentTreeRoot, dir: File): IO[Unit] = {
       val paths = root.tree.allDocuments.map(_.path.withSuffix("html").toString)
       val versionedPaths = paths.map("0.1" + _) ++ paths.drop(1).map("0.2" + _) ++ paths.dropRight(1).map("0.3" + _)
       
-      versionedPaths.toList.map { path =>
+      versionedPaths.toList.traverse { path =>
         val file = new File(dir, path)
         writeFile(file, "<html></html>")
-      }.sequence.void
+      }.void
     }
 
     val expectedFileContents: List[String] = (1 to 6).map(num => s"<p>Text $num</p>").toList

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -19,6 +19,8 @@ package laika.io
 import cats.data.{Chain, NonEmptyChain}
 import cats.effect.{Async, IO, Resource}
 import cats.syntax.all._
+import fs2.io.file
+import fs2.io.file.Files
 import laika.api.Renderer
 import laika.ast.Path.Root
 import laika.ast._
@@ -857,11 +859,10 @@ class TreeRendererSpec extends CatsEffectSuite
   test("directory with existing versioned renderer output") {
     import VersionInfoSetup._
       
-    def mkDirs (dir: File): IO[Unit] = IO {
-      Seq("0.1/tree-1", "0.1/tree-2", "0.2/tree-1", "0.2/tree-2", "0.3/tree-1", "0.3/tree-2").foreach { name =>
-        new File(dir, name).mkdirs()
-      }
-    }
+    def mkDirs (dir: File): IO[Unit] = 
+      List("0.1/tree-1", "0.1/tree-2", "0.2/tree-1", "0.2/tree-2", "0.3/tree-1", "0.3/tree-2").map { name =>
+        Files[IO].createDirectories(fs2.io.file.Path.fromNioPath(new File(dir, name).toPath))
+      }.sequence.void
 
     def writeExistingVersionedFiles (root: DocumentTreeRoot, dir: File): IO[Unit] = {
       val paths = root.tree.allDocuments.map(_.path.withSuffix("html").toString)


### PR DESCRIPTION
Penultimate migration step. Fairly simple and straightforward changes. 

Includes an API improvement: `InputTreeBuilder.addClasspathResource` has a new `ClassLoader` parameter to ensure the functionality can be used in code not sharing the same class loader with Laika.