### PR TITLE
Helium: introduce new menu component

### DIFF
--- a/docs/src/03-preparing-content/03-theme-settings.md
+++ b/docs/src/03-preparing-content/03-theme-settings.md
@@ -528,7 +528,7 @@ Helium.defaults.site
 All the properties shown above have default values, so you don't have to specify them all.
 The link to the homepage can be customized, by default it is pointing to `index.html` and using the Helium home icon.
 The links for the right navigation bar (`navLinks`, by default empty) can be an `IconLink` with optional text,
-a `ButtonLink` with an optional icon, or a plain `TextLink` or `ImageLink`.
+a `ButtonLink` with an optional icon, a plain `TextLink`, an `ImageLink` or a drop-down `Menu`.
 All links can be external or internal, in case of the latter, it is always a path from the perspective 
 of Laika's virtual root, not a file system path, and will be validated (dead links will cause the transformation to fail).
 Finally, the `highContrast` option indicates whether the background color should have a high contrast to the background

--- a/io/src/main/resources/laika/helium/css/nav.css
+++ b/io/src/main/resources/laika/helium/css/nav.css
@@ -79,7 +79,7 @@ nav .row {
 
 /* version dropdown ============================================== */
 
-.drop-down-toggle:after {
+.drop-down-toggle:after, .menu-toggle:after {
   display: inline-block;
   width: 0;
   height: 0;
@@ -91,16 +91,20 @@ nav .row {
   border-top: 8px solid var(--primary-color);
 }
 
-.drop-down-toggle:hover:after {
+.menu-toggle:after {
+  margin-left: 0.5em;
+}
+
+.drop-down-toggle:hover:after, .menu-toggle:hover:after {
   border-top: 8px solid var(--secondary-color);
 }
 
-#version-menu-container {
+#version-menu-container, .menu-container {
   position: relative;
   display: inline-block;
 }
 
-#version-menu {
+#version-menu, .menu-content {
   display: none;
   position: absolute;
   z-index: 5000;
@@ -112,20 +116,20 @@ nav .row {
   white-space: nowrap;
 }
 
-#version-menu ul.nav-list {
+#version-menu ul.nav-list, .menu-content ul.nav-list {
   padding-top: 5px;
   padding-bottom: 5px;
   margin: 0;
 }
-#version-menu .nav-list li {
+#version-menu .nav-list li, .menu-content .nav-list li {
   margin-left: 0;
   margin-bottom: 2px;
 }
-#version-menu .nav-list li a {
+#version-menu .nav-list li a, .menu-content .nav-list li a {
   margin: 0;
   line-height: 1.2;
 }
