### PR TITLE
add PrettyURLs extension

### DIFF
--- a/core/shared/src/main/scala/laika/bundle/ExtensionBundle.scala
+++ b/core/shared/src/main/scala/laika/bundle/ExtensionBundle.scala
@@ -133,6 +133,9 @@ trait ExtensionBundle { self =>
     * 
     * Alternatively a completely custom implementation of the `PathTranslator` trait can be provided,
     * but this will usually not be necessary.
+    * 
+    * `PathTranslator` implementations usually do not deal with the fragment part of the path.
+    * Use the `slugBuilder` extension point for this purpose.
     */
   def extendPathTranslator: PartialFunction[PathTranslatorExtensionContext, PathTranslator] = PartialFunction.empty
   

--- a/core/shared/src/main/scala/laika/render/HTMLRenderer.scala
+++ b/core/shared/src/main/scala/laika/render/HTMLRenderer.scala
@@ -108,7 +108,12 @@ class HTMLRenderer (fileSuffix: String, format: String) extends ((HTMLFormatter,
     
     def renderTarget (target: Target): String = fmt.pathTranslator.translate(target) match {
       case ext: ExternalTarget => ext.url
-      case int: InternalTarget => int.relativeTo(fmt.path).relativePath.toString
+      case int: InternalTarget =>
+        val relPath = int.relativeTo(fmt.path).relativePath
+        if (relPath.withoutFragment.toString.endsWith("/index.html"))
+          relPath.withBasename("").withoutSuffix.toString
+        else 
+          relPath.toString
     }
 
     def renderSpanContainer (con: SpanContainer): String = {

--- a/core/shared/src/main/scala/laika/rewrite/nav/PrettyURLs.scala
+++ b/core/shared/src/main/scala/laika/rewrite/nav/PrettyURLs.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package laika.rewrite.nav
+
+import laika.ast.Path
+import laika.bundle.{BundleOrigin, ExtensionBundle}
+
+/** Extension specific to site rendering that translates the output path,
+  * producing "pretty URLs" that do not contain the `html` file suffix.
+  * 
+  * A path like `foo/bar.html` for example would be translated to `foo/bar/index.html` so that
+  * links can be simply rendered as `foo/bar/`.
+  * 
+  * When the render format is anything other than HTML, this extension has no effect.
+  * 
+  * The extension can be added to a transformer like any other extension:
+  *
+  * {{{
+  * val transformer = Transformer
+  *   .from(Markdown)
+  *   .to(HTML)
+  *   .using(GitHubFlavor)
+  *   .using(SyntaxHighlighting)
+  *   .using(PrettyURLs)
+  *   .build
+  * }}}
+  * 
+  * or via the `laikaExtensions` setting when using the sbt plugin:
+  * 
+  * {{{
+  *   laikaExtensions += PrettyURLs
+  * }}}
+  *
+  * @author Jens Halm
+  */
+object PrettyURLs extends ExtensionBundle {
+
+  override val origin: BundleOrigin = BundleOrigin.Library
+
+  val description: String = "Pretty URL extension for site rendering"
+  
+  private val outputBaseName = "index"
+  private val formatSelector = "html"
+
+  override def extendPathTranslator: PartialFunction[ExtensionBundle.PathTranslatorExtensionContext, PathTranslator] = {
+    case context if context.outputContext.formatSelector == formatSelector =>
+      val asPrettyURL: Path => Path = path =>
+        if (path.basename == outputBaseName || !path.suffix.contains(context.outputContext.fileSuffix)) path
+        else {
+          val basePath = path.withoutFragment.withoutSuffix / outputBaseName
+          val withSuffix = path.suffix.fold(basePath)(basePath.withSuffix)
+          path.fragment.fold(withSuffix)(withSuffix.withFragment)
+        }
+      PathTranslator.postTranslate(context.baseTranslator)(asPrettyURL)
+  }
+}

--- a/docs/src/03-preparing-content/02-navigation.md
+++ b/docs/src/03-preparing-content/02-navigation.md
@@ -554,6 +554,35 @@ The numbers will be added to the headers of the sections and also appear in tabl
 The default setting for Laika has auto-numbering switched off completely.
 
 
+Pretty URLs
+------------
+
+The library contains an extension for publishing a site with so-called "pretty URLs", 
+where a path like `foo/bar.html` gets translated to `foo/bar/index.html` which in turns means
+that links to that page can be expressed as `foo/bar/`, essentially stripping the `.html` suffix.
+
+The extension changes both, the physical structure of files of the generated site as well as 
+the rendering of internal links. It has no effect on other formats like EPUB or PDF.
+
+In contrast to some other site generators, this extension is disabled by default.
+It can be enabled like any other extension:
+
+@:choice(sbt)
+```scala
+laikaExtensions += PrettyURLs
+```
+
+@:choice(library)
+```scala
+val transformer = Transformer
+  .from(Markdown)
+  .to(HTML)
+  .using(PrettyURLs)
+  .build
+```
+@:@
+
+
 Custom Link Directives
 ----------------------
 

--- a/docs/src/05-extending-laika/01-overview.md
+++ b/docs/src/05-extending-laika/01-overview.md
@@ -156,10 +156,16 @@ Two of the most commonly used hooks in the `ExtensionBundle` API are described i
 * [Overriding Renderers], a hook into phase 4 that allows to override the rendered output for specific
   AST nodes.
 
-There are two further hooks that drive more low-level functionality:
+There are three further hooks that drive more low-level functionality:
 
 * The `docTypeMatcher` property in `ExtensionBundle` controls how a virtual path is used to determine the document type
   (e.g. markup document vs. template vs. configuration file).
+
+* The `pathTranslator` property in `ExtensionBundle` controls how a virtual path is translated 
+  to the corresponding output path.
+  The internal path translator deals with aspects like applying the suffix for the output format
+  or modifying the path for versioned documents.
+  An extension can perform additional translations either before or after delegating to the built-in translator. 
 
 * The `slugBuilder` property in `ExtensionBundle` controls how the text from a section headline is translated
   to a slug for element ids. 

--- a/io/src/test/scala/laika/helium/HeliumHTMLNavSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumHTMLNavSpec.scala
@@ -190,7 +190,7 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
         |</nav>
         |</div>
         |</div>
-        |<a class="icon-link" href="../index.html"><i class="icofont-laika" title="Home">&#xef47;</i></a>
+        |<a class="icon-link" href="../"><i class="icofont-laika" title="Home">&#xef47;</i></a>
         |<span class="row links"></span>""".stripMargin
     val config = Root / "directory.conf" -> "laika.versioned = true"
     transformAndExtract(inputs :+ config, helium, "<header id=\"top-bar\">", "</header>", Root / "0.42" / "doc-1.html").assertEquals(expected)


### PR DESCRIPTION
Extension specific to site rendering that translates the output path,
producing "pretty URLs" that do not contain the `html` file suffix.
 
A path like `foo/bar.html` for example would be translated to `foo/bar/index.html` so that
links can be simply rendered as `foo/bar/`.
 
When the render format is anything other than HTML, this extension has no effect.
 
The extension can be added to a transformer like any other extension:

```scala
val transformer = Transformer
  .from(Markdown)
  .to(HTML)
  .using(GitHubFlavor)
  .using(SyntaxHighlighting)
  .using(PrettyURLs)
  .build
```

or via the `laikaExtensions` setting when using the sbt plugin:
 
```scala
laikaExtensions += PrettyURLs
```