### PR TITLE
helium: fix and improve styling for main navigation pane

### DIFF
--- a/core/shared/src/main/scala/laika/ast/Options.scala
+++ b/core/shared/src/main/scala/laika/ast/Options.scala
@@ -89,9 +89,12 @@ object Style {
   val title: Options = Styles("title")
   val section: Options = Styles("section")
   val sectionNumber: Options = Styles("section-number")
+  
   val nav: Options = Styles("nav")
-  val navHeader: Options = Styles("nav-header")
   val navList: Options = Styles("nav-list")
+  val navSectionHeader: Options = Styles("nav-section-header")
+  val navTitlePage: Options = Styles("nav-title-page")
+  val navLeafEntry: Options = Styles("nav-leaf-entry")
   val active: Options = Styles("active")
   val breadcrumb: Options = Styles("breadcrumb")
   val bookmark: Options = Styles("bookmark")

--- a/core/shared/src/main/scala/laika/render/HTMLRenderer.scala
+++ b/core/shared/src/main/scala/laika/render/HTMLRenderer.scala
@@ -47,7 +47,10 @@ class HTMLRenderer (fileSuffix: String, format: String) extends ((HTMLFormatter,
         items.flatMap { item =>
           val target: BulletListItem = {
             val linkStyles = if (item.link.exists(_.selfLink)) Style.active else NoOpt
-            val typeStyles = if (item.link.isEmpty) Style.navHeader else NoOpt
+            val typeStyles = 
+              if (item.link.isEmpty) Style.navSectionHeader
+              else if (item.content.nonEmpty) Style.navTitlePage
+              else Style.navLeafEntry
             val content = item.link.fold(item.title) { link =>
               SpanSequence(SpanLink(item.title.content, link.target))
             }

--- a/core/shared/src/test/scala/laika/render/HTMLRendererSpec.scala
+++ b/core/shared/src/test/scala/laika/render/HTMLRendererSpec.scala
@@ -284,11 +284,11 @@ class HTMLRendererSpec extends FunSuite with ParagraphCompanionShortcuts with Te
     ))
     val html =
       """<ul class="nav-list">
-        |  <li class="level1"><a href="doc-1.html">Link-1</a></li>
-        |  <li class="level2"><a href="doc-2.html">Link-2</a></li>
-        |  <li class="level1 nav-header">Header-3</li>
-        |  <li class="level2 active"><a href="doc-4.html">Link-4</a></li>
-        |  <li class="level1"><a href="doc-5.html">Link-5</a></li>
+        |  <li class="level1 nav-title-page"><a href="doc-1.html">Link-1</a></li>
+        |  <li class="level2 nav-leaf-entry"><a href="doc-2.html">Link-2</a></li>
+        |  <li class="level1 nav-section-header">Header-3</li>
+        |  <li class="level2 active nav-leaf-entry"><a href="doc-4.html">Link-4</a></li>
+        |  <li class="level1 nav-leaf-entry"><a href="doc-5.html">Link-5</a></li>
         |</ul>""".stripMargin
     run(elem, html)
   }

--- a/io/src/main/resources/laika/helium/css/nav.css
+++ b/io/src/main/resources/laika/helium/css/nav.css
@@ -154,6 +154,25 @@ nav .row {
   color: black;
 }
 
+/* navigation lists - common styles (menus, main nav, page nav) ==== */
+
+.nav-list {
+  font-size: var(--body-font-size);
+}
+
+.nav-list li {
+  margin-left: 10px;
+  margin-bottom: 2px;
+  line-height: 1.1;
+}
+
+.nav-list li a {
+  display: block;
+  padding: 3px 15px 4px 15px;
+  color: var(--primary-color);
+  font-weight: normal;
+}
+
 /* left navigation bar =========================================== */
 
 #sidebar {
@@ -185,14 +204,51 @@ nav .row {
   margin-bottom: 15px;
 }
 
-.nav-list li.nav-header {
-  font-size: var(--body-font-size);
+#sidebar ul.nav-list {
+  padding-top: 10px;
+  padding-bottom: 15px;
+  margin: 0 0 0 15px;
+}
+
+#sidebar .nav-list li.level1 {
+  margin-left: 0;
+  padding: 3px 15px;
+  font-size: 1.1em;
+}
+
+#sidebar .nav-list li.level1.nav-title-page {
+  margin-bottom: 5px;
+  border-bottom: 2px solid var(--secondary-color);
+}
+
+#sidebar .nav-list li.level1 a {
+  margin-left: -5px;
+  padding-left: 0;
+}
+
+#sidebar .nav-list li.level1.nav-title-page a {
+  padding-bottom: 1px;
+}
+
+#sidebar .nav-list li.nav-section-header {
   color: var(--secondary-color);
   display: block;
   padding: 3px 15px;
   font-weight: bold;
   text-transform: uppercase;
   margin-left: -5px;
