### PR TITLE
add InputTreeBuilder.describe + report missing directories

### DIFF
--- a/io/src/main/scala/laika/io/runtime/ParserRuntime.scala
+++ b/io/src/main/scala/laika/io/runtime/ParserRuntime.scala
@@ -137,6 +137,9 @@ object ParserRuntime {
   case class DuplicatePath (path: Path, filePaths: Set[String] = Set.empty) extends
     RuntimeException(s"Duplicate path: $path ${filePathMessage(filePaths)}")
 
+  case class MissingDirectory (path: FilePath) extends
+    RuntimeException(s"Path does not exist or is not a directory: ${path.toString}")
+
   case class ParserErrors (errors: Set[Throwable]) extends
     RuntimeException(s"Multiple errors during parsing: ${errors.map(_.getMessage).mkString(", ")}")
 

--- a/io/src/test/scala/laika/io/TreeTransformerSpec.scala
+++ b/io/src/test/scala/laika/io/TreeTransformerSpec.scala
@@ -547,15 +547,21 @@ class TreeTransformerSpec extends CatsEffectSuite
                      |  Render Formatted: true
                      |Sources:
                      |  Markup File(s)
-                     |    In-memory string or stream
+                     |    /dir1/doc3.md: in-memory string or stream
+                     |    /dir1/doc4.md: in-memory string or stream
+                     |    /dir2/doc5.md: in-memory string or stream
+                     |    /dir2/doc6.md: in-memory string or stream
+                     |    /doc1.md: in-memory string or stream
+                     |    /doc2.rst: in-memory string or stream
                      |  Template(s)
-                     |    In-memory string or stream
+                     |    /default.template.txt: in-memory string or stream
+                     |    /dir1/default.template.txt: in-memory string or stream
                      |  Configuration Files(s)
                      |    -
                      |  CSS for PDF
                      |    -
                      |  Copied File(s)
-                     |    In-memory bytes or stream
+                     |    /dir2/omg.js: in-memory bytes or stream
                      |  Root Directories
                      |    -
                      |Target:


### PR DESCRIPTION
Previously missing directories were simply omitted in all descriptors. Given that the functionality is mostly intended to assist in logging or debugging it made sense to improve on this.

The new `InputTreeBuilder.describe` method is used from `TreeParser.Op.describe` and similar APIs which in turn are used by the `laikaDescribe` task of the sbt plugin.

The functionality required some modest refactoring inside `InputTreeBuilder`.