### PR TITLE
preview server - reduce graceful shutdown to 2 seconds

### DIFF
--- a/preview/src/main/scala/laika/preview/ServerBuilder.scala
+++ b/preview/src/main/scala/laika/preview/ServerBuilder.scala
@@ -82,6 +82,7 @@ class ServerBuilder[F[_]: Async] (parser: Resource[F, TreeParser[F]],
     
   private def createServer (httpApp: HttpApp[F]): Resource[F, Server] =
     EmberServerBuilder.default[F]
+      .withShutdownTimeout(2.seconds)
       .withPort(config.port)
       .withHost(config.host)
       .withHttpApp(httpApp)

--- a/sbt/src/main/scala/laika/sbt/Tasks.scala
+++ b/sbt/src/main/scala/laika/sbt/Tasks.scala
@@ -232,7 +232,7 @@ object Tasks {
       System.in.read
     }
     finally {
-      streams.value.log.info(s"Shutting down preview server.")
+      streams.value.log.info(s"Shutting down preview server...")
       cancel.unsafeRunSync()
     }
   }


### PR DESCRIPTION
Also closes #311 as the upgrade of cats-effect made the observed issue with exceptions when navigating go away.
I'll move to automatic updates once 0.19 is out.