+  font-size: 1em;
+}
+
+#sidebar .nav-list li.nav-section-header.level2 {
+  margin-left: 10px;
+  margin-top: 5px;
+  font-size: 0.9em;
+}
+
+#sidebar .nav-list .level3 {
+  margin-left: 18px;
+  font-size: 0.9em;
 }
 
 /* right page navigation =========================================== */
@@ -229,11 +285,6 @@ ul.nav-list, #page-nav ul {
   border-top: 1px solid var(--primary-medium);
 }
 
-ul.nav-list {
-  padding-top: 10px;
-  padding-bottom: 15px;
-  margin: 0 0 0 15px;
-}
 #page-nav ul.nav-list {
   padding: 0;
   margin: 12px;
@@ -252,24 +303,13 @@ ul.nav-list {
 #page-nav .nav-list li a {
   padding: 0;
 }
-.nav-list li {
-  margin-left: 10px;
-  margin-bottom: 2px;
-  line-height: 1.1;
-  font-size: var(--body-font-size);
-}
 
 #page-nav li a:hover,
 .nav-list li a:hover {
   background-color: rgba(0, 0, 0, 0.03);
   text-decoration: none;
 }
-.nav-list li a {
-  display: block;
-  padding: 3px 15px 4px 15px;
-  color: var(--primary-color);
-  font-weight: normal;
-}
+
 .nav-list .active a,
 .nav-list .active a:hover,
 #page-nav .header a,
@@ -284,7 +324,7 @@ ul.nav-list {
   text-decoration: none;
 }
 
