### PR TITLE
Helium: introduce LinkGroup UI option

### DIFF
--- a/docs/src/03-preparing-content/03-theme-settings.md
+++ b/docs/src/03-preparing-content/03-theme-settings.md
@@ -660,8 +660,12 @@ Helium.defaults
       TextLink.internal(Root / "doc-2.md", "Doc 2")
     ),
     projectLinks = Seq(
-      IconLink.internal(Root / "doc-2.md", HeliumIcon.demo),
-      ButtonLink.external("http://somewhere.com/", "Somewhere")
+      TextLink.internal(Root / "doc-1.md", "Text Link"),
+      ButtonLink.external("http://somewhere.com/", "Button Label"),
+      LinkGroup.create(
+        IconLink.internal(Root / "doc-2.md", HeliumIcon.demo),
+        IconLink.internal(Root / "doc-3.md", HeliumIcon.info)
+      )  
     ),
     teasers = Seq(
       Teaser("Teaser 1", "Description 1"),
@@ -691,7 +695,8 @@ tables of contents, and hopefully also a link to the API documentation.
 
 The project links below can be any set of additional links, like to GitHub, Twitter or your chat.
 Like with the top navigation bar of the main page, you can choose between an `IconLink` with optional text,
-a `ButtonLink` with an optional icon, or a plain `TextLink`.
+a `ButtonLink` with an optional icon, a plain `TextLink` or a horizontal group of links (`LinkGroup`) which
+are usually a row of icon links placed into a column of text links.
 Internal targets are again within the virtual path and will be validated.
 
 @:callout(info)

--- a/io/src/main/scala/laika/helium/config/layout.scala
+++ b/io/src/main/scala/laika/helium/config/layout.scala
@@ -140,6 +140,7 @@ private[helium] case class HTMLIncludes (includeCSS: Seq[Path] = Seq(Root), incl
 
 private[helium] object HeliumStyles {
   val row: Options = Styles("row")
+  val linkRow: Options = Styles("row", "links")
   val buttonLink: Options = Styles("button-link")
   val textLink: Options = Styles("text-link")
   val iconLink: Options = Styles("icon-link")

--- a/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
@@ -111,8 +111,9 @@ class HeliumLandingPageSpec extends CatsEffectSuite with InputBuilder with Resul
                      |<li><a class="text-link" href="doc-2.html">Doc 2</a></li>
                      |</ul>
                      |</div>
-                     |<p class="medium"><a class="icon-link" href="doc-2.html"><i class="icofont-laika" title="Demo">&#xeeea;</i></a></p>
+                     |<p class="medium"><a class="text-link" href="doc-1.html">Text Link</a></p>
                      |<p class="medium"><a class="button-link" href="http://somewhere.com/">Somewhere</a></p>
+                     |<p class="medium"><span class="row links"><a class="icon-link" href="doc-2.html"><i class="icofont-laika" title="Demo">&#xeeea;</i></a><a class="icon-link" href="doc-3.md"><i class="icofont-laika">&#xef4e;</i></a></span></p>
                      |</div>
                      |</div>
                      |$teaserHTML
@@ -132,8 +133,12 @@ class HeliumLandingPageSpec extends CatsEffectSuite with InputBuilder with Resul
         TextLink.internal(Root / "doc-2.md", "Doc 2")
       ),
       projectLinks = Seq(
-        IconLink.internal(Root / "doc-2.md", HeliumIcon.demo),
-        ButtonLink.external("http://somewhere.com/", "Somewhere")
+        TextLink.internal(Root / "doc-1.md", "Text Link"),
+        ButtonLink.external("http://somewhere.com/", "Somewhere"),
+        LinkGroup.create(
+          IconLink.internal(Root / "doc-2.md", HeliumIcon.demo),
+          IconLink.internal(Root / "doc-3.md", HeliumIcon.info)
+        )
       ),
       teasers = Seq(
         Teaser("Teaser 1", "Description 1"),


### PR DESCRIPTION
This is a simple addition for the config APIs that can be used to place a row of icon links into a column of text links for example. Mostly useful for the landing page.

Also introduces a new sub-trait `SingleTargetLink` for the existing Helium link types.
