### PR TITLE
add new extension point for custom PathTranslators

### DIFF
--- a/core/shared/src/main/scala/laika/bundle/ExtensionBundle.scala
+++ b/core/shared/src/main/scala/laika/bundle/ExtensionBundle.scala
@@ -18,9 +18,12 @@ package laika.bundle
 
 import laika.ast.RewriteRules.RewriteRulesBuilder
 import laika.ast._
+import laika.bundle.ExtensionBundle.PathTranslatorExtensionContext
 import laika.config.Config
 import laika.parse.css.CSSParsers
+import laika.rewrite.OutputContext
 import laika.rewrite.link.SlugBuilder
+import laika.rewrite.nav.PathTranslator
 
 /** An extension bundle is a collection of parser extensions, rewrite rules, render overrides
   * and other features to be applied to parse, render and transform operations. It serves
@@ -116,6 +119,23 @@ trait ExtensionBundle { self =>
     */
   def renderOverrides: Seq[RenderOverrides] = Seq.empty
 
+  /** Extends the built-in path translator with additional functionality.
+    * 
+    * The internal path translator deals with aspects like applying the suffix for the output format
+    * or modifying the path for versioned documents and more.
+    * 
+    * The `PathTranslatorExtensionContext` provides access to this internal path translator, to the output
+    * format it is going to be used for and the complete user configuration.
+    * 
+    * In most cases, extensions can simply be created by using either `PathTranslator.preTranslate`
+    * or `PathTranslator.postTranslate` to apply additional translation steps either before or after 
+    * applying the internal translator.
+    * 
+    * Alternatively a completely custom implementation of the `PathTranslator` trait can be provided,
+    * but this will usually not be necessary.
+    */
+  def extendPathTranslator: PartialFunction[PathTranslatorExtensionContext, PathTranslator] = PartialFunction.empty
+  
   /** Internal API usually only called by other extension bundles.
     *
     * In some cases a bundle might be an extension of another bundle and needs the opportunity
@@ -162,6 +182,21 @@ trait ExtensionBundle { self =>
 
     override lazy val renderOverrides = self.renderOverrides ++ base.renderOverrides
 
+    override def extendPathTranslator: PartialFunction[PathTranslatorExtensionContext, PathTranslator] =
+      new PartialFunction[PathTranslatorExtensionContext, PathTranslator] {
+
+        def isDefinedAt (ctx: PathTranslatorExtensionContext): Boolean =
+          self.extendPathTranslator.isDefinedAt(ctx) || base.extendPathTranslator.isDefinedAt(ctx)
+
+        def apply (ctx: PathTranslatorExtensionContext): PathTranslator = {
+          val newPathTranslator = base.extendPathTranslator
+            .applyOrElse[PathTranslatorExtensionContext, PathTranslator](ctx, _.baseTranslator)
+          val newCtx = new PathTranslatorExtensionContext(newPathTranslator, ctx.outputContext, ctx.config)
+          self.extendPathTranslator
+            .applyOrElse[PathTranslatorExtensionContext, PathTranslator](newCtx, _.baseTranslator)
+        }
+      }
+
     override def processExtension: PartialFunction[ExtensionBundle, ExtensionBundle] =
       self.processExtension.orElse(base.processExtension)
   }
@@ -193,6 +228,15 @@ trait ExtensionBundle { self =>
 /** Provides default ExtensionBundle instances.
   */
 object ExtensionBundle {
+
+  /** The context that is provided to builders for path translator extensions.
+    * 
+    * @param baseTranslator the internal path translator that can be used for delegating most translation steps to
+    * @param outputContext  the context for the output format the translator is used for 
+    *                       (since translators are different per render format)
+    * @param config         the complete user configuration for the current transformation
+    */
+  class PathTranslatorExtensionContext (val baseTranslator: PathTranslator, val outputContext: OutputContext, val config: Config)
 
   /** An empty bundle */
   object Empty extends ExtensionBundle {

--- a/core/shared/src/test/scala/laika/bundle/BundleProvider.scala
+++ b/core/shared/src/test/scala/laika/bundle/BundleProvider.scala
@@ -22,6 +22,7 @@ import laika.ast._
 import laika.directive.{DirectiveRegistry, Templates}
 import laika.parse.Parser
 import laika.parse.markup.DocumentParser.DocumentInput
+import laika.rewrite.nav.PathTranslator
 
 /**
   * @author Jens Halm
@@ -88,6 +89,14 @@ object BundleProvider {
 
     override def slugBuilder: Option[String => String] = Some(f)
 
+  }
+  
+  def forPathTranslator (origin: BundleOrigin = BundleOrigin.User)(f: Path => Path): ExtensionBundle = new TestExtensionBundle(origin) {
+    
+    override def extendPathTranslator: PartialFunction[ExtensionBundle.PathTranslatorExtensionContext, PathTranslator] = {
+      case context => PathTranslator.postTranslate(context.baseTranslator)(f)
+    }
+    
   }
 
   def forSpanRewriteRule (rule: RewriteRule[Span]): ExtensionBundle = new TestExtensionBundle() {

--- a/io/src/test/scala/laika/io/TreeRendererSpec.scala
+++ b/io/src/test/scala/laika/io/TreeRendererSpec.scala
@@ -340,6 +340,20 @@ class TreeRendererSpec extends CatsEffectSuite
       .render(HTMLRenderer.defaultTree, renderer)
       .assertEquals(Results.rootWithSingleDoc(Root / "doc.html", expected, HTMLRenderer.outputContext))
   }
+
+  test("tree with a single document to HTML using a path translator in a theme") {
+    val renderer = Renderer
+      .of(HTML)
+      .parallel[IO]
+      .withTheme(TestThemeBuilder.forBundle(BundleProvider.forPathTranslator()(_.withSuffix("xhtml"))))
+      .build
+
+    val expected = """<h1 id="title" class="title">Title</h1>
+                     |<p>bbb</p>""".stripMargin
+    HTMLRenderer
+      .render(HTMLRenderer.defaultTree, renderer)
+      .assertEquals(Results.rootWithSingleDoc(Root / "doc.xhtml", expected, HTMLRenderer.outputContext))
+  }
   
   private def renderOverrideBundle (appendChar: Char, origin: BundleOrigin): ExtensionBundle = BundleProvider.forOverrides(HTML.Overrides {
     case (fmt, Text(txt, _)) => fmt.text(txt + appendChar)


### PR DESCRIPTION
It's been a while since `ExtensionBundle` got any expansion, but there was still one fairly important aspect that was previously buried in internal logic: the way a virtual path from the processed tree of documents gets translated to the path of the output document.

The internal path translator deals with aspects like applying the file suffix of the corresponding output format, moving versioned documents into the corresponding sub-directories and special treatment of title documents (e.g. translating `README.md` to `index.html`).

Custom extensions can wrap functionality around this internal logic, usually by using `PathTranslator.preTranslate` or `PathTranslator.postTranslate` to apply additional translation steps either before or after applying the internal translator.

The new member in `ExtensionBundle` is of type `PartialFunction[PathTranslatorExtensionContext, PathTranslator]`.
The `PathTranslatorExtensionContext` provides access to this internal path translator, to the output format it is going to be used for and the complete user configuration.

An example use case is a "Pretty URL" extension that allows to render a site in a way that all links can use a style that does not contain any `.html` suffixes. Such an extension will be added in a subsequent PR, to also be included in the upcoming 0.19 release.