-.nav-list li + .nav-header {
+.nav-list li + .nav-section-header {
   margin-top: 9px;
 }
 

--- a/io/src/main/resources/laika/helium/css/toc.css
+++ b/io/src/main/resources/laika/helium/css/toc.css
@@ -9,7 +9,7 @@ ul.toc, .toc ul {
   font-weight: bold;
   color: var(--primary-color);
 }
-.toc.nav-list li.nav-header {
+.toc.nav-list li.nav-section-header {
   font-size: var(--title-font-size);
   margin-bottom: 20px;
   margin-top: 36px;

--- a/io/src/test/scala/laika/helium/HeliumDownloadPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumDownloadPageSpec.scala
@@ -100,8 +100,8 @@ class HeliumDownloadPageSpec extends CatsEffectSuite with InputBuilder with Resu
                      |<div class="row">
                      |</div>
                      |<ul class="nav-list">
-                     |<li class="level1 active"><a href="#">Downloads</a></li>
-                     |<li class="level1"><a href="doc.html">doc.md</a></li>
+                     |<li class="level1 active nav-leaf-entry"><a href="#">Downloads</a></li>
+                     |<li class="level1 nav-leaf-entry"><a href="doc.html">doc.md</a></li>
                      |</ul>
                      |</nav>
                      |<div id="container">

--- a/io/src/test/scala/laika/helium/HeliumEPUBTocPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumEPUBTocPageSpec.scala
@@ -70,10 +70,10 @@ class HeliumEPUBTocPageSpec extends CatsEffectSuite with InputBuilder with Resul
                      |<main class="content">
                      |<h1 class="title">Contents</h1>
                      |<ul class="toc nav-list">
-                     |<li class="level1 toc"><a href="doc-1.epub.xhtml">doc-1.md</a></li>
-                     |<li class="level1 toc"><a href="doc-2.epub.xhtml">doc-2.md</a></li>
-                     |<li class="level1 toc nav-header">dir-1</li>
-                     |<li class="level2 toc"><a href="dir-1/doc-3.epub.xhtml">doc-3.md</a></li>
+                     |<li class="level1 toc nav-leaf-entry"><a href="doc-1.epub.xhtml">doc-1.md</a></li>
+                     |<li class="level1 toc nav-leaf-entry"><a href="doc-2.epub.xhtml">doc-2.md</a></li>
+                     |<li class="level1 toc nav-section-header">dir-1</li>
+                     |<li class="level2 toc nav-leaf-entry"><a href="dir-1/doc-3.epub.xhtml">doc-3.md</a></li>
                      |</ul>
                      |</main>
                      |</body>""".stripMargin

--- a/io/src/test/scala/laika/helium/HeliumHTMLNavSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumHTMLNavSpec.scala
@@ -95,9 +95,9 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
     val expected = """<div class="row">
                      |</div>
                      |<ul class="nav-list">
-                     |<li class="level1 active"><a href="#">Doc 1</a></li>
-                     |<li class="level1"><a href="doc-2.html">Doc 2</a></li>
-                     |<li class="level1"><a href="doc-3.html">Doc 3</a></li>
+                     |<li class="level1 active nav-leaf-entry"><a href="#">Doc 1</a></li>
+                     |<li class="level1 nav-leaf-entry"><a href="doc-2.html">Doc 2</a></li>
+                     |<li class="level1 nav-leaf-entry"><a href="doc-3.html">Doc 3</a></li>
                      |</ul>""".stripMargin
     transformAndExtract(inputs, Helium.defaults, "<nav id=\"sidebar\">", "</nav>").assertEquals(expected)
   }
@@ -106,10 +106,10 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
     val expected =
       """<p class="header"><a href="#">Doc 1</a></p>
         |<ul class="nav-list">
-        |<li class="level1"><a href="#section-1">Section 1</a></li>
-        |<li class="level2"><a href="#section-1-1">Section 1.1</a></li>
-        |<li class="level1"><a href="#section-2">Section 2</a></li>
-        |<li class="level2"><a href="#section-2-1">Section 2.1</a></li>
+        |<li class="level1 nav-title-page"><a href="#section-1">Section 1</a></li>
+        |<li class="level2 nav-leaf-entry"><a href="#section-1-1">Section 1.1</a></li>
+        |<li class="level1 nav-title-page"><a href="#section-2">Section 2</a></li>
+        |<li class="level2 nav-leaf-entry"><a href="#section-2-1">Section 2.1</a></li>
         |</ul>
         |<p class="footer"></p>""".stripMargin
     transformAndExtract(inputs, Helium.defaults, "<nav id=\"page-nav\">", "</nav>").assertEquals(expected)
@@ -119,10 +119,10 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
     val expected =
       """<p class="header"><a href="#">Doc 1</a></p>
         |<ul class="nav-list">
-        |<li class="level1"><a href="#section-1">Section 1</a></li>
-        |<li class="level2"><a href="#section-1-1">Section 1.1</a></li>
-        |<li class="level1"><a href="#section-2">Section 2</a></li>
-        |<li class="level2"><a href="#section-2-1">Section 2.1</a></li>
+        |<li class="level1 nav-title-page"><a href="#section-1">Section 1</a></li>
+        |<li class="level2 nav-leaf-entry"><a href="#section-1-1">Section 1.1</a></li>
+        |<li class="level1 nav-title-page"><a href="#section-2">Section 2</a></li>
+        |<li class="level2 nav-leaf-entry"><a href="#section-2-1">Section 2.1</a></li>
         |</ul>
         |<p class="footer"><a href="https://github.com/my-project/doc-1.md"><i class="icofont-laika" title="Edit">&#xef10;</i>Source for this page</a></p>""".stripMargin
     val helium = Helium.defaults.site.markupEditLinks("Source for this page", "https://github.com/my-project")
@@ -190,8 +190,8 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
         |<a class="text-link menu-toggle" href="#">Menu Label</a>
         |<nav class="menu-content">
         |<ul class="nav-list">
-        |<li class="level1"><a href="doc-2.html">Link 1</a></li>
-        |<li class="level1"><a href="doc-3.html">Link 2</a></li>
+        |<li class="level1 nav-leaf-entry"><a href="doc-2.html">Link 1</a></li>
+        |<li class="level1 nav-leaf-entry"><a href="doc-3.html">Link 2</a></li>
         |</ul>
         |</nav>
         |</div>

--- a/io/src/test/scala/laika/helium/HeliumTocPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumTocPageSpec.scala
@@ -87,11 +87,11 @@ class HeliumTocPageSpec extends CatsEffectSuite with InputBuilder with ResultExt
                      |<div class="row">
                      |</div>
                      |<ul class="nav-list">
-                     |<li class="level1 active"><a href="#">Contents</a></li>
-                     |<li class="level1"><a href="doc-1.html">doc-1.md</a></li>
-                     |<li class="level1"><a href="doc-2.html">doc-2.md</a></li>
-                     |<li class="level1 nav-header">dir-1</li>
-                     |<li class="level2"><a href="dir-1/doc-3.html">doc-3.md</a></li>
+                     |<li class="level1 active nav-leaf-entry"><a href="#">Contents</a></li>
+                     |<li class="level1 nav-leaf-entry"><a href="doc-1.html">doc-1.md</a></li>
+                     |<li class="level1 nav-leaf-entry"><a href="doc-2.html">doc-2.md</a></li>
+                     |<li class="level1 nav-section-header">dir-1</li>
+                     |<li class="level2 nav-leaf-entry"><a href="dir-1/doc-3.html">doc-3.md</a></li>
                      |</ul>
                      |</nav>
                      |<div id="container">
@@ -104,10 +104,10 @@ class HeliumTocPageSpec extends CatsEffectSuite with InputBuilder with ResultExt
                      |<main class="content">
                      |<h1 class="title">Contents</h1>
                      |<ul class="toc nav-list">
-                     |<li class="level1 toc"><a href="doc-1.html">doc-1.md</a></li>
-                     |<li class="level1 toc"><a href="doc-2.html">doc-2.md</a></li>
-                     |<li class="level1 toc nav-header">dir-1</li>
-                     |<li class="level2 toc"><a href="dir-1/doc-3.html">doc-3.md</a></li>
+                     |<li class="level1 toc nav-leaf-entry"><a href="doc-1.html">doc-1.md</a></li>
+                     |<li class="level1 toc nav-leaf-entry"><a href="doc-2.html">doc-2.md</a></li>
+                     |<li class="level1 toc nav-section-header">dir-1</li>
+                     |<li class="level2 toc nav-leaf-entry"><a href="dir-1/doc-3.html">doc-3.md</a></li>
                      |</ul>
                      |</main>
                      |</div>


### PR DESCRIPTION
Closes #306 which was merely a case of missing CSS and some messed up specificity.

Apart from adding all the necessary CSS for having at least 3 layers of navigation fully styled, it also adds a small code change to the renderer which now writes out more classes to the navigation entries to make it easier to customize the CSS.

In addition to the existing `levelN` classes for the nesting level it now also writes one out of the following three classes to denote the type of node: 
* `nav-section-header` if it is a header without a link (which you get from directories without README files)
* `nav-title-page` if it is a linked node with children (as you get from directories with README files)
* `nav-leaf-entry` if it is neither of the two