### PR TITLE
preview server: revert back to blaze backend for better user experience

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ val munitCE3   = "org.typelevel"          %% "munit-cats-effect-3" % versions.mu
 val fop        = "org.apache.xmlgraphics" %  "fop"         % versions.fop
 val http4s     = Seq(
                    "org.http4s"           %% "http4s-dsl"          % versions.http4s,
-                   "org.http4s"           %% "http4s-blaze-server" % versions.http4s
+                   "org.http4s"           %% "http4s-blaze-server" % versions.blaze
                  )
 
 lazy val root = project.in(file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ val munitCE3   = "org.typelevel"          %% "munit-cats-effect-3" % versions.mu
 val fop        = "org.apache.xmlgraphics" %  "fop"         % versions.fop
 val http4s     = Seq(
                    "org.http4s"           %% "http4s-dsl"          % versions.http4s,
-                   "org.http4s"           %% "http4s-ember-server" % versions.http4s
+                   "org.http4s"           %% "http4s-blaze-server" % versions.http4s
                  )
 
 lazy val root = project.in(file("."))

--- a/demo/jvm/src/main/scala/laika/webtool/Main.scala
+++ b/demo/jvm/src/main/scala/laika/webtool/Main.scala
@@ -34,11 +34,9 @@ object Main extends IOApp {
     app.use(_ => IO.never).as(ExitCode.Success)
 
   val app: Resource[IO, Server] =
-    for {
-      ctx    <- Resource.eval(IO.executionContext)
-      server <- BlazeServerBuilder[IO](ctx)
-        .bindHttp(8080, "0.0.0.0")
-        .withHttpApp(service)
-        .resource
-    } yield server
+    BlazeServerBuilder[IO]
+      .bindHttp(8080, "0.0.0.0")
+      .withHttpApp(service)
+      .resource
+    
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,6 +11,7 @@ object Dependencies {
     val catsEffect = "3.3.5"
     val fs2        = "3.2.7"
     val http4s     = "0.23.14"
+    val blaze      = "0.23.12"
     
     val munit      = "0.7.29"
     val munitCE3   = "1.0.7"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     val catsCore   = "2.7.0"
     val catsEffect = "3.3.5"
     val fs2        = "3.2.7"
-    val http4s     = "0.23.10"
+    val http4s     = "0.23.14"
     
     val munit      = "0.7.29"
     val munitCE3   = "1.0.7"

--- a/sbt/src/main/scala/laika/sbt/LaikaPreviewConfig.scala
+++ b/sbt/src/main/scala/laika/sbt/LaikaPreviewConfig.scala
@@ -16,7 +16,6 @@
 
 package laika.sbt
 
-import com.comcast.ip4s._
 import laika.preview.ServerConfig
 
 import scala.concurrent.duration.FiniteDuration
@@ -27,22 +26,22 @@ import scala.concurrent.duration.FiniteDuration
   * @param pollInterval the interval at which input file resources are polled for changes (default 3 seconds)
   * @param isVerbose whether each served page and each detected file change should be logged (default false)
   */
-class LaikaPreviewConfig (val port: Port,
-                          val host:Host,
+class LaikaPreviewConfig (val port: Int,
+                          val host:String,
                           val pollInterval: FiniteDuration,
                           val isVerbose: Boolean) {
 
-  private def copy (newPort: Port = port,
-                    newHost:Host = host,
+  private def copy (newPort: Int = port,
+                    newHost:String = host,
                     newPollInterval: FiniteDuration = pollInterval,
                     newVerbose: Boolean = isVerbose): LaikaPreviewConfig =
     new LaikaPreviewConfig(newPort, newHost,newPollInterval, newVerbose)
   
   /** Specifies the port the server should run on (default 4242).
     */
-  def withPort (port: Port): LaikaPreviewConfig = copy(newPort = port)
+  def withPort (port: Int): LaikaPreviewConfig = copy(newPort = port)
 
-  def withHost(host:Host):LaikaPreviewConfig = copy(newHost = host)
+  def withHost(host:String):LaikaPreviewConfig = copy(newHost = host)
 
   /** Specifies the interval at which input file resources are polled for changes (default 3 seconds).
     */


### PR DESCRIPTION
As much as I would prefer to switch to Ember for the 0.19 series, as long as the user experience for Laika's particular use case seems to be superior with blaze I'm reluctant to do so. The issues I observe with Ember are:

* Delayed shutdown - when killing the `laikaPreview` task by hitting the enter key, there is a delay of 30 seconds before it actually shuts down. Since it is always fairly exactly that amount of time, I suspect it is some internal timeout in Ember that kills some cleanup task that hangs, but I'm not sure of course. The problem is that for the user it looks as if the shutdown is not working or they might wrongly assume it already completed without any message. This problem occurs with or without using SSE.
* Exceptions when navigating - when navigating to a different page in the preview site, there are lots of broken pipe exceptions, all occurring within 10-20 seconds after navigating. This error only occurs on pages with activated auto-refresh which is based on SSE, it does not happen on pages without an SSE connection.

On the contrary when using blaze the situation looks somewhat better:

* Shutdown - happens immediately, but is followed by ` org.http4s.blaze.server.Http1ServerStage$$anon$1 - Error writing body` exceptions a few seconds later.
* Navigation - happens without any exceptions, both with or without SSE.

Comparing the two scenarios the blaze version appears superior for Laika, despite not being perfect either.

@armanbilge I did not bring this to the http4s repo yet, as I am not sure whether any of the above is an issue in http4s or just me using it wrongly, either in the way how I shut it down or in the way I initiate the SSE connection. I did not find much documentation on the latter, so it's entirely possible I'm not doing it in the intended way (even though it clearly seems to be working otherwise).