### PR TITLE
Deprecate API expecting java.io.File in favour of FilePath + introduce effectful FileFilter

### DIFF
--- a/io/src/main/scala/laika/io/config/ResourceLoader.scala
+++ b/io/src/main/scala/laika/io/config/ResourceLoader.scala
@@ -52,7 +52,7 @@ object ResourceLoader {
   def loadFile[F[_]: Async] (file: FilePath): F[Option[Either[ConfigResourceError, String]]] = {
     
     def load: F[Either[ConfigResourceError, String]] = {
-      val input = TextInput.fromFile[F](Root, DocumentType.Config, file, Codec.UTF8)
+      val input = TextInput.fromFile[F](file, Root, DocumentType.Config)
       input.asDocumentInput.attempt.map(_.bimap(
         t => ConfigResourceError(s"Unable to load file '${file.toString}': ${t.getMessage}"), 
         _.source.input
@@ -94,7 +94,7 @@ object ResourceLoader {
       str <- Sync[F].delay(con.getInputStream)
     } yield str
     
-    val input = TextInput.fromStream[F](Root, DocumentType.Config, stream, Codec.UTF8, autoClose = true)
+    val input = TextInput.fromStream[F](stream, Root, DocumentType.Config, autoClose = true)
     input.asDocumentInput.attempt.map {
       case Left(_: FileNotFoundException) => None
       case Left(t) => Some(Left(ConfigResourceError(s"Unable to load config from URL '${url.toString}': ${t.getMessage}")))

--- a/io/src/main/scala/laika/io/descriptor/InputDescriptor.scala
+++ b/io/src/main/scala/laika/io/descriptor/InputDescriptor.scala
@@ -20,7 +20,7 @@ import cats.effect.Sync
 import cats.implicits._
 import laika.ast.DocumentType
 import laika.collection.TransitionalCollectionOps._
-import laika.io.model.{BinaryInput, TextInput, InputTree}
+import laika.io.model.{BinaryInput, FilePath, InputTree, TextInput}
 
 /** Describes a single, textual or binary input for a parsing or rendering operation.
   * This functionality is mostly intended for tooling support.
@@ -34,24 +34,24 @@ object InputDescriptor {
   def create[F[_]] (input: TextInput[F]): InputDescriptor = {
     val desc = input.sourceFile.fold(
       "In-memory string or stream"
-    )(f => s"File '${f.getPath}'")
+    )(f => s"File '${f.toString}'")
     apply(desc, input.docType)
   }
 
   def create[F[_]] (input: BinaryInput[F]): InputDescriptor = {
     val desc = input.sourceFile.fold(
       "In-memory bytes or stream"
-    )(f => s"File '${f.getPath}'")
+    )(f => s"File '${f.toString}'")
     apply(desc, DocumentType.Static())
   }
   
 }
 
-case class TreeInputDescriptor (inputs: Seq[InputDescriptor], sourceDirectories: Seq[String] = Nil) {
+case class TreeInputDescriptor (inputs: Seq[InputDescriptor], sourceDirectories: Seq[FilePath] = Nil) {
   
   def formatted: String = {
     val grouped = (inputs.map(in => (in.docType.productPrefix, in.description)) ++ 
-                    sourceDirectories.map(dir => ("Root Directories", dir)))
+                    sourceDirectories.map(dir => ("Root Directories", dir.toString)))
                     .groupBy(_._1).mapValuesStrict(_.map(_._2))
     
     TreeInputDescriptor.docTypeMappings.map { case (docType, typeDesc) =>

--- a/io/src/main/scala/laika/io/descriptor/ParserDescriptor.scala
+++ b/io/src/main/scala/laika/io/descriptor/ParserDescriptor.scala
@@ -17,9 +17,11 @@
 package laika.io.descriptor
 
 import cats.data.NonEmptyList
-import cats.effect.Sync
+import cats.effect.{Async, Sync}
 import cats.implicits._
+import fs2.io.file.Files
 import laika.io.api.TreeParser
+import laika.io.model.{FileFilter, FilePath}
 
 /** Provides a description of a parsing operation, including the parsers
   * and extension bundles used, as well as the input sources.
@@ -50,9 +52,13 @@ case class ParserDescriptor (parsers: NonEmptyList[String],
 
 object ParserDescriptor {
   
+  private val fileFilter = new FileFilter {
+    def filter[F[_] : Async] (file: FilePath) = Files[F].exists(file.toFS2Path).map(!_)
+  }
+  
   def create[F[_]: Sync] (op: TreeParser.Op[F]): F[ParserDescriptor] = 
     TreeInputDescriptor
-      .create(op.input.withFileFilter(f => !f.exists).build(op.config.docTypeMatcher))
+      .create(op.input.withFileFilter(fileFilter).build(op.config.docTypeMatcher))
       .map { inputDesc =>
         apply(
           op.parsers.map(_.format.description),

--- a/io/src/main/scala/laika/io/descriptor/RendererDescriptor.scala
+++ b/io/src/main/scala/laika/io/descriptor/RendererDescriptor.scala
@@ -52,7 +52,7 @@ object RendererDescriptor {
   )(f => s"File '${f.getPath}'")
   
   private def describeOutput (out: TreeOutput): String = out match {
-    case DirectoryOutput(dir, _) => s"Directory '${dir.getPath}'"
+    case DirectoryOutput(dir, _) => s"Directory '${dir.toString}'"
     case _ => "In-memory strings or streams"
   }
   

--- a/io/src/main/scala/laika/io/model/FilePath.scala
+++ b/io/src/main/scala/laika/io/model/FilePath.scala
@@ -74,6 +74,12 @@ class FilePath private (private val root: Option[String], private[FilePath] val 
 
   def / (path: RelativePath): FilePath = new FilePath(root, underlying / path)
 
+  /** Indicates whether this path is absolute.
+    * Relative paths are interpreted relative to the current working directory 
+    * during a transformation.
+    */
+  val isAbsolute: Boolean = root.nonEmpty 
+
   /** Converts this `FilePath` to a `java.nio.file.Path`.
     */
   def toNioPath: java.nio.file.Path = underlying match {

--- a/io/src/main/scala/laika/io/model/FilePath.scala
+++ b/io/src/main/scala/laika/io/model/FilePath.scala
@@ -48,7 +48,7 @@ import java.nio.file.{InvalidPathException, Paths}
   * 
   * @author Jens Halm
   */
-class FilePath private (private val root: Option[String], private val underlying: Path) extends GenericPath {
+class FilePath private (private val root: Option[String], private[FilePath] val underlying: Path) extends GenericPath {
 
   type Self = FilePath
   
@@ -69,6 +69,8 @@ class FilePath private (private val root: Option[String], private val underlying
         fragment = fragment
       ))
     }
+
+  override def / (name: String): FilePath = this / FilePath.parse(name).underlying.relative
 
   def / (path: RelativePath): FilePath = new FilePath(root, underlying / path)
 

--- a/io/src/main/scala/laika/io/model/Input.scala
+++ b/io/src/main/scala/laika/io/model/Input.scala
@@ -38,7 +38,7 @@ import scala.io.Codec
 case class BinaryInput[F[_]: Sync] (path: Path, 
                                     input: fs2.Stream[F, Byte], 
                                     formats: TargetFormats = TargetFormats.All, 
-                                    sourceFile: Option[File] = None) extends Navigatable
+                                    sourceFile: Option[FilePath] = None) extends Navigatable
 
 object BinaryInput {
   
@@ -47,8 +47,8 @@ object BinaryInput {
     BinaryInput(path, stream, targetFormats)
   }
 
-  def fromFile[F[_]: Async] (path: Path, file: File, targetFormats: TargetFormats = TargetFormats.All): BinaryInput[F] = {
-    val stream = Files[F].readAll(fs2.io.file.Path.fromNioPath(file.toPath))
+  def fromFile[F[_]: Async] (path: Path, file: FilePath, targetFormats: TargetFormats = TargetFormats.All): BinaryInput[F] = {
+    val stream = Files[F].readAll(file.toFS2Path)
     BinaryInput[F](path, stream, targetFormats, Some(file))
   }
 
@@ -72,7 +72,7 @@ object BinaryInput {
   * @param input   The character input
   * @param sourceFile The source file from the file system, empty if this does not represent a file system resource
   */
-case class TextInput[F[_]: Functor] (path: Path, docType: TextDocumentType, input: F[String], sourceFile: Option[File] = None) extends Navigatable {
+case class TextInput[F[_]: Functor] (path: Path, docType: TextDocumentType, input: F[String], sourceFile: Option[FilePath] = None) extends Navigatable {
   lazy val asDocumentInput: F[DocumentInput] = input.map(DocumentInput(path, _))
 }
 
@@ -84,8 +84,8 @@ object TextInput {
   def fromString[F[_]: Applicative] (path: Path, docType: TextDocumentType, input: String): TextInput[F] = 
     TextInput[F](path, docType, Applicative[F].pure(input))
 
-  def fromFile[F[_]: Async] (path: Path, docType: TextDocumentType, file: File, codec: Codec): TextInput[F] = {
-    val input = readAll(Files[F].readAll(fs2.io.file.Path.fromNioPath(file.toPath)), codec)
+  def fromFile[F[_]: Async] (path: Path, docType: TextDocumentType, file: FilePath, codec: Codec): TextInput[F] = {
+    val input = readAll(Files[F].readAll(file.toFS2Path), codec)
     TextInput[F](path, docType, input, Some(file))
   }
 
@@ -110,7 +110,7 @@ case class InputTree[F[_]](textInputs: Seq[TextInput[F]] = Nil,
                            binaryInputs: Seq[BinaryInput[F]] = Nil,
                            parsedResults: Seq[ParserResult] = Nil,
                            providedPaths: Seq[StaticDocument] = Nil,
-                           sourcePaths: Seq[String] = Nil) {
+                           sourcePaths: Seq[FilePath] = Nil) {
 
   /** A collection of all paths in this input tree, which may contain duplicates.
     */
@@ -164,7 +164,7 @@ object InputTree {
     * The filter will only be used for scanning directories when calling `addDirectory` on the builder,
     * not for any of the other methods.
     */
-  def apply[F[_]: Async] (exclude: File => Boolean): InputTreeBuilder[F] = new InputTreeBuilder(exclude, Vector.empty, Vector.empty)
+  def apply[F[_]: Async] (exclude: FileFilter): InputTreeBuilder[F] = new InputTreeBuilder(exclude, Vector.empty, Vector.empty)
 
   /** Creates a new, empty InputTreeBuilder.
     */
@@ -222,20 +222,20 @@ object InputTree {
   * }
   * }}}
   */
-class InputTreeBuilder[F[_]](private[laika] val exclude: File => Boolean, 
-                             private[model] val steps: Vector[(Path => DocumentType, File => Boolean) => Kleisli[F, InputTree[F], InputTree[F]]],
-                             private[laika] val fileRoots: Vector[File])(implicit F: Async[F]) {
+class InputTreeBuilder[F[_]](private[laika] val exclude: FileFilter, 
+                             private[model] val steps: Vector[(Path => DocumentType, FileFilter) => Kleisli[F, InputTree[F], InputTree[F]]],
+                             private[laika] val fileRoots: Vector[FilePath])(implicit F: Async[F]) {
   
   import cats.implicits._
 
-  private def addStep (step: (Path => DocumentType, File => Boolean) => Kleisli[F, InputTree[F], InputTree[F]]): InputTreeBuilder[F] =
+  private def addStep (step: (Path => DocumentType, FileFilter) => Kleisli[F, InputTree[F], InputTree[F]]): InputTreeBuilder[F] =
     addStep(None)(step)
     
-  private def addStep (newFileRoot: Option[File])
-                      (step: (Path => DocumentType, File => Boolean) => Kleisli[F, InputTree[F], InputTree[F]]): InputTreeBuilder[F] =
+  private def addStep (newFileRoot: Option[FilePath])
+                      (step: (Path => DocumentType, FileFilter) => Kleisli[F, InputTree[F], InputTree[F]]): InputTreeBuilder[F] =
     new InputTreeBuilder(exclude, steps = steps :+ step, newFileRoot.fold(fileRoots)(fileRoots :+ _))
   
-  private def addStep (path: Path, newFileRoot: Option[File] = None)
+  private def addStep (path: Path, newFileRoot: Option[FilePath] = None)
                       (f: PartialFunction[DocumentType, InputTree[F] => InputTree[F]]): InputTreeBuilder[F] = 
     addStep(newFileRoot) { (docTypeFunction, _) =>
       Kleisli { tree =>
@@ -249,29 +249,40 @@ class InputTreeBuilder[F[_]](private[laika] val exclude: File => Boolean,
 
   /** Adds the specified directories to the input tree, merging them all into a single virtual root, recursively.
     */
-  def addDirectories (dirs: Seq[File])(implicit codec: Codec): InputTreeBuilder[F] = dirs.foldLeft(this) {
+  def addDirectories (dirs: Seq[FilePath])(implicit codec: Codec): InputTreeBuilder[F] = dirs.foldLeft(this) {
     case (builder, dir) => builder.addDirectory(dir)
   }
-
+  
   /** Adds the specified directories to the input tree, placing it in the virtual root.
     */
-  def addDirectory (name: String)(implicit codec: Codec): InputTreeBuilder[F] = addDirectory(new File(name), Root)
+  def addDirectory (name: String)(implicit codec: Codec): InputTreeBuilder[F] = 
+    addDirectory(FilePath.parse(name), Root)
 
   /** Adds the specified directories to the input tree, placing it at the specified mount point in the virtual tree.
     */
   def addDirectory (name: String, mountPoint: Path)(implicit codec: Codec): InputTreeBuilder[F] = 
-    addDirectory(new File(name), mountPoint)
+    addDirectory(FilePath.parse(name), mountPoint)
+
+  @deprecated("use addDirectory(String) or addDirectory(FilePath)", "0.19.0")
+  def addDirectory (dir: File)(implicit codec: Codec): InputTreeBuilder[F] = 
+    addDirectory(FilePath.fromJavaFile(dir), Root)
 
   /** Adds the specified directories to the input tree, placing it in the virtual root.
     */
-  def addDirectory (dir: File)(implicit codec: Codec): InputTreeBuilder[F] = addDirectory(dir, Root)
+  def addDirectory (dir: FilePath)(implicit codec: Codec): InputTreeBuilder[F] = addDirectory(dir, Root)
+
+  @deprecated("use addDirectory(String, Path) or addDirectory(FilePath, Path)", "0.19.0")
+  def addDirectory (dir: File, mountPoint: Path)(implicit codec: Codec): InputTreeBuilder[F] =
+    addDirectory(FilePath.fromJavaFile(dir), mountPoint)
 
   /** Adds the specified directories to the input tree, placing it at the specified mount point in the virtual tree.
     */
-  def addDirectory (dir: File, mountPoint: Path)(implicit codec: Codec): InputTreeBuilder[F] = addStep(Some(dir)) { (docTypeFunction, fileFilter) =>
-    if (fileFilter(dir)) Kleisli.ask else
-    Kleisli { input => 
-      DirectoryScanner.scanDirectories[F](new DirectoryInput(Seq(dir), codec, docTypeFunction, fileFilter, mountPoint)).map(input ++ _)
+  def addDirectory (dir: FilePath, mountPoint: Path)(implicit codec: Codec): InputTreeBuilder[F] = addStep(Some(dir)) { (docTypeFunction, fileFilter) =>
+    Kleisli { input =>
+      fileFilter.filter(dir).ifM(
+        Async[F].pure(input),
+        DirectoryScanner.scanDirectories[F](new DirectoryInput(Seq(dir), codec, docTypeFunction, fileFilter, mountPoint)).map(input ++ _)
+      )
     }
   }
 
@@ -281,14 +292,18 @@ class InputTreeBuilder[F[_]](private[laika] val exclude: File => Boolean,
     * `doc.md` would be passed to the markup parser, `doc.template.html` to the template parser, and so on.
     */
   def addFile (name: String, mountPoint: Path)(implicit codec: Codec): InputTreeBuilder[F] = 
-    addFile(new File(name), mountPoint)
+    addFile(FilePath.parse(name), mountPoint)
+
+  @deprecated("use addFile(String) or addFile(FilePath)", "0.19.0")
+  def addFile (file: File, mountPoint: Path)(implicit codec: Codec): InputTreeBuilder[F] =
+    addFile(FilePath.fromJavaFile(file), mountPoint)
 
   /** Adds the specified file to the input tree, placing it at the specified mount point in the virtual tree.
-    * 
+    *
     * The content type of the stream will be determined by the suffix of the virtual path, e.g.
     * `doc.md` would be passed to the markup parser, `doc.template.html` to the template parser, and so on.
     */
-  def addFile (file: File, mountPoint: Path)(implicit codec: Codec): InputTreeBuilder[F] =
+  def addFile (file: FilePath, mountPoint: Path)(implicit codec: Codec): InputTreeBuilder[F] =
     addStep(mountPoint, Some(file)) {
       case DocumentType.Static(formats) => _ + BinaryInput.fromFile(mountPoint, file, formats)
       case docType: TextDocumentType    => _ + TextInput.fromFile[F](mountPoint, docType, file, codec)
@@ -385,15 +400,14 @@ class InputTreeBuilder[F[_]](private[laika] val exclude: File => Boolean,
     * The filter will only be used for scanning directories when calling `addDirectory` on this builder,
     * not for any of the other methods.
     */
-  def withFileFilter (filter: File => Boolean): InputTreeBuilder[F] = {
-    val combinedFilter: File => Boolean = f => filter(f) || exclude(f)
-    new InputTreeBuilder(combinedFilter, steps, fileRoots)
+  def withFileFilter (newFilter: FileFilter): InputTreeBuilder[F] = {
+    new InputTreeBuilder(exclude.combine(newFilter), steps, fileRoots)
   }
 
   /** Merges this input tree with the specified tree, recursively.
     */
   def merge (other: InputTreeBuilder[F]): InputTreeBuilder[F] = 
-    new InputTreeBuilder(f => other.exclude(f) || exclude(f), steps ++ other.steps, fileRoots ++ other.fileRoots)
+    new InputTreeBuilder(exclude.combine(other.exclude), steps ++ other.steps, fileRoots ++ other.fileRoots)
 
   /** Merges this input tree with the specified tree, recursively.
     */
@@ -426,38 +440,60 @@ class InputTreeBuilder[F[_]](private[laika] val exclude: File => Boolean,
 
 }
 
+/** File filter that defines the filter function in `[F[_]]` to allow for effectful filter logic.
+  */
+trait FileFilter { self =>
+  
+  def filter[F[_]: Async] (file: FilePath): F[Boolean]
+  
+  def combine (other: FileFilter): FileFilter = new FileFilter {
+    def filter[G[_] : Async] (file: FilePath) = self.filter[G](file).ifM(
+      Async[G].pure(true),
+      other.filter[G](file)
+    )
+  }
+}
 
+object FileFilter {
+ 
+  def lift (f: FilePath => Boolean): FileFilter = new FileFilter {
+    def filter[F[_] : Async] (file: FilePath) = Async[F].pure(f(file))
+  }
+  
+}
 
 /** A directory in the file system containing input documents for a tree transformation.
   *
   * The specified `docTypeMatcher` is responsible for determining the type of input 
   * (e.g. text markup, template, etc.) based on the (virtual) document path.
   */
-case class DirectoryInput (directories: Seq[File],
+case class DirectoryInput (directories: Seq[FilePath],
                            codec: Codec,
                            docTypeMatcher: Path => DocumentType = DocumentTypeMatcher.base,
-                           fileFilter: File => Boolean = DirectoryInput.hiddenFileFilter,
-                           mountPoint: Path = Root) {
-  lazy val sourcePaths: Seq[String] = directories map (_.getAbsolutePath)
-}
+                           fileFilter: FileFilter = DirectoryInput.hiddenFileFilter,
+                           mountPoint: Path = Root)
 
 object DirectoryInput {
 
-  /** A filter that selects files that are hidden according to `java.io.File.isHidden`.
+  /** A filter that selects files that are hidden in a platform-dependent way.
     */
-  val hiddenFileFilter: File => Boolean = file => file.isHidden && file.getName != "."
+  val hiddenFileFilter: FileFilter = new FileFilter {
+    def filter[F[_] : Async] (file: FilePath) = Files[F].isHidden(file.toFS2Path)
+  }
 
+  @deprecated("use apply(FilePath)", "0.19.0")
+  def apply (directory: File)(implicit codec: Codec): DirectoryInput = apply(FilePath.fromJavaFile(directory))
+  
   /** Creates a new instance using the library's defaults for the `docTypeMatcher` and
     * `fileFilter` properties.
     */
-  def apply (directory: File)(implicit codec: Codec): DirectoryInput = DirectoryInput(Seq(directory), codec)
+  def apply (directory: FilePath)(implicit codec: Codec): DirectoryInput = DirectoryInput(Seq(directory), codec)
 
+  
   /** Creates a file filter that filters all files in the specified directory.
     */
-  def filter (dir: File): File => Boolean = file => {
-    val filePath = file.getCanonicalPath
-    val dirPath = dir.getCanonicalPath
-    filePath.startsWith(dirPath)
+  def filterDirectory (dir: FilePath): FileFilter = FileFilter.lift { file =>
+    file.toString.startsWith(dir.toString)
   }
 }
 

--- a/io/src/main/scala/laika/io/model/Input.scala
+++ b/io/src/main/scala/laika/io/model/Input.scala
@@ -320,7 +320,7 @@ class InputTreeBuilder[F[_]](private[laika] val exclude: FileFilter,
   def addDirectory (dir: FilePath, mountPoint: Path)(implicit codec: Codec): InputTreeBuilder[F] = addStep(Some(dir)) { (docTypeFunction, fileFilter) =>
     Kleisli { input =>
       fileFilter.filter(dir).ifM(
-        Async[F].pure(input),
+        F.pure(input),
         DirectoryScanner.scanDirectories[F](new DirectoryInput(Seq(dir), codec, docTypeFunction, fileFilter, mountPoint)).map(input ++ _)
       )
     }

--- a/io/src/main/scala/laika/io/model/Input.scala
+++ b/io/src/main/scala/laika/io/model/Input.scala
@@ -34,45 +34,70 @@ import java.io.{File, InputStream}
 import scala.io.Codec
 
 /** A binary input stream and its virtual path within the input tree.
+  * 
+  * @param input      The binary input
+  * @param path       The full virtual path of this input (does not represent the filesystem path in case of file I/O),
+  *                   the point within the virtual tree of inputs (usually a `DocumentTree`)
+  *                   this resource should be linked into.
+  * @param formats    Indicates the output formats this binary input should be included in; 
+  *                   by default binary resources are included in all output formats, but it can be restricted
+  *                   if necessary (e.g. to only include it in HTML output, but omit it from PDF or EPUB)
+  * @param sourceFile The source file from the file system, empty if this does not represent a file system resource
   */
-case class BinaryInput[F[_]: Sync] (path: Path, 
-                                    input: fs2.Stream[F, Byte], 
-                                    formats: TargetFormats = TargetFormats.All, 
+case class BinaryInput[F[_]: Sync] (input: fs2.Stream[F, Byte],
+                                    path: Path,
+                                    formats: TargetFormats = TargetFormats.All,
                                     sourceFile: Option[FilePath] = None) extends Navigatable
 
 object BinaryInput {
   
-  def fromString[F[_]: Sync] (path: Path, input: String, targetFormats: TargetFormats = TargetFormats.All): BinaryInput[F] = {
+  def fromString[F[_]: Sync] (input: String, 
+                              mountPoint: Path = Root/"doc", 
+                              targetFormats: TargetFormats = TargetFormats.All): BinaryInput[F] = {
     val stream = fs2.Stream.emit(input).through(fs2.text.utf8.encode)
-    BinaryInput(path, stream, targetFormats)
+    BinaryInput(stream, mountPoint, targetFormats)
   }
 
-  def fromFile[F[_]: Async] (path: Path, file: FilePath, targetFormats: TargetFormats = TargetFormats.All): BinaryInput[F] = {
+  def fromFile[F[_]: Async] (file: FilePath, 
+                             mountPoint: Path = Root/"doc", 
+                             targetFormats: TargetFormats = TargetFormats.All): BinaryInput[F] = {
     val stream = Files[F].readAll(file.toFS2Path)
-    BinaryInput[F](path, stream, targetFormats, Some(file))
+    BinaryInput(stream, mountPoint, targetFormats, Some(file))
   }
 
-  def fromStream[F[_]: Sync] (path: Path, stream: F[InputStream], autoClose: Boolean, targetFormats: TargetFormats = TargetFormats.All): BinaryInput[F] = {
+  def fromStream[F[_]: Sync] (stream: F[InputStream], 
+                              mountPoint: Path = Root/"doc", 
+                              autoClose: Boolean = true, 
+                              targetFormats: TargetFormats = TargetFormats.All): BinaryInput[F] = {
     val input = fs2.io.readInputStream(stream, 64 * 1024, autoClose)
-    BinaryInput(path, input, targetFormats)
+    BinaryInput(input, mountPoint, targetFormats)
   }
 
-  def fromClasspath[F[_]: Async] (name: String, path: Path, targetFormats: TargetFormats = TargetFormats.All, classLoader: ClassLoader = getClass.getClassLoader): BinaryInput[F] = {
-    val input = fs2.io.readClassLoaderResource(name, classLoader = classLoader)
-    BinaryInput[F](path, input, targetFormats)
+  def fromClasspath[F[_]: Async] (resource: String, 
+                                  mountPoint: Path = Root/"doc", 
+                                  targetFormats: TargetFormats = TargetFormats.All, 
+                                  classLoader: ClassLoader = getClass.getClassLoader): BinaryInput[F] = {
+    val stream = fs2.io.readClassLoaderResource(resource, classLoader = classLoader)
+    BinaryInput(stream, mountPoint, targetFormats)
   }
   
 }
 
-/** Character input for the various parsers of this library.
+/** Character input for the various parsers of this library and its virtual path within the input tree.
   * 
-  * @param path    The full virtual path of this input (does not represent the filesystem path in case of file I/O)
-  * @param docType Indicates the type of the document, to distinguish between text markup, templates, configuration 
-  *                and style sheets, which all have a different kind of parser
-  * @param input   The character input
+  * @param input      The character input
+  * @param path The full virtual path of this input (does not represent the filesystem path in case of file I/O),
+  *                   the point within the virtual tree of inputs (usually a `DocumentTree`)
+  *                   this resource should be linked into.
+  * @param docType    Indicates the type of the document, to distinguish between text markup, templates, configuration 
+  *                   and style sheets, which all have a different kind of parser
   * @param sourceFile The source file from the file system, empty if this does not represent a file system resource
   */
-case class TextInput[F[_]: Functor] (path: Path, docType: TextDocumentType, input: F[String], sourceFile: Option[FilePath] = None) extends Navigatable {
+case class TextInput[F[_]: Functor] (input: F[String],
+                                     path: Path,
+                                     docType: TextDocumentType,
+                                     sourceFile: Option[FilePath] = None) extends Navigatable {
+  
   lazy val asDocumentInput: F[DocumentInput] = input.map(DocumentInput(path, _))
 }
 
@@ -81,22 +106,37 @@ object TextInput {
   private def readAll[F[_]: Concurrent](input: fs2.Stream[F, Byte], codec: Codec): F[String] = 
     input.through(fs2.text.decodeWithCharset(codec.charSet)).compile.string
 
-  def fromString[F[_]: Applicative] (path: Path, docType: TextDocumentType, input: String): TextInput[F] = 
-    TextInput[F](path, docType, Applicative[F].pure(input))
+  def fromString[F[_]: Applicative] (input: String, 
+                                     mountPoint: Path = Root/"doc", 
+                                     docType: TextDocumentType = DocumentType.Markup): TextInput[F] = 
+    TextInput[F](Applicative[F].pure(input), mountPoint, docType)
 
-  def fromFile[F[_]: Async] (path: Path, docType: TextDocumentType, file: FilePath, codec: Codec): TextInput[F] = {
+  def fromFile[F[_]: Async] (file: FilePath, 
+                             mountPoint: Path = Root/"doc", 
+                             docType: TextDocumentType = DocumentType.Markup)
+                            (implicit codec: Codec): TextInput[F] = {
+    
     val input = readAll(Files[F].readAll(file.toFS2Path), codec)
-    TextInput[F](path, docType, input, Some(file))
+    TextInput[F](input, mountPoint, docType, Some(file))
   }
 
-  def fromStream[F[_]: Async] (path: Path, docType: TextDocumentType, stream: F[InputStream], codec: Codec, autoClose: Boolean): TextInput[F] = {
+  def fromStream[F[_]: Async] (stream: F[InputStream], 
+                               mountPoint: Path = Root/"doc", 
+                               docType: TextDocumentType = DocumentType.Markup, 
+                               autoClose: Boolean = true)
+                              (implicit codec: Codec): TextInput[F] = {
+    
     val input = readAll(fs2.io.readInputStream(stream, 64 * 1024, autoClose), codec)
-    TextInput[F](path, docType, input)
+    TextInput[F](input, mountPoint, docType)
   }
   
-  def fromClasspath[F[_]: Async] (name: String, path: Path, docType: TextDocumentType, classLoader: ClassLoader = getClass.getClassLoader)(implicit codec: Codec): TextInput[F] = {
-    val input = readAll(fs2.io.readClassLoaderResource(name, classLoader = classLoader), codec)
-    TextInput[F](path, docType, input)
+  def fromClasspath[F[_]: Async] (resource: String, 
+                                  mountPoint: Path = Root/"doc", 
+                                  docType: TextDocumentType = DocumentType.Markup, 
+                                  classLoader: ClassLoader = getClass.getClassLoader)
+                                 (implicit codec: Codec): TextInput[F] = {
+    val input = readAll(fs2.io.readClassLoaderResource(resource, classLoader = classLoader), codec)
+    TextInput[F](input, mountPoint, docType)
   }
 }
 
@@ -305,8 +345,8 @@ class InputTreeBuilder[F[_]](private[laika] val exclude: FileFilter,
     */
   def addFile (file: FilePath, mountPoint: Path)(implicit codec: Codec): InputTreeBuilder[F] =
     addStep(mountPoint, Some(file)) {
-      case DocumentType.Static(formats) => _ + BinaryInput.fromFile(mountPoint, file, formats)
-      case docType: TextDocumentType    => _ + TextInput.fromFile[F](mountPoint, docType, file, codec)
+      case DocumentType.Static(formats) => _ + BinaryInput.fromFile(file, mountPoint, formats)
+      case docType: TextDocumentType    => _ + TextInput.fromFile(file, mountPoint, docType)
     }
 
   /** Adds the specified classpath resource to the input tree, placing it at the specified mount point in the virtual tree.
@@ -318,7 +358,10 @@ class InputTreeBuilder[F[_]](private[laika] val exclude: FileFilter,
     * The content type of the stream will be determined by the suffix of the virtual path, e.g.
     * `doc.md` would be passed to the markup parser, `doc.template.html` to the template parser, and so on.
     */
-  def addClasspathResource (name: String, mountPoint: Path, classLoader: ClassLoader = getClass.getClassLoader)(implicit codec: Codec): InputTreeBuilder[F] =
+  def addClasspathResource (name: String, 
+                            mountPoint: Path, 
+                            classLoader: ClassLoader = getClass.getClassLoader)
+                           (implicit codec: Codec): InputTreeBuilder[F] =
     addStep(mountPoint) {
       case DocumentType.Static(formats) =>
         _ + BinaryInput.fromClasspath(name, mountPoint, formats, classLoader)
@@ -335,12 +378,15 @@ class InputTreeBuilder[F[_]](private[laika] val exclude: FileFilter,
     * In some integration scenarios with 3rd-party libraries, e.g. for PDF creation, `autoClose` is not
     * guaranteed as the handling of the stream is entirely managed by the 3rd party tool.
     */
-  def addStream (stream: F[InputStream], mountPoint: Path, autoClose: Boolean = true)(implicit codec: Codec): InputTreeBuilder[F] =
+  def addStream (stream: F[InputStream], 
+                 mountPoint: Path, 
+                 autoClose: Boolean = true)
+                (implicit codec: Codec): InputTreeBuilder[F] =
     addStep(mountPoint) {
       case DocumentType.Static(formats) =>
-        _ + BinaryInput.fromStream(mountPoint,stream, autoClose, formats)
+        _ + BinaryInput.fromStream(stream, mountPoint,autoClose, formats)
       case docType: TextDocumentType => 
-        _ + TextInput.fromStream(mountPoint, docType, stream, codec, autoClose)
+        _ + TextInput.fromStream(stream, mountPoint, docType, autoClose)
     }
 
   /** Adds the specified string resource to the input tree, placing it at the specified mount point in the virtual tree.
@@ -348,10 +394,10 @@ class InputTreeBuilder[F[_]](private[laika] val exclude: FileFilter,
     * The content type of the stream will be determined by the suffix of the virtual path, e.g.
     * * `doc.md` would be passed to the markup parser, `doc.template.html` to the template parser, and so on.
     */
-  def addString (str: String, mountPoint: Path): InputTreeBuilder[F] =
+  def addString (input: String, mountPoint: Path): InputTreeBuilder[F] =
     addStep(mountPoint) {
-      case DocumentType.Static(formats) => _ + BinaryInput.fromString(mountPoint,str, formats)
-      case docType: TextDocumentType    => _ + TextInput.fromString[F](mountPoint, docType, str)
+      case DocumentType.Static(formats) => _ + BinaryInput.fromString(input, mountPoint,formats)
+      case docType: TextDocumentType    => _ + TextInput.fromString[F](input, mountPoint, docType)
     }
 
   /** Adds the specified document AST to the input tree, by-passing the parsing step.
@@ -375,7 +421,7 @@ class InputTreeBuilder[F[_]](private[laika] val exclude: FileFilter,
 
   /** Adds the specified styles for PDF to the input tree.
     * These type of style declarations are only used in the context of Laika's "CSS for PDF" support 
-    * which works slightly differently than web CSS as PDF generation Laika is not based on interim HTML results.
+    * which works slightly differently than web CSS as PDF generation in Laika is not based on interim HTML results.
     */
   def addStyles (styles: Set[StyleDeclaration], path: Path, precedence: Precedence = Precedence.High): InputTreeBuilder[F] = 
     addParserResult(StyleResult(StyleDeclarationSet(Set(path), styles, precedence), "fo"))
@@ -401,13 +447,13 @@ class InputTreeBuilder[F[_]](private[laika] val exclude: FileFilter,
     * not for any of the other methods.
     */
   def withFileFilter (newFilter: FileFilter): InputTreeBuilder[F] = {
-    new InputTreeBuilder(exclude.combine(newFilter), steps, fileRoots)
+    new InputTreeBuilder(exclude.orElse(newFilter), steps, fileRoots)
   }
 
   /** Merges this input tree with the specified tree, recursively.
     */
   def merge (other: InputTreeBuilder[F]): InputTreeBuilder[F] = 
-    new InputTreeBuilder(exclude.combine(other.exclude), steps ++ other.steps, fileRoots ++ other.fileRoots)
+    new InputTreeBuilder(exclude.orElse(other.exclude), steps ++ other.steps, fileRoots ++ other.fileRoots)
 
   /** Merges this input tree with the specified tree, recursively.
     */
@@ -445,8 +491,11 @@ class InputTreeBuilder[F[_]](private[laika] val exclude: FileFilter,
 trait FileFilter { self =>
   
   def filter[F[_]: Async] (file: FilePath): F[Boolean]
-  
-  def combine (other: FileFilter): FileFilter = new FileFilter {
+
+  /** Creates a new instance that filters file paths where either
+    * this filter or the specified other filter applies.
+    */
+  def orElse (other: FileFilter): FileFilter = new FileFilter {
     def filter[G[_] : Async] (file: FilePath) = self.filter[G](file).ifM(
       Async[G].pure(true),
       other.filter[G](file)

--- a/io/src/main/scala/laika/io/model/Output.scala
+++ b/io/src/main/scala/laika/io/model/Output.scala
@@ -19,6 +19,7 @@ package laika.io.model
 import cats.Applicative
 import cats.effect.{Async, Concurrent, Resource, Sync}
 import fs2.io.file.Files
+import laika.ast.Path.Root
 import laika.ast._
 
 import java.io.{File, OutputStream}
@@ -26,11 +27,11 @@ import scala.io.Codec
 
 /** Character output for the various renderers of this library
   *
-  * @param path       The full virtual path of this input (does not represent the filesystem path in case of file I/O)
   * @param writer     Handler for the character output (a function `String => F[Unit]`)
+  * @param path       The full virtual path of this output (does not represent the filesystem path in case of file I/O)
   * @param targetFile The target file in the file system, empty if this does not represent a file system resource
   */
-case class TextOutput[F[_]] (path: Path, writer: TextOutput.Writer[F], targetFile: Option[FilePath] = None)
+case class TextOutput[F[_]] (writer: TextOutput.Writer[F], path: Path, targetFile: Option[FilePath] = None)
 
 object TextOutput {
   
@@ -44,14 +45,17 @@ object TextOutput {
       .compile
       .drain
   
-  def noOp[F[_]: Applicative] (path: Path): TextOutput[F] =
-    TextOutput[F](path, _ => Applicative[F].unit)
+  def noOp[F[_]: Applicative] (path: Path = Root/"doc"): TextOutput[F] =
+    TextOutput[F](_ => Applicative[F].unit, path)
 
-  def forFile[F[_]: Async] (path: Path, file: FilePath, codec: Codec): TextOutput[F] =
-    TextOutput[F](path, writeAll(Files[F].writeAll(file.toFS2Path), codec), Some(file))
+  def forFile[F[_]: Async] (file: FilePath, path: Path = Root/"doc")(implicit codec: Codec): TextOutput[F] =
+    TextOutput[F](writeAll(Files[F].writeAll(file.toFS2Path), codec), path, Some(file))
     
-  def forStream[F[_]: Async] (path: Path, stream: F[OutputStream], codec: Codec, autoClose: Boolean): TextOutput[F] =
-    TextOutput[F](path, writeAll(fs2.io.writeOutputStream(stream, autoClose), codec))
+  def forStream[F[_]: Async] (stream: F[OutputStream],
+                              path: Path = Root/"doc",
+                              autoClose: Boolean = true)
+                             (implicit codec: Codec): TextOutput[F] =
+    TextOutput[F](writeAll(fs2.io.writeOutputStream(stream, autoClose), codec), path)
 }
 
 /** A resource for binary output.
@@ -62,20 +66,20 @@ object TextOutput {
   * This is the only I/O type not expressed through a generic `F[_]` or an `fs2.Stream` or `fs2.Pipe`
   * as Laika's binary output needs to work with Java libraries for its EPUB and PDF output.
   */
-case class BinaryOutput[F[_]] (path: Path, resource: Resource[F, OutputStream], targetFile: Option[File] = None)
+case class BinaryOutput[F[_]] (resource: Resource[F, OutputStream], path: Path, targetFile: Option[File] = None)
 
 object BinaryOutput {
 
-  def forFile[F[_]: Sync] (path: Path, file: FilePath): BinaryOutput[F] = {
+  def forFile[F[_]: Sync] (file: FilePath, path: Path): BinaryOutput[F] = {
     val resource = Resource.fromAutoCloseable(Sync[F].blocking(
       new java.io.BufferedOutputStream(new java.io.FileOutputStream(file.toJavaFile)))
     )
-    BinaryOutput(path, resource)
+    BinaryOutput(resource, path)
   }
 
-  def forStream[F[_]: Sync] (path: Path, stream: F[OutputStream], autoClose: Boolean): BinaryOutput[F] = {
+  def forStream[F[_]: Sync] (stream: F[OutputStream], path: Path, autoClose: Boolean = true): BinaryOutput[F] = {
     val resource = if (autoClose) Resource.fromAutoCloseable(stream) else Resource.eval(stream)
-    BinaryOutput(path, resource)
+    BinaryOutput(resource, path)
   }
 
 }

--- a/io/src/main/scala/laika/io/ops/BinaryOutputOps.scala
+++ b/io/src/main/scala/laika/io/ops/BinaryOutputOps.scala
@@ -18,7 +18,7 @@ package laika.io.ops
 
 import cats.effect.Async
 import laika.ast.Path.Root
-import laika.io.model.BinaryOutput
+import laika.io.model.{BinaryOutput, FilePath}
 
 import java.io.{File, OutputStream}
 
@@ -40,15 +40,18 @@ trait BinaryOutputOps[F[_]] {
     *
     *  @param name the name of the file to write to
     */
-  def toFile (name: String): Result = toFile(new File(name))
+  def toFile (name: String): Result = toFile(FilePath.parse(name))
+
+  @deprecated("use toFile(String) or toFile(FilePath)", "0.19.0")
+  def toFile (file: File): Result = toFile(FilePath.fromJavaFile(file))
 
   /** Builder step that instructs the runtime to render
     * to the specified file.
     *
     *  @param file the file to write to
     */
-  def toFile (file: File): Result =
-    toOutput(BinaryOutput.forFile(Root / file.getName, file)(F))
+  def toFile (file: FilePath): Result =
+    toOutput(BinaryOutput.forFile(Root / file.name, file)(F))
 
   /** Builder step that instructs the runtime to render
     * to the specified output stream.

--- a/io/src/main/scala/laika/io/ops/BinaryOutputOps.scala
+++ b/io/src/main/scala/laika/io/ops/BinaryOutputOps.scala
@@ -51,7 +51,7 @@ trait BinaryOutputOps[F[_]] {
     *  @param file the file to write to
     */
   def toFile (file: FilePath): Result =
-    toOutput(BinaryOutput.forFile(Root / file.name, file)(F))
+    toOutput(BinaryOutput.forFile(file, Root / file.name)(F))
 
   /** Builder step that instructs the runtime to render
     * to the specified output stream.
@@ -60,7 +60,7 @@ trait BinaryOutputOps[F[_]] {
     * @param autoClose indicates whether the stream should be closed after all output had been written                 
     */
   def toStream (stream: F[OutputStream], autoClose: Boolean = true): Result =
-    toOutput(BinaryOutput.forStream(Root, stream, autoClose)(F))
+    toOutput(BinaryOutput.forStream(stream, Root, autoClose)(F))
 
   /** Builder step that instructs the runtime to render
     * to the specified output.

--- a/io/src/main/scala/laika/io/ops/TextOutputOps.scala
+++ b/io/src/main/scala/laika/io/ops/TextOutputOps.scala
@@ -17,9 +17,8 @@
 package laika.io.ops
 
 import java.io.File
-
 import cats.effect.Sync
-import laika.io.model.{DirectoryOutput, TreeOutput}
+import laika.io.model.{DirectoryOutput, FilePath, TreeOutput}
 
 import scala.io.Codec
 
@@ -45,7 +44,7 @@ trait TextOutputOps[F[_]] {
     * @param name the name of the directory to write to
     * @param codec the character encoding of the files, if not specified the platform default will be used.
     */
-  def toDirectory (name: String)(implicit codec: Codec): Result = toDirectory(new File(name))
+  def toDirectory (name: String)(implicit codec: Codec): Result = toDirectory(FilePath.parse(name))
 
   /** Builder step that instructs the runtime to render the document tree to files
     * in the specified directory and its subdirectories.
@@ -56,18 +55,14 @@ trait TextOutputOps[F[_]] {
     * @param dir the directory to write to
     * @param codec the character encoding of the files, if not specified the platform default will be used.
     */
-  def toDirectory (dir: File)(implicit codec: Codec): Result = toOutput(DirectoryOutput(dir, codec))
+  def toDirectory (dir: FilePath)(implicit codec: Codec): Result = toOutput(DirectoryOutput(dir, codec))
 
-  /** Builder step that instructs the runtime to render the document tree to files
-    * in the working directory and its subdirectories.
-    *
-    * The virtual paths of the document tree will be translated to a directory structure,
-    * with the root of the virtual path being the directory specified with this method.
-    *
-    *  @param codec the character encoding of the files, if not specified the platform default will be used.
-    */
+  @deprecated("use toDirectory(String) or toDirectory(FilePath)", "0.19.0")
+  def toDirectory (dir: File)(implicit codec: Codec): Result = toDirectory(FilePath.fromJavaFile(dir))
+
+  @deprecated("use toDirectory(String) or toDirectory(FilePath) using a relative path", "0.19.0")
   def toWorkingDirectory (implicit codec: Codec): Result = 
-    toOutput(DirectoryOutput(new File(System.getProperty("user.dir")), codec))
+    toOutput(DirectoryOutput(FilePath.parse(System.getProperty("user.dir")), codec))
 
   /** Builder step that instructs the runtime to render
     * to the specified tree output.

--- a/io/src/main/scala/laika/io/runtime/DirectoryScanner.scala
+++ b/io/src/main/scala/laika/io/runtime/DirectoryScanner.scala
@@ -19,11 +19,10 @@ package laika.io.runtime
 import cats.effect.Sync
 import cats.effect.kernel.Async
 import cats.implicits._
+import fs2.io.file.Files
 import laika.ast.DocumentType.Static
 import laika.ast.{Path, TextDocumentType}
 import laika.io.model._
-
-import java.nio.file.{Path => JPath}
 
 /** Scans a directory in the file system and transforms it into a generic InputCollection
   * that can serve as input for parallel parsers or transformers.
@@ -34,19 +33,19 @@ object DirectoryScanner {
 
   /** Scans the specified directory passing all child paths to the given function.
     */
-  def scanDirectory[F[_]: Async, A] (directory: JPath)(f: Seq[JPath] => F[A]): F[A] = 
+  def scanDirectory[F[_]: Async, A] (directory: FilePath)(f: Seq[FilePath] => F[A]): F[A] = 
     fs2.io.file.Files[F]
-      .list(fs2.io.file.Path.fromNioPath(directory))
+      .list(directory.toFS2Path)
+      .map(FilePath.fromFS2Path)
       .compile
       .toList
-      .flatMap(p => f(p.map(_.toNioPath)) )
+      .flatMap(f)
   
   /** Scans the specified directory and transforms it into a generic InputCollection.
     */
   def scanDirectories[F[_]: Async] (input: DirectoryInput): F[InputTree[F]] = {
-    val sourcePaths: Seq[String] = input.directories map (_.getAbsolutePath)
-    join(input.directories.map(d => scanDirectory[F, InputTree[F]](d.toPath)(asInputCollection(input.mountPoint, input))))
-      .map(_.copy(sourcePaths = sourcePaths))
+    join(input.directories.map(d => scanDirectory[F, InputTree[F]](d)(asInputCollection(input.mountPoint, input))))
+      .map(_.copy(sourcePaths = input.directories))
   }
   
   private def join[F[_]: Sync] (collections: Seq[F[InputTree[F]]]): F[InputTree[F]] = collections
@@ -54,20 +53,22 @@ object DirectoryScanner {
     .sequence
     .map(_.reduceLeftOption(_ ++ _).getOrElse(InputTree.empty))
 
-  private def asInputCollection[F[_]: Async] (path: Path, input: DirectoryInput)(entries: Seq[JPath]): F[InputTree[F]] = {
+  private def asInputCollection[F[_]: Async] (path: Path, input: DirectoryInput)(entries: Seq[FilePath]): F[InputTree[F]] = {
 
-    def toCollection (filePath: JPath): F[InputTree[F]] = {
+    def toCollection (filePath: FilePath): F[InputTree[F]] = {
 
-      val childPath = path / filePath.getFileName.toString
+      val childPath = path / filePath.name
 
-      if (input.fileFilter(filePath.toFile)) InputTree.empty[F].pure[F]
-      else fs2.io.file.Files[F].isDirectory(fs2.io.file.Path.fromNioPath(filePath)).ifM(
-        scanDirectory(filePath)(asInputCollection(childPath, input)),
-        input.docTypeMatcher(childPath) match {
-          case docType: TextDocumentType => InputTree[F](Seq(TextInput.fromFile(childPath, docType, filePath.toFile, input.codec)), Nil, Nil).pure[F]
-          case Static(formats)           => InputTree[F](Nil, Seq(BinaryInput.fromFile(childPath, filePath.toFile, formats)), Nil).pure[F]
-          case _                         => InputTree.empty[F].pure[F]
-        }
+      input.fileFilter.filter(filePath).ifM(
+        InputTree.empty[F].pure[F],
+        Files[F].isDirectory(filePath.toFS2Path).ifM(
+          scanDirectory(filePath)(asInputCollection(childPath, input)),
+          input.docTypeMatcher(childPath) match {
+            case docType: TextDocumentType => InputTree[F](Seq(TextInput.fromFile(childPath, docType, filePath, input.codec)), Nil, Nil).pure[F]
+            case Static(formats)           => InputTree[F](Nil, Seq(BinaryInput.fromFile(childPath, filePath, formats)), Nil).pure[F]
+            case _                         => InputTree.empty[F].pure[F]
+          }
+        )
       )
     }
 

--- a/io/src/main/scala/laika/io/runtime/TransformerRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/TransformerRuntime.scala
@@ -22,11 +22,9 @@ import cats.implicits._
 import laika.bundle.ExtensionBundle
 import laika.factory.Format
 import laika.io.api.{BinaryTreeRenderer, BinaryTreeTransformer, TreeParser, TreeRenderer, TreeTransformer}
-import laika.io.model.{DirectoryInput, DirectoryOutput, InputTree, RenderedTreeRoot, TreeOutput}
+import laika.io.model.{DirectoryInput, DirectoryOutput, FileFilter, InputTree, RenderedTreeRoot, TreeOutput}
 import laika.theme.Theme
 import laika.theme.Theme.TreeProcessor
-
-import java.io.File
 
 /** Internal runtime for transform operations, for text and binary output as well
   * as parallel and sequential execution. 
@@ -41,9 +39,9 @@ object TransformerRuntime {
     def treeProcessor: Format => TreeProcessor[F] = theme.treeProcessor
   }
   
-  private def fileFilterFor (output: TreeOutput): File => Boolean = output match {
-    case DirectoryOutput(directory, _) => DirectoryInput.filter(directory)
-    case _ => _ => false
+  private def fileFilterFor (output: TreeOutput): FileFilter = output match {
+    case DirectoryOutput(directory, _) => DirectoryInput.filterDirectory(directory)
+    case _                             => FileFilter.lift(_ => false)
   } 
 
   /** Process the specified transform operation for an entire input tree and a character output format.

--- a/io/src/main/scala/laika/io/runtime/VersionedLinkTargets.scala
+++ b/io/src/main/scala/laika/io/runtime/VersionedLinkTargets.scala
@@ -26,10 +26,9 @@ import laika.ast.Path.Root
 import laika.ast.{DocumentType, Path, SegmentedPath}
 import laika.config.Config.ConfigResult
 import laika.config.{ConfigDecoder, ConfigException, ConfigParser}
-import laika.io.model.{BinaryInput, DirectoryInput}
+import laika.io.model.{BinaryInput, DirectoryInput, FilePath}
 import laika.rewrite.{VersionScannerConfig, Versions}
 
-import java.io.File
 import scala.io.Codec
 
 private[runtime] object VersionedLinkTargets {
@@ -50,7 +49,7 @@ private[runtime] object VersionedLinkTargets {
       case p @ SegmentedPath(segments, _, _) if included(p, segments) => Static()
       case _ => Ignored
     }
-    val input = DirectoryInput(Seq(new File(config.rootDirectory)), Codec.UTF8, docTypeMather)
+    val input = DirectoryInput(Seq(FilePath.parse(config.rootDirectory)), Codec.UTF8, docTypeMather)
     DirectoryScanner.scanDirectories(input).map { tree =>
       tree.binaryInputs
         .collect { case BinaryInput(path: SegmentedPath, _, _, _) if path.depth > 1 =>

--- a/io/src/main/scala/laika/io/runtime/VersionedLinkTargets.scala
+++ b/io/src/main/scala/laika/io/runtime/VersionedLinkTargets.scala
@@ -52,7 +52,7 @@ private[runtime] object VersionedLinkTargets {
     val input = DirectoryInput(Seq(FilePath.parse(config.rootDirectory)), Codec.UTF8, docTypeMather)
     DirectoryScanner.scanDirectories(input).map { tree =>
       tree.binaryInputs
-        .collect { case BinaryInput(path: SegmentedPath, _, _, _) if path.depth > 1 =>
+        .collect { case BinaryInput(_, path: SegmentedPath, _, _) if path.depth > 1 =>
           (path.segments.head, SegmentedPath(NonEmptyChain.fromChainUnsafe(path.segments.tail), path.suffix, None))
         }
         .groupBy(_._1)

--- a/io/src/main/scala/laika/render/epub/ContainerWriter.scala
+++ b/io/src/main/scala/laika/render/epub/ContainerWriter.scala
@@ -57,7 +57,7 @@ class ContainerWriter {
       if (path.suffix.contains("html")) contentRoot / path.withSuffix("xhtml").relative
       else contentRoot / path.relative
 
-    def toBinaryInput (content: String, path: Path): BinaryInput[F] = BinaryInput.fromString(path, content)
+    def toBinaryInput (content: String, path: Path): BinaryInput[F] = BinaryInput.fromString(content, path)
 
     val finalResult = result.copy[F](staticDocuments = result.staticDocuments)
     

--- a/io/src/test/scala/laika/ast/ConfigSpec.scala
+++ b/io/src/test/scala/laika/ast/ConfigSpec.scala
@@ -28,11 +28,9 @@ import laika.format.{Markdown, ReStructuredText}
 import laika.io.FileIO
 import laika.io.helper.{InputBuilder, TestThemeBuilder}
 import laika.io.implicits._
-import laika.io.model.{InputTreeBuilder, ParsedTree}
+import laika.io.model.{FilePath, InputTreeBuilder, ParsedTree}
 import laika.rewrite.{DefaultTemplatePath, TemplateContext, TemplateRewriter}
 import munit.CatsEffectSuite
-
-import java.io.File
 
 
 class ConfigSpec extends CatsEffectSuite
@@ -240,8 +238,8 @@ class ConfigSpec extends CatsEffectSuite
   }
 
   test("include file resources in directory configuration") {
-    def inputs(file: File) = Seq(
-      Root / "directory.conf" -> Contents.configWithFileInclude(file.getPath),
+    def inputs(file: FilePath) = Seq(
+      Root / "directory.conf" -> Contents.configWithFileInclude(file.toString),
       DefaultTemplatePath.forHTML -> Contents.templateWithoutConfig,
       Root / "input.md" -> Contents.markupWithRefs
     )
@@ -260,9 +258,9 @@ class ConfigSpec extends CatsEffectSuite
     
     val res = for {
       tempDir <- newTempDirectory
-      conf    =  new File(tempDir, "b.conf")
+      conf    =  tempDir / "b.conf"
       _       <- writeFile(conf, bConf)
-      _       <- writeFile(new File(tempDir, "c.conf"), "c = 3")
+      _       <- writeFile(tempDir / "c.conf", "c = 3")
       res     <- parseMD(build(inputs(conf)))
     } yield res
     

--- a/io/src/test/scala/laika/directive/std/IncludeDirectiveSpec.scala
+++ b/io/src/test/scala/laika/directive/std/IncludeDirectiveSpec.scala
@@ -22,7 +22,6 @@ import laika.ast.Path.Root
 import laika.ast._
 import laika.config.ConfigException
 import laika.format.Markdown
-import laika.io.FileIO
 import laika.io.api.TreeParser
 import laika.io.helper.InputBuilder
 import laika.io.implicits._
@@ -31,7 +30,7 @@ import laika.theme.Theme
 import munit.CatsEffectSuite
 
 
-class IncludeDirectiveSpec extends CatsEffectSuite with InputBuilder with FileIO {
+class IncludeDirectiveSpec extends CatsEffectSuite with InputBuilder {
 
   val parser: Resource[IO, TreeParser[IO]] = MarkupParser
     .of(Markdown)

--- a/io/src/test/scala/laika/io/FileIO.scala
+++ b/io/src/test/scala/laika/io/FileIO.scala
@@ -18,7 +18,6 @@ package laika.io
 
 import cats.effect.IO
 import fs2.io.file.Files
-import laika.ast.DocumentType
 import laika.ast.Path.Root
 import laika.io.model.{FilePath, TextInput, TextOutput}
 
@@ -29,15 +28,9 @@ trait FileIO {
 
   def readFile (base: String): IO[String] = readFile(FilePath.parse(base))
   
-  def readFile (f: FilePath): IO[String] = readFile(f, Codec.UTF8)
+  def readFile (f: FilePath)(implicit codec: Codec): IO[String] = TextInput.fromFile[IO](f).input
 
-  def readFile (f: FilePath, codec: Codec): IO[String] = {
-    val input = TextInput.fromFile[IO](Root, DocumentType.Markup, f, codec)
-    input.asDocumentInput.map(_.source.input)
-  }
-
-  def writeFile (f: FilePath, content: String): IO[Unit] =
-    TextOutput.forFile[IO](Root, f, Codec.UTF8).writer(content)
+  def writeFile (f: FilePath, content: String): IO[Unit] = TextOutput.forFile[IO](f).writer(content)
 
   def newTempDirectory: IO[FilePath] = Files[IO].createTempDirectory.map(FilePath.fromFS2Path)
 

--- a/io/src/test/scala/laika/io/FileIO.scala
+++ b/io/src/test/scala/laika/io/FileIO.scala
@@ -20,36 +20,34 @@ import cats.effect.IO
 import fs2.io.file.Files
 import laika.ast.DocumentType
 import laika.ast.Path.Root
-import laika.io.model.{TextInput, TextOutput}
+import laika.io.model.{FilePath, TextInput, TextOutput}
 
-import java.io.{ByteArrayOutputStream, File}
+import java.io.ByteArrayOutputStream
 import scala.io.Codec
 
 trait FileIO {
 
-  def readFile (base: String): IO[String] = readFile(new File(base))
+  def readFile (base: String): IO[String] = readFile(FilePath.parse(base))
   
-  def readFile (f: File): IO[String] = readFile(f, Codec.UTF8)
+  def readFile (f: FilePath): IO[String] = readFile(f, Codec.UTF8)
 
-  def readFile (f: File, codec: Codec): IO[String] = {
+  def readFile (f: FilePath, codec: Codec): IO[String] = {
     val input = TextInput.fromFile[IO](Root, DocumentType.Markup, f, codec)
     input.asDocumentInput.map(_.source.input)
   }
 
-  def writeFile (f: File, content: String): IO[Unit] =
+  def writeFile (f: FilePath, content: String): IO[Unit] =
     TextOutput.forFile[IO](Root, f, Codec.UTF8).writer(content)
 
-  def newTempDirectory: IO[File] = Files[IO].createTempDirectory.map(_.toNioPath.toFile)
+  def newTempDirectory: IO[FilePath] = Files[IO].createTempDirectory.map(FilePath.fromFS2Path)
 
-  def newTempFile: IO[File] = Files[IO].createTempFile.map(_.toNioPath.toFile)
+  def newTempFile: IO[FilePath] = Files[IO].createTempFile.map(FilePath.fromFS2Path)
   
-  def fs2Path(f: File): fs2.io.file.Path = fs2.io.file.Path.fromNioPath(f.toPath)
-  
-  def mkDir (f: File): IO[Unit] = Files[IO].createDirectory(fs2Path(f))
+  def mkDir (f: FilePath): IO[Unit] = Files[IO].createDirectory(f.toFS2Path)
 
-  def delete (f: File): IO[Unit] = Files[IO].delete(fs2Path(f))
+  def delete (f: FilePath): IO[Unit] = Files[IO].delete(f.toFS2Path)
   
-  def exists (f: File): IO[Boolean] = Files[IO].exists(fs2Path(f))
+  def exists (f: FilePath): IO[Boolean] = Files[IO].exists(f.toFS2Path)
 
   def withByteArrayTextOutput (charSet: String)(f: ByteArrayOutputStream => IO[Unit]): IO[String] =
     for {

--- a/io/src/test/scala/laika/io/TreeParserFileIOSpec.scala
+++ b/io/src/test/scala/laika/io/TreeParserFileIOSpec.scala
@@ -27,7 +27,7 @@ import laika.config.{ConfigBuilder, Origin}
 import laika.config.Origin.TreeScope
 import laika.io.api.TreeParser
 import laika.io.helper.TestThemeBuilder
-import laika.io.model.{InputTree, InputTreeBuilder}
+import laika.io.model.{FileFilter, FilePath, InputTree, InputTreeBuilder}
 import munit.CatsEffectSuite
 
 import java.io.ByteArrayInputStream
@@ -94,9 +94,11 @@ class TreeParserFileIOSpec
         content = baseTree.tree.content.filter(c => c.path.name != "doc-1.md" && c.path.name != "tree-1")
       )
     )
+    
+    val fileFilter = FileFilter.lift(f => f.name == "doc-1.md" || f.name == "tree-1")
 
     defaultParser
-      .use(_.fromDirectory(dirname, { (f: java.io.File) => f.getName == "doc-1.md" || f.getName == "tree-1" }).parse)
+      .use(_.fromDirectory(dirname, fileFilter).parse)
       .map(_.root)
       .assertEquals(expected)
   }
@@ -303,8 +305,8 @@ class TreeParserFileIOSpec
   
 
   trait DirectorySetup {
-    val dir1 = new java.io.File(getClass.getResource("/trees/a/").getFile)
-    val dir2 = new java.io.File(getClass.getResource("/trees/b/").getFile)
+    val dir1 = FilePath.parse(getClass.getResource("/trees/a/").getFile)
+    val dir2 = FilePath.parse(getClass.getResource("/trees/b/").getFile)
 
     val baseTree: DocumentTreeRoot = SampleTrees.sixDocuments
       .docContent(key => Seq(p("Doc" + key.num)))

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -104,7 +104,7 @@ class TreeRendererSpec extends CatsEffectSuite
       TemplateRoot.fallback,
       Config.empty,
       coverDocument = coverDocument,
-      staticDocuments = staticDocuments.map(Inputs.ByteInput.apply(_))
+      staticDocuments = staticDocuments.map(Inputs.ByteInput.empty(_))
     )
     
     def tree (path: Path, content: Seq[RenderContent]): RenderedTree = RenderedTree(path, None, content)
@@ -836,7 +836,7 @@ class TreeRendererSpec extends CatsEffectSuite
         |    { "path": "/tree-2/doc-6.html", "versions": ["0.1","0.2"] }
         |  ]
         |}""".stripMargin
-    val versionInfoInput = BinaryInput.fromString[IO](VersionInfoGenerator.path, existingVersionInfo)
+    val versionInfoInput = BinaryInput.fromString[IO](existingVersionInfo, VersionInfoGenerator.path)
 
     htmlRenderer
       .use(_
@@ -910,7 +910,7 @@ class TreeRendererSpec extends CatsEffectSuite
     val res = for {
       d <- newTempDirectory
       _ <- ASTRenderer.defaultRenderer.use(_.from(ASTRenderer.defaultRoot(input)).toDirectory(d)(Codec.ISO8859).render)
-      res <- readFile(d / "doc.txt", Codec.ISO8859)
+      res <- readFile(d / "doc.txt")(Codec.ISO8859)
     } yield res
 
     res.assertEquals(expected)

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -19,7 +19,6 @@ package laika.io
 import cats.data.{Chain, NonEmptyChain}
 import cats.effect.{Async, IO, Resource}
 import cats.syntax.all._
-import fs2.io.file
 import fs2.io.file.Files
 import laika.api.Renderer
 import laika.ast.Path.Root
@@ -45,7 +44,6 @@ import laika.rewrite.nav.TargetFormats
 import laika.rewrite.{DefaultTemplatePath, Version, VersionScannerConfig, Versions}
 import munit.CatsEffectSuite
 
-import java.io.File
 import scala.io.Codec
 
 class TreeRendererSpec extends CatsEffectSuite 
@@ -773,7 +771,7 @@ class TreeRendererSpec extends CatsEffectSuite
     val res = for {
       f   <- newTempDirectory
       _   <- renderer.use(_.from(FileSystemTest.input).toDirectory(f).render)
-      res <- FileSystemTest.readFiles(f.getPath)
+      res <- FileSystemTest.readFiles(f.toString)
     } yield res
     
     res.assertEquals(expectedFileContents)  
@@ -859,18 +857,17 @@ class TreeRendererSpec extends CatsEffectSuite
   test("directory with existing versioned renderer output") {
     import VersionInfoSetup._
       
-    def mkDirs (dir: File): IO[Unit] = 
+    def mkDirs (dir: FilePath): IO[Unit] = 
       List("0.1/tree-1", "0.1/tree-2", "0.2/tree-1", "0.2/tree-2", "0.3/tree-1", "0.3/tree-2").traverse { name =>
-        Files[IO].createDirectories(fs2.io.file.Path.fromNioPath(new File(dir, name).toPath))
+        Files[IO].createDirectories((dir / name).toFS2Path)
       }.void
 
-    def writeExistingVersionedFiles (root: DocumentTreeRoot, dir: File): IO[Unit] = {
+    def writeExistingVersionedFiles (root: DocumentTreeRoot, dir: FilePath): IO[Unit] = {
       val paths = root.tree.allDocuments.map(_.path.withSuffix("html").toString)
       val versionedPaths = paths.map("0.1" + _) ++ paths.drop(1).map("0.2" + _) ++ paths.dropRight(1).map("0.3" + _)
       
       versionedPaths.toList.traverse { path =>
-        val file = new File(dir, path)
-        writeFile(file, "<html></html>")
+        writeFile(dir / path, "<html></html>")
       }.void
     }
 
@@ -891,12 +888,12 @@ class TreeRendererSpec extends CatsEffectSuite
     
     val res = for {
       f    <- newTempDirectory
-      root =  versionedInput(Some(f.getAbsolutePath))
+      root =  versionedInput(Some(f.toString))
       _    <- mkDirs(f)
       _    <- writeExistingVersionedFiles(root, f)
       _    <- htmlRenderer.use(_.from(root).toDirectory(f).render)
-      res  <- readVersionedFiles(f.getPath)
-      vi   <- readVersionInfo(f.getPath)
+      res  <- readVersionedFiles(f.toString)
+      vi   <- readVersionInfo(f.toString)
     } yield (res, vi)
 
     res.assertEquals((expectedFileContents, expectedVersionInfo))
@@ -911,9 +908,9 @@ class TreeRendererSpec extends CatsEffectSuite
     val input = ASTRenderer.defaultTree(RootElement(p("Doc äöü")))
 
     val res = for {
-      f <- newTempDirectory
-      _ <- ASTRenderer.defaultRenderer.use(_.from(ASTRenderer.defaultRoot(input)).toDirectory(f)(Codec.ISO8859).render)
-      res <- readFile(new File(f, "doc.txt"), Codec.ISO8859)
+      d <- newTempDirectory
+      _ <- ASTRenderer.defaultRenderer.use(_.from(ASTRenderer.defaultRoot(input)).toDirectory(d)(Codec.ISO8859).render)
+      res <- readFile(d / "doc.txt", Codec.ISO8859)
     } yield res
 
     res.assertEquals(expected)

--- a/io/src/test/scala/laika/io/TreeTransformerSpec.scala
+++ b/io/src/test/scala/laika/io/TreeTransformerSpec.scala
@@ -138,7 +138,7 @@ class TreeTransformerSpec extends CatsEffectSuite
     TemplateRoot.fallback,
     Config.empty,
     coverDocument = coverDocument,
-    staticDocuments = staticDocuments.map(ByteInput.apply(_))
+    staticDocuments = staticDocuments.map(ByteInput.empty(_))
   )
 
   def renderedTree(path: Path, content: Seq[RenderContent]): RenderedTree = RenderedTree(path, None, content)

--- a/io/src/test/scala/laika/io/helper/InputBuilder.scala
+++ b/io/src/test/scala/laika/io/helper/InputBuilder.scala
@@ -24,9 +24,11 @@ import laika.rewrite.nav.TargetFormats
 trait InputBuilder {
 
   object ByteInput {
+    
     def apply (input: String, path: Path, targetFormats: TargetFormats = TargetFormats.All): BinaryInput[IO] =
-      BinaryInput.fromString(path, input, targetFormats)
-    def apply (path: Path): BinaryInput[IO] = BinaryInput.fromString(path, "")
+      BinaryInput.fromString(input, path, targetFormats)
+      
+    def empty (path: Path): BinaryInput[IO] = BinaryInput.fromString("", path)
   }
   
   def build (inputs: Seq[(Path, String)], docTypeMatcher: Path => DocumentType): IO[InputTree[IO]] =

--- a/io/src/test/scala/laika/io/model/FilePathSpec.scala
+++ b/io/src/test/scala/laika/io/model/FilePathSpec.scala
@@ -70,6 +70,7 @@ class FilePathSpec extends FunSuite {
 
   test("round trip relative FilePath from and to NIO path") {
     val inPath = Paths.get(relTestPathString)
+    inPath.resolve("foo")
     val outPath = FilePath.fromNioPath(inPath).toNioPath
     assertEquals(outPath, inPath.normalize())
   }
@@ -83,7 +84,6 @@ class FilePathSpec extends FunSuite {
   test("round trip relative FilePath from and to Java file") {
     val inPath = new File(relTestPathString)
     val outPath = FilePath.fromJavaFile(inPath).toJavaFile
-    val remove = ".." + platformSeparator
     assertEquals(outPath, new File(List("foo", "baz.jpg").mkString(platformSeparator)))
   }
   

--- a/io/src/test/scala/laika/io/model/FilePathSpec.scala
+++ b/io/src/test/scala/laika/io/model/FilePathSpec.scala
@@ -26,45 +26,65 @@ class FilePathSpec extends FunSuite {
   private val platformSeparator = FileSystems.getDefault.getSeparator
   private val platformRoot = Paths.get(System.getProperty("user.dir")).getRoot.toString
 
-  private val testPathString = platformRoot + List("foo", "bar", "..", "baz.jpg").mkString(platformSeparator)
+  private val absTestPathString = platformRoot + List("foo", "bar", "..", "baz.jpg").mkString(platformSeparator)
+  private val relTestPathString = List("foo", "bar", "..", "baz.jpg").mkString(platformSeparator)
   private val expectedPath = platformRoot + List("foo", "baz.gif").mkString(platformSeparator)
 
   test("create and modify normalized FilePath from NIO path") {
-    val path = FilePath.fromNioPath(Paths.get(testPathString))
+    val path = FilePath.fromNioPath(Paths.get(absTestPathString))
     assertEquals(path.withSuffix("gif").toString, expectedPath)
   }
 
   test("create and modify normalized FilePath from fs2 path") {
-    val path = FilePath.fromFS2Path(fs2.io.file.Path.fromNioPath(Paths.get(testPathString)))
+    val path = FilePath.fromFS2Path(fs2.io.file.Path.fromNioPath(Paths.get(absTestPathString)))
     assertEquals(path.withSuffix("gif").toString, expectedPath)
   }
 
   test("create and modify normalized FilePath from Java File") {
-    val path = FilePath.fromJavaFile(new File(testPathString))
+    val path = FilePath.fromJavaFile(new File(absTestPathString))
     assertEquals(path.withSuffix("gif").toString, expectedPath)
   }
 
   test("create and modify normalized FilePath from parsed string") {
-    val path = FilePath.parse(testPathString)
+    val path = FilePath.parse(absTestPathString)
     assertEquals(path.withSuffix("gif").toString, expectedPath)
   }
 
-  test("round trip FilePath from and to NIO path") {
-    val inPath = Paths.get(testPathString)
+  test("round trip absolute FilePath from and to NIO path") {
+    val inPath = Paths.get(absTestPathString)
     val outPath = FilePath.fromNioPath(inPath).toNioPath
     assertEquals(outPath, inPath.normalize())
   }
 
-  test("round trip FilePath from and to fs2 path") {
-    val inPath = fs2.io.file.Path.fromNioPath(Paths.get(testPathString))
+  test("round trip absolute FilePath from and to fs2 path") {
+    val inPath = fs2.io.file.Path.fromNioPath(Paths.get(absTestPathString))
     val outPath = FilePath.fromFS2Path(inPath).toFS2Path
     assertEquals(outPath, inPath.normalize)
   }
 
-  test("round trip FilePath from and to Java file") {
-    val inPath = new File(testPathString)
+  test("round trip absolute FilePath from and to Java file") {
+    val inPath = new File(absTestPathString)
     val outPath = FilePath.fromJavaFile(inPath).toJavaFile
     assertEquals(outPath, inPath.getCanonicalFile)
+  }
+
+  test("round trip relative FilePath from and to NIO path") {
+    val inPath = Paths.get(relTestPathString)
+    val outPath = FilePath.fromNioPath(inPath).toNioPath
+    assertEquals(outPath, inPath.normalize())
+  }
+
+  test("round trip relative FilePath from and to fs2 path") {
+    val inPath = fs2.io.file.Path.fromNioPath(Paths.get(relTestPathString))
+    val outPath = FilePath.fromFS2Path(inPath).toFS2Path
+    assertEquals(outPath, inPath.normalize)
+  }
+
+  test("round trip relative FilePath from and to Java file") {
+    val inPath = new File(relTestPathString)
+    val outPath = FilePath.fromJavaFile(inPath).toJavaFile
+    val remove = ".." + platformSeparator
+    assertEquals(outPath, new File(List("foo", "baz.jpg").mkString(platformSeparator)))
   }
   
 }

--- a/io/src/test/scala/laika/render/epub/XHTMLRendererSpec.scala
+++ b/io/src/test/scala/laika/render/epub/XHTMLRendererSpec.scala
@@ -22,14 +22,13 @@ import laika.ast._
 import laika.ast.sample.ParagraphCompanionShortcuts
 import laika.config.{ConfigBuilder, LaikaKeys}
 import laika.format.EPUB
-import laika.io.FileIO
 import laika.rewrite.nav.{ConfigurablePathTranslator, TargetFormats, TranslatorConfig, TranslatorSpec}
 import munit.CatsEffectSuite
 
 /**
   * @author Jens Halm
   */
-class XHTMLRendererSpec extends CatsEffectSuite with ParagraphCompanionShortcuts with FileIO {
+class XHTMLRendererSpec extends CatsEffectSuite with ParagraphCompanionShortcuts {
 
   private val defaultRenderer = Renderer.of(EPUB.XHTML).build
   

--- a/pdf/src/main/scala/laika/render/pdf/FopFactoryBuilder.scala
+++ b/pdf/src/main/scala/laika/render/pdf/FopFactoryBuilder.scala
@@ -18,7 +18,7 @@ package laika.render.pdf
 
 import java.io.{ByteArrayInputStream, File}
 
-import cats.effect.{Async, Sync}
+import cats.effect.Async
 import cats.effect.std.Dispatcher
 import laika.format.PDF
 import laika.io.model.BinaryInput

--- a/pdf/src/test/scala/laika/render/PDFRendererSpec.scala
+++ b/pdf/src/test/scala/laika/render/PDFRendererSpec.scala
@@ -22,11 +22,11 @@ import laika.ast.{DocumentTree, DocumentTreeRoot}
 import laika.format.{Markdown, PDF}
 import laika.io.FileIO
 import laika.io.implicits._
-import laika.io.model.{InputTree, ParsedTree}
+import laika.io.model.{FilePath, InputTree, ParsedTree}
 import laika.rewrite.DefaultTemplatePath
 import munit.CatsEffectSuite
 
-import java.io.{BufferedInputStream, File, FileInputStream}
+import java.io.{BufferedInputStream, FileInputStream}
 
 /** Since there is no straightforward way to validate a rendered PDF document
  *  on the JVM, this Spec merely asserts that a file or OutputStream is non-empty
@@ -39,20 +39,6 @@ import java.io.{BufferedInputStream, File, FileInputStream}
  */
 class PDFRendererSpec extends CatsEffectSuite with FileIO with PDFTreeModel {
 
-  
-  class FileSetup {
-    
-    val file: File = File.createTempFile("output", null)
-    
-    val firstChar: IO[Int] = for {
-      in   <- IO(new BufferedInputStream(new FileInputStream(file)))
-      read <- IO(in.read)
-    } yield read
-    
-    def firstCharAvailable(render: IO[Unit]): IO[Unit] = (render >> firstChar).map(_ != -1).assert
-  }
-  
-  
   private val templateParser = MarkupParser.of(Markdown).parallel[IO].build
   
   // run a parser with an empty input tree to obtain a parsed default template
@@ -67,16 +53,24 @@ class PDFRendererSpec extends CatsEffectSuite with FileIO with PDFTreeModel {
   }
 
   test("render a tree to a file") {
-    val fileSetup = new FileSetup
+
+    def readFirstChar(f: FilePath): IO[Int] = for {
+      in   <- IO(new BufferedInputStream(new FileInputStream(f.toJavaFile)))
+      read <- IO(in.read)
+    } yield read
+
     val renderer = Renderer.of(PDF)
       .parallel[IO]
       .build
 
-    val res = renderer.use { r => emptyTreeWithTemplate.flatMap { templateTree =>
-      r.from(buildInputTree(templateTree, createTree())).toFile(fileSetup.file).render
-    }}
-
-    fileSetup.firstCharAvailable(res)
+    newTempFile.flatMap { tempFile =>
+      
+      val res = renderer.use { r => emptyTreeWithTemplate.flatMap { templateTree =>
+        r.from(buildInputTree(templateTree, createTree())).toFile(tempFile).render
+      }}
+  
+      (res >> readFirstChar(tempFile)).map(_ != -1).assert
+    }
   }
 
   test("render a tree to an OutputStream") {

--- a/pdf/src/test/scala/laika/render/PDFRendererSpec.scala
+++ b/pdf/src/test/scala/laika/render/PDFRendererSpec.scala
@@ -17,6 +17,7 @@
 package laika.render
 
 import cats.effect.IO
+import fs2.io.file.Files
 import laika.api.{MarkupParser, Renderer}
 import laika.ast.{DocumentTree, DocumentTreeRoot}
 import laika.format.{Markdown, PDF}
@@ -54,11 +55,6 @@ class PDFRendererSpec extends CatsEffectSuite with FileIO with PDFTreeModel {
 
   test("render a tree to a file") {
 
-    def readFirstChar(f: FilePath): IO[Int] = for {
-      in   <- IO(new BufferedInputStream(new FileInputStream(f.toJavaFile)))
-      read <- IO(in.read)
-    } yield read
-
     val renderer = Renderer.of(PDF)
       .parallel[IO]
       .build
@@ -69,7 +65,7 @@ class PDFRendererSpec extends CatsEffectSuite with FileIO with PDFTreeModel {
         r.from(buildInputTree(templateTree, createTree())).toFile(tempFile).render
       }}
   
-      (res >> readFirstChar(tempFile)).map(_ != -1).assert
+      (res >> Files[IO].size(tempFile.toFS2Path)).map(_ > 0).assert
     }
   }
 

--- a/preview/src/main/scala/laika/preview/ServerBuilder.scala
+++ b/preview/src/main/scala/laika/preview/ServerBuilder.scala
@@ -27,7 +27,7 @@ import laika.ast
 import laika.ast.DocumentType
 import laika.format.{EPUB, PDF}
 import laika.io.api.TreeParser
-import laika.io.model.InputTreeBuilder
+import laika.io.model.{FilePath, InputTreeBuilder}
 import laika.preview.ServerBuilder.Logger
 import org.http4s.dsl.Http4sDsl
 import org.http4s.{HttpApp, HttpRoutes, Request}
@@ -140,7 +140,7 @@ class ServerConfig private (val port: Port,
                             val includeEPUB: Boolean,
                             val includePDF: Boolean,
                             val isVerbose: Boolean,
-                            val apiDir: Option[File]) {
+                            val apiDir: Option[FilePath]) {
 
   private def copy (newPort: Port = port,
                     newHost: Host = host,
@@ -149,7 +149,7 @@ class ServerConfig private (val port: Port,
                     newIncludeEPUB: Boolean = includeEPUB,
                     newIncludePDF: Boolean = includePDF,
                     newVerbose: Boolean = isVerbose,
-                    newAPIDir: Option[File] = apiDir): ServerConfig =
+                    newAPIDir: Option[FilePath] = apiDir): ServerConfig =
     new ServerConfig(newPort, newHost,newPollInterval, newArtifactBasename, newIncludeEPUB, newIncludePDF, newVerbose, newAPIDir)
 
   /** Specifies the port the server should run on (default 4242).
@@ -180,7 +180,10 @@ class ServerConfig private (val port: Port,
   /** Specifies a directory from which API documentation of the site can be served.
     * This step is only necessary if you want to test links to API documentation with the preview server.
     */
-  def withAPIDirectory (dir: File): ServerConfig = copy(newAPIDir = Some(dir))
+  def withAPIDirectory (dir: FilePath): ServerConfig = copy(newAPIDir = Some(dir))
+
+  @deprecated("use withAPIDirectory(FilePath)", "0.19.0")
+  def withAPIDirectory (dir: File): ServerConfig = copy(newAPIDir = Some(FilePath.fromJavaFile(dir)))
 
   /** Indicates that each served page and each detected file change should be logged to the console.
     */

--- a/preview/src/main/scala/laika/preview/SiteTransformer.scala
+++ b/preview/src/main/scala/laika/preview/SiteTransformer.scala
@@ -29,12 +29,12 @@ import laika.format.HTML
 import laika.io.api.{BinaryTreeRenderer, TreeParser, TreeRenderer}
 import laika.io.config.SiteConfig
 import laika.io.implicits._
-import laika.io.model.{BinaryInput, InputTree, InputTreeBuilder, ParsedTree, StringTreeOutput}
+import laika.io.model._
 import laika.preview.SiteTransformer.ResultMap
 import laika.rewrite.nav.{Selections, TargetFormats}
 import laika.theme.Theme
 
-import java.io.{ByteArrayOutputStream, File}
+import java.io.ByteArrayOutputStream
 
 private [preview] class SiteTransformer[F[_]: Async] (val parser: TreeParser[F], 
                                                       htmlRenderer: TreeRenderer[F],
@@ -131,7 +131,7 @@ private [preview] object SiteTransformer {
   def create[F[_]: Async](parser: Resource[F, TreeParser[F]],
                           inputs: InputTreeBuilder[F],
                           renderFormats: List[TwoPhaseRenderFormat[_, BinaryPostProcessorBuilder]],
-                          apiDir: Option[File],
+                          apiDir: Option[FilePath],
                           artifactBasename: String): Resource[F, SiteTransformer[F]] = {
     
     def adjustConfig (p: TreeParser[F]): TreeParser[F] = p.modifyConfig(oc => oc.copy(

--- a/preview/src/main/scala/laika/preview/SiteTransformer.scala
+++ b/preview/src/main/scala/laika/preview/SiteTransformer.scala
@@ -142,7 +142,7 @@ private [preview] object SiteTransformer {
     
     def asInputTree (map: ResultMap[F]): InputTree[F] = {
       val inputs = map.collect {
-        case (path, static: StaticResult[F]) => BinaryInput(path, static.content, TargetFormats.Selected("html")) 
+        case (path, static: StaticResult[F]) => BinaryInput(static.content, path, TargetFormats.Selected("html")) 
       }
       new InputTree[F](binaryInputs = inputs.toSeq)
     }

--- a/preview/src/main/scala/laika/preview/StaticFileScanner.scala
+++ b/preview/src/main/scala/laika/preview/StaticFileScanner.scala
@@ -33,11 +33,11 @@ private[preview] object StaticFileScanner {
   private def collect[F[_]: Async] (filePath: FilePath, vPath: Path = Root): F[List[(Path, SiteResult[F])]] = {
     DirectoryScanner.scanDirectory(filePath) { paths =>
       paths.toList
-        .map { path =>
-          val vChild = vPath / path.name
-          def result: (Path, SiteResult[F]) = (vChild, StaticResult(BinaryInput.fromFile(vPath, path).input))
-          Files[F].isDirectory(path.toFS2Path).ifM(
-            collect(path, vChild),
+        .map { filePath =>
+          val vChild = vPath / filePath.name
+          def result: (Path, SiteResult[F]) = (vChild, StaticResult(BinaryInput.fromFile(filePath, vPath).input))
+          Files[F].isDirectory(filePath.toFS2Path).ifM(
+            collect(filePath, vChild),
             Async[F].pure(List(result))
           )
         }

--- a/sbt/src/main/scala/laika/sbt/Tasks.scala
+++ b/sbt/src/main/scala/laika/sbt/Tasks.scala
@@ -117,7 +117,7 @@ object Tasks {
         .build
         .use(_
           .from(tree)
-          .toDirectory(targetDir)(userConfig.encoding)
+          .toDirectory(FilePath.fromJavaFile(targetDir))(userConfig.encoding)
           .render
         )
         .unsafeRunSync()      
@@ -147,7 +147,7 @@ object Tasks {
             renderer
               .from(root)
               .copying(tree.staticDocuments)
-              .toFile(file)
+              .toFile(FilePath.fromJavaFile(file))
               .render
               .as(file)
           }.sequence
@@ -201,7 +201,7 @@ object Tasks {
     
     val applyFlags = applyIf(laikaIncludeEPUB.value, _.withEPUBDownloads)
       .andThen(applyIf(laikaIncludePDF.value, _.withPDFDownloads))
-      .andThen(applyIf(laikaIncludeAPI.value, _.withAPIDirectory(Settings.apiTargetDirectory.value)))
+      .andThen(applyIf(laikaIncludeAPI.value, _.withAPIDirectory(FilePath.fromJavaFile(Settings.apiTargetDirectory.value))))
       .andThen(applyIf(previewConfig.isVerbose, _.verbose))
     
     val config = ServerConfig.defaults
@@ -306,8 +306,8 @@ object Tasks {
     * Ignores any virtual inputs in the input trees.
     */
   def collectInputFiles (inputs: InputTree[IO]): Set[File] = 
-    inputs.textInputs.flatMap(_.sourceFile).toSet ++ 
-      inputs.binaryInputs.flatMap(_.sourceFile)
+    inputs.textInputs.flatMap(_.sourceFile.map(_.toJavaFile)).toSet ++ 
+      inputs.binaryInputs.flatMap(_.sourceFile.map(_.toJavaFile))
 
   /** Enumeration of output formats supported by the plugin.
     */


### PR DESCRIPTION
This PR is not strictly part of the fs2 migration, but related in the effort to reduce the use of Java APIs in Laika's public API. It's a collection of related changes listed below:

**Deprecate API expecting `java.io.File` in favour of Laika's own `FilePath` type**

* Methods in user-facing public APIs that expect as a parameter a single instance of type `java.io.File` are deprecated
* Methods in user-facing public APIs that expect a `Seq[File]` are modified without deprecation, due to type erasure preventing an overload of the deprecated and new method. Since APIs taking a single file are probably more commonly used, this breaking change is hopefully acceptable.
* Methods in public-internal APIs are simply changed without deprecation.

**Introduce a new `FileFilter` trait**

Previously some APIs expected an argument of type `File => Boolean` which was limited in that it did not allow for effectful filter logic. This PR introduces a new trait that overcomes that limitation and uses it in APIs where the pure function has previously been used:

```scala
trait FileFilter {
  def filter[F[_] : Async] (file: FilePath): F[Boolean]
}
```

**Other small changes**

* Deprecates `InputOps.fromWorkingDirectory` and `TextOutputOps.toWorkingDirectory` in favor of asking users to pass a relative `FilePath`.
* The order of arguments for the builder methods in `TextInput`, `TextOutput`, `BinaryInput` and `BinaryOutput` have been aligned with the order of similar methods in the user-facing APIs.
