### PR TITLE
navigationTree directive - add tests + docs for nested manual nodes

### DIFF
--- a/core/shared/src/main/scala/laika/directive/std/NavigationTreeDirectives.scala
+++ b/core/shared/src/main/scala/laika/directive/std/NavigationTreeDirectives.scala
@@ -71,8 +71,8 @@ object NavigationTreeDirectives {
 
       def generate (node: NavigationNodeConfig): ValidatedNec[String, List[NavigationItem]] = node match {
 
-        case ManualNavigationNode(title, target, children) =>
-          children.toList.map(generate).combineAll.map { childNodes =>
+        case ManualNavigationNode(title, target, entries) =>
+          entries.toList.map(generate).combineAll.map { childNodes =>
             val link = target.map(NavigationLink(_))
             List(NavigationItem(title, childNodes, link))
           }
@@ -150,7 +150,7 @@ object NavigationTreeDirectives {
 
         def createManualNode (externalTarget: Option[ExternalTarget]): Either[ConfigError, NavigationNodeConfig] = for {
           title    <- config.get[String]("title")
-          children <- config.get[Seq[NavigationNodeConfig]]("children", Nil)(ConfigDecoder.seq(decoder))
+          children <- config.get[Seq[NavigationNodeConfig]]("entries", Nil)(ConfigDecoder.seq(decoder))
         } yield {
           ManualNavigationNode(SpanSequence(title), externalTarget, children)
         }
@@ -195,11 +195,11 @@ object NavigationTreeDirectives {
     *
     * @param title    the title for this entry when getting rendered as a link
     * @param target   the external link for this node (if missing this node just generates a navigation header as a separator within the tree)
-    * @param children the children of this node, either manual or automatically generated
+    * @param entries  the children of this node, either manual or automatically generated
     */
   case class ManualNavigationNode (title: SpanSequence,
                                    target: Option[ExternalTarget] = None,
-                                   children: Seq[NavigationNodeConfig] = Nil) extends NavigationNodeConfig
+                                   entries: Seq[NavigationNodeConfig] = Nil) extends NavigationNodeConfig
 
   /** Implementation of the `navigationTree` directive for templates.
     */

--- a/core/shared/src/test/scala/laika/directive/std/NavigationDirectiveSpec.scala
+++ b/core/shared/src/test/scala/laika/directive/std/NavigationDirectiveSpec.scala
@@ -115,6 +115,12 @@ class NavigationDirectiveSpec extends FunSuite with ParagraphCompanionShortcuts 
       Nil,
       Some(NavigationLink(ExternalTarget(s"http://domain-$num.com/")))
     )
+    
+    def section (title: String, entries: NavigationItem*): NavigationItem = NavigationItem(
+      SpanSequence(title),
+      entries,
+      None
+    )
   }
   
   import NavModel._
@@ -172,6 +178,22 @@ class NavigationDirectiveSpec extends FunSuite with ParagraphCompanionShortcuts 
         |} bbb ${cursor.currentDocument.content}""".stripMargin
 
     runTemplate(template, extLink(1), extLink(2))
+  }
+
+  test("template nav - one manual entry and a section with two manual entries") {
+
+    val template =
+      """aaa @:navigationTree { 
+        |  entries = [
+        |    { title = Link 1, target = "http://domain-1.com/"}
+        |    { title = Section, entries = [
+        |      { title = Link 2, target = "http://domain-2.com/"}
+        |      { title = Link 3, target = "http://domain-3.com/"}
+        |    ]}   
+        |  ] 
+        |} bbb ${cursor.currentDocument.content}""".stripMargin
+
+    runTemplate(template, extLink(1), section("Section", extLink(2), extLink(3)))
   }
 
   test("template nav - a manual entry and a generated entry") {
@@ -402,7 +424,7 @@ class NavigationDirectiveSpec extends FunSuite with ParagraphCompanionShortcuts 
         |
         |bbb""".stripMargin
 
-    runDocument(input,extLink(1), extLink(2))
+    runDocument(input, extLink(1), extLink(2))
   }
 
   test("block nav - entry generated from a document referred to with a relative path") {
@@ -421,7 +443,7 @@ class NavigationDirectiveSpec extends FunSuite with ParagraphCompanionShortcuts 
         |
         |bbb""".stripMargin
 
-    runDocument(input,docList(Root / "tree-1" / "doc-3", 3, 1))
+    runDocument(input, docList(Root / "tree-1" / "doc-3", 3, 1))
   }
 
   test("template breadcrumb directive - three entries") {

--- a/docs/src/03-preparing-content/02-navigation.md
+++ b/docs/src/03-preparing-content/02-navigation.md
@@ -494,6 +494,23 @@ Finally you can also include hard-coded link targets in addition to the auto-gen
 In this example an auto-generated navigation tree with depth 3 will be inserted, but an additional element
 with an external link target will be added as the final node.
 
+Manual nodes can also form a nested structure like this:
+
+```laika-md
+@:navigationTree { 
+  entries = [
+    { title = Link 1, target = "http://domain-1.com/"}
+    { title = Section, entries = [
+      { title = Link 2, target = "http://domain-2.com/"}
+      { title = Link 3, target = "http://domain-3.com/"}
+    ]}   
+  ] 
+}
+```
+
+In this case the entry with the title 'Section' does not have a target defined and only serves as a section
+header without a link.
+
 
 Breadcrumbs
 -----------


### PR DESCRIPTION
The `@:navigationTree` directive supports the manual creation of nested structures in addition to the more common use case of auto-generating navigation based on the structure of the input sources. For some reason there were neither any tests nor documentation for this feature, which this PR adds.

The attribute for nested links gets renamed from `children` to `entries` to align with the top-level attribute of the same name. Renaming undocumented attributes should not affect many users.