-#version-menu.versions-open {
+#version-menu.versions-open, .menu-content.menu-open {
   display: block;
 }
 .left-column {

--- a/io/src/main/resources/laika/helium/js/versions.js
+++ b/io/src/main/resources/laika/helium/js/versions.js
@@ -72,6 +72,25 @@ function initMenuToggle () {
   document.getElementById("version-menu-toggle").onclick = () => {
     document.getElementById("version-menu").classList.toggle("versions-open");
   };
+  document.querySelectorAll(".menu-container").forEach((container) => {
+    const toggle = container.querySelector(".menu-toggle");
+    const content = container.querySelector(".menu-content");
+    if (toggle && content) {
+      const closeHandler = (evt) => {
+        const contentClicked = evt.target.closest(".menu-content");
+        const toggleClicked = evt.target.closest(".menu-toggle");
+        if ((!toggleClicked || toggleClicked !== toggle) && (!contentClicked || contentClicked !== content)) {
+          content.classList.remove("menu-open");
+          document.removeEventListener("click", closeHandler)
+        }
+      }
+      toggle.onclick = () => {
+        if (content.classList.toggle("menu-open")) {
+          document.addEventListener("click", closeHandler);
+        }
+      };
+    }
+  });
 }
 
 function insertCanonicalLink (linkHref) {

--- a/io/src/main/resources/laika/helium/templates/includes/mainNav.template.html
+++ b/io/src/main/resources/laika/helium/templates/includes/mainNav.template.html
@@ -1,6 +1,10 @@
 <nav id="sidebar">
 
-  ${?helium.topBar.phoneLinks}
+  <div class="row">
+    @:for(helium.topBar.phoneLinks)
+    ${_}
+    @:@
+  </div>
 
   @:navigationTree {
     entries = [

--- a/io/src/main/resources/laika/helium/templates/includes/topNav.template.html
+++ b/io/src/main/resources/laika/helium/templates/includes/topNav.template.html
@@ -25,6 +25,10 @@
 
   ${?helium.topBar.home}
 
-  ${?helium.topBar.links}
+  <div class="row links">
+    @:for(helium.topBar.links)
+    ${_}
+    @:@
+  </div>  
 
 </header>

--- a/io/src/main/scala/laika/helium/builder/HeliumRenderOverrides.scala
+++ b/io/src/main/scala/laika/helium/builder/HeliumRenderOverrides.scala
@@ -18,7 +18,7 @@ package laika.helium.builder
 
 import laika.ast.RelativePath.CurrentDocument
 import laika.ast._
-import laika.helium.config.{AnchorPlacement, HeliumIcon}
+import laika.helium.config.{AnchorPlacement, HeliumIcon, HeliumStyles}
 import laika.render.{FOFormatter, HTMLFormatter}
 
 /**
@@ -79,8 +79,9 @@ private[helium] object HeliumRenderOverrides {
     case (fmt, InvalidBlock(msg, _, fallback, opt)) =>
       fmt.forMessage(msg)(renderCallout(fmt, opt + Styles("callout", msg.level.toString), Seq(Paragraph(msg), fallback)))
     
-    case (fmt, b: BlockSequence) if b.hasStyle("callout") => renderCallout(fmt, htmlCalloutOptions(b), b.content)
-    case (fmt, Selection(name, choices, opt))             => renderChoices(fmt, name, choices, opt)
+    case (fmt, b: BlockSequence) if b.hasStyle("callout")      => renderCallout(fmt, htmlCalloutOptions(b), b.content)
+    case (fmt, b: BlockSequence) if b.hasStyle("menu-content") => fmt.indentedElement("nav", b.options, b.content)
+    case (fmt, Selection(name, choices, opt))                  => renderChoices(fmt, name, choices, opt)
       
     case (fmt, tabs: Tabs)      => fmt.indentedElement("ul", Styles("tab-group"), tabs.tabs)
     case (fmt, tab: TabContent) => fmt.indentedElement("div", Styles("tab-content") + tab.options, tab.content, "data-choice-name" -> tab.name)

--- a/io/src/main/scala/laika/helium/config/layout.scala
+++ b/io/src/main/scala/laika/helium/config/layout.scala
@@ -70,7 +70,7 @@ private[helium] case class LandingPage (logo: Option[Image] = None,
                                         latestReleases: Seq[ReleaseInfo] = Nil,
                                         license: Option[String] = None,
                                         documentationLinks: Seq[TextLink] = Nil,
-                                        projectLinks: Seq[ThemeLink] = Nil,
+                                        projectLinks: Seq[ThemeLinkSpan] = Nil,
                                         teasers: Seq[Teaser] = Nil)
 
 private[helium] case class MarkupEditLinks (text: String, baseURL: String)
@@ -145,6 +145,9 @@ private[helium] object HeliumStyles {
   val textLink: Options = Styles("text-link")
   val iconLink: Options = Styles("icon-link")
   val imageLink: Options = Styles("image-link")
+  val menuToggle: Options = Styles("menu-toggle")
+  val menuContainer: Options = Styles("menu-container")
+  val menuContent: Options = Styles("menu-content")
 }
 
 private[helium] case class ThemeFonts (body: String, headlines: String, code: String)

--- a/io/src/main/scala/laika/helium/config/settings.scala
+++ b/io/src/main/scala/laika/helium/config/settings.scala
@@ -477,7 +477,7 @@ private[helium] trait SiteOps extends SingleConfigOps with CopyOps {
                    latestReleases: Seq[ReleaseInfo] = Nil,
                    license: Option[String] = None,
                    documentationLinks: Seq[TextLink] = Nil,
-                   projectLinks: Seq[ThemeLink] = Nil,
+                   projectLinks: Seq[ThemeLinkSpan] = Nil,
                    teasers: Seq[Teaser] = Nil): Helium = {
     val page = LandingPage(logo, title, subtitle, latestReleases, license, documentationLinks, projectLinks, teasers)
     val oldTopBar = helium.siteSettings.layout.topNavigationBar

--- a/io/src/main/scala/laika/helium/generate/ConfigGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/ConfigGenerator.scala
@@ -62,8 +62,8 @@ private[laika] object ConfigGenerator {
   implicit val topNavBarEncoder: ConfigEncoder[TopNavigationBar] = ConfigEncoder[TopNavigationBar] { navBar =>
     ConfigEncoder.ObjectBuilder.empty
       .withValue("home", navBar.homeLink)
-      .withValue("links", SpanSequence(navBar.navLinks, HeliumStyles.row + Styles("links")))
-      .withValue("phoneLinks", BlockSequence(Seq(SpanSequence(navBar.navLinks)), HeliumStyles.row))
+      .withValue("links", navBar.navLinks)
+      .withValue("phoneLinks", navBar.navLinks)
       .withValue("versionPrefix", navBar.versionPrefix)
       .build
   }

--- a/io/src/main/scala/laika/helium/generate/ConfigGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/ConfigGenerator.scala
@@ -63,7 +63,7 @@ private[laika] object ConfigGenerator {
     ConfigEncoder.ObjectBuilder.empty
       .withValue("home", navBar.homeLink)
       .withValue("links", navBar.navLinks)
-      .withValue("phoneLinks", navBar.navLinks)
+      .withValue("phoneLinks", navBar.navLinks.collect { case s: ThemeLinkSpan => s })
       .withValue("versionPrefix", navBar.versionPrefix)
       .build
   }

--- a/io/src/test/scala/laika/helium/HeliumDownloadPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumDownloadPageSpec.scala
@@ -93,7 +93,8 @@ class HeliumDownloadPageSpec extends CatsEffectSuite with InputBuilder with Resu
                      |</a>
                      |</div>
                      |<a class="icon-link" href="index.html"><i class="icofont-laika" title="Home">&#xef47;</i></a>
-                     |<span class="row links"></span>
+                     |<div class="row links">
+                     |</div>
                      |</header>
                      |<nav id="sidebar">
                      |<div class="row">

--- a/io/src/test/scala/laika/helium/HeliumHTMLNavSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumHTMLNavSpec.scala
@@ -177,6 +177,38 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
     transformAndExtract(inputs, helium, "<header id=\"top-bar\">", "</header>").assertEquals(expected)
   }
 
+  test("top navigation - with menu") {
+    val expected =
+      """<div class="row">
+        |<a id="nav-icon">
+        |<i class="icofont-laika" title="Navigation">&#xefa2;</i>
+        |</a>
+        |</div>
+        |<a class="image-link" href="index.html"><img src="home.png" alt="Homepage" title="Home"></a>
+        |<div class="row links">
+        |<div class="menu-container">
+        |<a class="text-link menu-toggle" href="#">Menu Label</a>
+        |<nav class="menu-content">
+        |<ul class="nav-list">
+        |<li class="level1"><a href="doc-2.html">Link 1</a></li>
+        |<li class="level1"><a href="doc-3.html">Link 2</a></li>
+        |</ul>
+        |</nav>
+        |</div>
+        |</div>""".stripMargin
+    val imagePath = Root / "home.png"
+    val helium = Helium.defaults.site.landingPage()
+      .site.topNavigationBar(
+      homeLink = ImageLink.internal(Root / "README", Image.internal(imagePath, alt = Some("Homepage"), title = Some("Home"))),
+      navLinks = Seq(
+        Menu.create("Menu Label",
+          TextLink.internal(Root / "doc-2.md", "Link 1"),  
+          TextLink.internal(Root / "doc-3.md", "Link 2")  
+        )
+      ))
+    transformAndExtract(inputs, helium, "<header id=\"top-bar\">", "</header>").assertEquals(expected)
+  }
+
   test("top navigation - with version dropdown on a versioned page") {
     val helium = Helium.defaults.site.landingPage().site.versions(versions, "Version:")
     val expected =

--- a/io/src/test/scala/laika/helium/HeliumHTMLNavSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumHTMLNavSpec.scala
@@ -149,7 +149,8 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
         |</a>
         |</div>
         |<a class="icon-link" href="index.html"><i class="icofont-laika" title="Home">&#xef47;</i></a>
-        |<span class="row links"></span>""".stripMargin
+        |<div class="row links">
+        |</div>""".stripMargin
     transformAndExtract(inputs, Helium.defaults.site.landingPage(), "<header id=\"top-bar\">", "</header>").assertEquals(expected)
   }
 
@@ -161,7 +162,10 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
         |</a>
         |</div>
         |<a class="image-link" href="index.html"><img src="home.png" alt="Homepage" title="Home"></a>
-        |<span class="row links"><a class="icon-link" href="doc-2.html"><i class="icofont-laika" title="Demo">&#xeeea;</i></a><a class="button-link" href="http://somewhere.com/">Somewhere</a></span>""".stripMargin
+        |<div class="row links">
+        |<a class="icon-link" href="doc-2.html"><i class="icofont-laika" title="Demo">&#xeeea;</i></a>
+        |<a class="button-link" href="http://somewhere.com/">Somewhere</a>
+        |</div>""".stripMargin
     val imagePath = Root / "home.png"
     val helium = Helium.defaults.site.landingPage()
       .site.topNavigationBar(
@@ -191,7 +195,8 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
         |</div>
         |</div>
         |<a class="icon-link" href="../"><i class="icofont-laika" title="Home">&#xef47;</i></a>
-        |<span class="row links"></span>""".stripMargin
+        |<div class="row links">
+        |</div>""".stripMargin
     val config = Root / "directory.conf" -> "laika.versioned = true"
     transformAndExtract(inputs :+ config, helium, "<header id=\"top-bar\">", "</header>", Root / "0.42" / "doc-1.html").assertEquals(expected)
   }
@@ -214,7 +219,8 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
         |</div>
         |</div>
         |<a class="icon-link" href="index.html"><i class="icofont-laika" title="Home">&#xef47;</i></a>
-        |<span class="row links"></span>""".stripMargin
+        |<div class="row links">
+        |</div>""".stripMargin
     transformAndExtract(inputs, helium, "<header id=\"top-bar\">", "</header>").assertEquals(expected)
   }
 

--- a/io/src/test/scala/laika/helium/HeliumTocPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumTocPageSpec.scala
@@ -80,7 +80,8 @@ class HeliumTocPageSpec extends CatsEffectSuite with InputBuilder with ResultExt
                      |</a>
                      |</div>
                      |<a class="icon-link" href="index.html"><i class="icofont-laika" title="Home">&#xef47;</i></a>
-                     |<span class="row links"></span>
+                     |<div class="row links">
+                     |</div>
                      |</header>
                      |<nav id="sidebar">
                      |<div class="row">


### PR DESCRIPTION
The component has the same look & feel and functionality as the existing version switcher menu, but the content of the menu can be populated explicitly via the Helium configuration API:

```scala
Menu.create("Menu Label",
  TextLink.internal(Root / "doc-2.md", "Link 1"),  
  TextLink.internal(Root / "doc-3.md", "Link 2")  
)
```

Such a menu can be placed in the top navigation bar (or later in the landing page after its configuration options have been expanded in a future PR).