### PR TITLE
helium: expand config options for version menu

### DIFF
--- a/docs/src/03-preparing-content/03-theme-settings.md
+++ b/docs/src/03-preparing-content/03-theme-settings.md
@@ -515,11 +515,15 @@ The left corner of the top bar is always reserved for the button to open or clos
 ```scala
 Helium.defaults.site
   .topNavigationBar(
-    homeLink = IconLink.internal(Root / "README.md", HeliumIcon.hone),
+    homeLink = IconLink.internal(Root / "README.md", HeliumIcon.home),
     navLinks = Seq(
       IconLink.internal(Root / "doc-2.md", HeliumIcon.download),
       TextLink.external("http://somewhere.com/", "Text Link"),
       ButtonLink.external("http://somewhere.com/", "Button Link")
+    ),
+    versionMenu = VersionMenu.create(
+      versionedLabelPrefix = "Version:", 
+      unversionedLabel = "Choose Version"
     ),
     highContrast = true
   )
@@ -527,10 +531,17 @@ Helium.defaults.site
 
 All the properties shown above have default values, so you don't have to specify them all.
 The link to the homepage can be customized, by default it is pointing to `index.html` and using the Helium home icon.
+
 The links for the right navigation bar (`navLinks`, by default empty) can be an `IconLink` with optional text,
 a `ButtonLink` with an optional icon, a plain `TextLink`, an `ImageLink` or a drop-down `Menu`.
 All links can be external or internal, in case of the latter, it is always a path from the perspective 
 of Laika's virtual root, not a file system path, and will be validated (dead links will cause the transformation to fail).
+
+The `versionMenu` property allows to override the defaults for the version dropdown. 
+You can specify the label prefix for versioned pages (the actual current version number will be appended),
+the label for the menu on unversioned pages (in the example "Choose Version") and optionally additional links
+like "Help me choose..." that point to static pages instead of a versioned sub-site.
+
 Finally, the `highContrast` option indicates whether the background color should have a high contrast to the background
 of the page (darker in light mode and lighter in dark mode).
 

--- a/io/src/main/resources/laika/helium/css/nav.css
+++ b/io/src/main/resources/laika/helium/css/nav.css
@@ -77,34 +77,30 @@ nav .row {
   color: var(--top-bg);
 }
 
-/* version dropdown ============================================== */
+/* menus =================================================== */
 
-.drop-down-toggle:after, .menu-toggle:after {
+.menu-toggle:after {
   display: inline-block;
   width: 0;
   height: 0;
   content: "";
-  margin-left: 0.2em;
+  margin-left: 0.5em;
   margin-bottom: 0.1em;
   border-left: 8px solid transparent;
   border-right: 8px solid transparent;
   border-top: 8px solid var(--primary-color);
 }
 
-.menu-toggle:after {
-  margin-left: 0.5em;
-}
-
-.drop-down-toggle:hover:after, .menu-toggle:hover:after {
+.menu-toggle:hover:after {
   border-top: 8px solid var(--secondary-color);
 }
 
-#version-menu-container, .menu-container {
+.menu-container {
   position: relative;
   display: inline-block;
 }
 
-#version-menu, .menu-content {
+.menu-content {
   display: none;
   position: absolute;
   z-index: 5000;
@@ -116,22 +112,25 @@ nav .row {
   white-space: nowrap;
 }
 
-#version-menu ul.nav-list, .menu-content ul.nav-list {
+.menu-content ul.nav-list {
   padding-top: 5px;
   padding-bottom: 5px;
   margin: 0;
 }
-#version-menu .nav-list li, .menu-content .nav-list li {
+.menu-content .nav-list li {
   margin-left: 0;
   margin-bottom: 2px;
 }
-#version-menu .nav-list li a, .menu-content .nav-list li a {
+.menu-content .nav-list li a {
   margin: 0;
   line-height: 1.2;
 }
-#version-menu.versions-open, .menu-content.menu-open {
+.menu-content.menu-open {
   display: block;
 }
+
+/* version menu =================================================== */
+
 .left-column {
   display: inline-block;
   width: 3.5em;

--- a/io/src/main/resources/laika/helium/js/versions.js
+++ b/io/src/main/resources/laika/helium/js/versions.js
@@ -6,10 +6,11 @@ function logError (req) {
 }
 
 function populateMenu (data, localRootPrefix, currentPath, currentVersion, siteBaseURL) {
+  
   const currentTarget = data.linkTargets.find(target => target.path === currentPath);
-  const menuList = document.getElementById("version-list");
   let canonicalLink;
-  data.versions.forEach(version => {
+  
+  const listItems = data.versions.map(version => {
     const pathPrefix = localRootPrefix + version.pathSegment;
     const hasMatchingLink = currentTarget && currentTarget.versions.includes(version.pathSegment);
     const href = (hasMatchingLink) ? pathPrefix + currentPath : pathPrefix + version.fallbackLink;
@@ -37,8 +38,18 @@ function populateMenu (data, localRootPrefix, currentPath, currentVersion, siteB
     if (version.pathSegment === currentVersion) listItem.classList.add("active");
     listItem.appendChild(link);
 
-    menuList.appendChild(listItem);
+    return listItem;
   });
+
+  const versionMenus = document.querySelectorAll(".version-menu");
+  versionMenus.forEach((container, index) => {
+    const list = container.querySelector(".nav-list")
+    if (list) {
+      const children = index === 0 ? listItems : listItems.map((item) => item.cloneNode(true));
+      list.prepend(...children);
+    }
+  });
+  
   return canonicalLink;
 }
 
@@ -50,7 +61,6 @@ function loadVersions (localRootPrefix, currentPath, currentVersion, siteBaseURL
   req.onload = () => {
     if (req.status === 200) {
       const canonicalLink = populateMenu(req.response, localRootPrefix, currentPath, currentVersion, siteBaseURL);
-      initMenuToggle();
       if (canonicalLink) insertCanonicalLink(canonicalLink);
     }
     else logError(req)
@@ -61,17 +71,8 @@ function loadVersions (localRootPrefix, currentPath, currentVersion, siteBaseURL
   req.send();
 }
 
-function initMenuToggle () {
-  document.addEventListener("click", (evt) => {
-    const menuClicked = evt.target.closest("#version-menu");
-    const buttonClicked = evt.target.closest("#version-menu-toggle");
-    if (!menuClicked && !buttonClicked) {
-      document.getElementById("version-menu").classList.remove("versions-open")
-    }
-  });
-  document.getElementById("version-menu-toggle").onclick = () => {
-    document.getElementById("version-menu").classList.toggle("versions-open");
-  };
+function initMenuToggles () {
+  // this functionality applies to all types of menus, including the version menu
   document.querySelectorAll(".menu-container").forEach((container) => {
     const toggle = container.querySelector(".menu-toggle");
     const content = container.querySelector(".menu-content");
@@ -106,5 +107,6 @@ function insertCanonicalLink (linkHref) {
 function initVersions (localRootPrefix, currentPath, currentVersion, siteBaseURL) {
   document.addEventListener('DOMContentLoaded', () => {
     loadVersions(localRootPrefix, currentPath, currentVersion, siteBaseURL);
+    initMenuToggles();
   });
 }

--- a/io/src/main/resources/laika/helium/templates/includes/topNav.template.html
+++ b/io/src/main/resources/laika/helium/templates/includes/topNav.template.html
@@ -5,22 +5,7 @@
       @:icon(navigationMenu)
     </a>
     
-    @:for(laika.versions)
-    <div id="version-menu-container">
-      <a id="version-menu-toggle" class="text-link drop-down-toggle" href="#">
-        @:if(laika.versioned)
-        ${helium.topBar.versionPrefix} ${laika.versions.currentVersion.displayValue}
-        @:else
-        Documentation
-        @:@
-      </a>
-      <nav id="version-menu">
-        <ul id="version-list" class="nav-list">
-        </ul>
-      </nav>
-    </div>
-    @:@
-    
+    ${helium.topBar.versionMenu}
   </div>
 
   ${?helium.topBar.home}

--- a/io/src/main/scala/laika/helium/config/layout.scala
+++ b/io/src/main/scala/laika/helium/config/layout.scala
@@ -52,9 +52,9 @@ private[helium] case class EPUBLayout (defaultBlockSpacing: Length,
 private[helium] case class TableOfContent (title: String, depth: Int)
 
 private[helium] case class TopNavigationBar (homeLink: ThemeLink, 
-                                             navLinks: Seq[ThemeLink], 
-                                             highContrast: Boolean = false, 
-                                             versionPrefix: String = "Version")
+                                             navLinks: Seq[ThemeLink],
+                                             versionMenu: VersionMenu = VersionMenu.default,
+                                             highContrast: Boolean = false)
 
 private[helium] object TopNavigationBar {
   def withHomeLink (path: Path): TopNavigationBar = TopNavigationBar(IconLink.internal(path, HeliumIcon.home), Nil)
@@ -148,6 +148,7 @@ private[helium] object HeliumStyles {
   val menuToggle: Options = Styles("menu-toggle")
   val menuContainer: Options = Styles("menu-container")
   val menuContent: Options = Styles("menu-content")
+  val versionMenu: Options = Styles("version-menu")
 }
 
 private[helium] case class ThemeFonts (body: String, headlines: String, code: String)

--- a/io/src/main/scala/laika/helium/config/settings.scala
+++ b/io/src/main/scala/laika/helium/config/settings.scala
@@ -400,11 +400,16 @@ private[helium] trait SiteOps extends SingleConfigOps with CopyOps {
     * @param homeLink the link to the homepage, by default pointing to `index.html` and using the Helium home icon.
     * @param navLinks an optional set of links to be placed at the right side of the bar, supported link
     *                 types are `IconLink`, `ButtonLink`, `ImageLink` and a plain `TextLink`
+    * @param versionMenu defines labels and optionally additional links for the version switcher menu
     * @param highContrast indicates whether the background color should have a high contrast to the background
     *                     of the page (darker in light mode and lighter in dark mode).
     */
-  def topNavigationBar (homeLink: ThemeLink = TopNavigationBar.default.homeLink, navLinks: Seq[ThemeLink] = Nil, highContrast: Boolean = false): Helium = {
-    val newLayout = helium.siteSettings.layout.copy(topNavigationBar = TopNavigationBar(homeLink, navLinks, highContrast))
+  def topNavigationBar (homeLink: ThemeLink = TopNavigationBar.default.homeLink, 
+                        navLinks: Seq[ThemeLink] = Nil,
+                        versionMenu: VersionMenu = VersionMenu.default,
+                        highContrast: Boolean = false): Helium = {
+    val newLayout = helium.siteSettings.layout
+      .copy(topNavigationBar = TopNavigationBar(homeLink, navLinks, versionMenu, highContrast))
     copyWith(helium.siteSettings.copy(layout = newLayout))
   }
 
@@ -490,7 +495,7 @@ private[helium] trait SiteOps extends SingleConfigOps with CopyOps {
     copyWith(helium.siteSettings.copy(landingPage = Some(page), layout = newLayout))
   }
 
-  /** Adds a version dropdown to the top navigation bar.
+  /** Specify the configuration for versioned documentation, a core Laika feature simply exposed via the Helium Config API.
     * 
     * The specified configuration allows to define the current version as well as any older or newer versions.
     * For each version the `pathSegment` property holds the value that should use as part of URLs 
@@ -500,13 +505,13 @@ private[helium] trait SiteOps extends SingleConfigOps with CopyOps {
     * those will be scanned to produce additional version information in the JSON loaded by the site.
     * This will be used for "smart linking" where the drop-down will link to the same page of a different version
     * if it exists.
+    * 
+    * The corresponding version switcher component of the theme can be configured with `topNavigationBar.versionMenu`.
+    * That setting allows to specify the labels and optionally additional link entries for the menu.
+    * Additional version switcher components can be added using the `VersionMenu` class, for example for
+    * adding the menu to the landing page where it is not included by default.
     */
-  def versions (versions: Versions, dropDownPrefix: String = "Version"): Helium = {
-    val newLayout = helium.siteSettings.layout.copy(topNavigationBar = 
-      helium.siteSettings.layout.topNavigationBar.copy(versionPrefix = dropDownPrefix)
-    ) 
-    copyWith(helium.siteSettings.copy(versions = Some(versions), layout = newLayout))
-  }
+  def versions (versions: Versions): Helium = copyWith(helium.siteSettings.copy(versions = Some(versions)))
 
   /** Specifies the base URL where the rendered site will be hosted.
     * This configuration option allows to turn internal links into external ones for documents which will be

--- a/io/src/main/scala/laika/helium/generate/ConfigGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/ConfigGenerator.scala
@@ -64,7 +64,7 @@ private[laika] object ConfigGenerator {
       .withValue("home", navBar.homeLink)
       .withValue("links", navBar.navLinks)
       .withValue("phoneLinks", navBar.navLinks.collect { case s: ThemeLinkSpan => s })
-      .withValue("versionPrefix", navBar.versionPrefix)
+      .withValue("versionMenu", navBar.versionMenu)
       .build
   }
 

--- a/io/src/test/scala/laika/helium/HeliumHTMLNavSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumHTMLNavSpec.scala
@@ -210,18 +210,20 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
   }
 
   test("top navigation - with version dropdown on a versioned page") {
-    val helium = Helium.defaults.site.landingPage().site.versions(versions, "Version:")
+    val versionMenu = VersionMenu.create("Version:", "Choose Version")
+    val helium = Helium.defaults
+      .site.versions(versions)
+      .site.topNavigationBar(versionMenu = versionMenu)
+      .site.landingPage()
     val expected =
       """<div class="row">
         |<a id="nav-icon">
         |<i class="icofont-laika" title="Navigation">&#xefa2;</i>
         |</a>
-        |<div id="version-menu-container">
-        |<a id="version-menu-toggle" class="text-link drop-down-toggle" href="#">
-        |Version: 0.42.x
-        |</a>
-        |<nav id="version-menu">
-        |<ul id="version-list" class="nav-list">
+        |<div class="menu-container version-menu">
+        |<a class="text-link menu-toggle" href="#">Version: 0.42.x</a>
+        |<nav class="menu-content">
+        |<ul class="nav-list">
         |</ul>
         |</nav>
         |</div>
@@ -234,18 +236,21 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
   }
 
   test("top navigation - with version dropdown on an unversioned page") {
-    val helium = Helium.defaults.site.landingPage().site.versions(versions, "Version:")
+    val versionMenu = VersionMenu.create("Version:", "Choose Version", Seq(TextLink.internal(Root / "doc-2.md", "Extra-Link")))
+    val helium = Helium.defaults
+      .site.versions(versions)
+      .site.topNavigationBar(versionMenu = versionMenu)
+      .site.landingPage()
     val expected =
       """<div class="row">
         |<a id="nav-icon">
         |<i class="icofont-laika" title="Navigation">&#xefa2;</i>
         |</a>
-        |<div id="version-menu-container">
-        |<a id="version-menu-toggle" class="text-link drop-down-toggle" href="#">
-        |Documentation
-        |</a>
-        |<nav id="version-menu">
-        |<ul id="version-list" class="nav-list">
+        |<div class="menu-container version-menu">
+        |<a class="text-link menu-toggle" href="#">Choose Version</a>
+        |<nav class="menu-content">
+        |<ul class="nav-list">
+        |<li class="level1"><a href="doc-2.html">Extra-Link</a></li>
         |</ul>
         |</nav>
         |</div>


### PR DESCRIPTION
Introduces a new `VersionMenu` UI component that captures the functionality of the existing version switcher dropdown and makes it available in the Helium configuration API.

Example:

```scala
Helium.defaults.site
  .topNavigationBar(
    versionMenu = VersionMenu.create(
      versionedLabelPrefix = "Version:", 
      unversionedLabel = "Choose Version",
      additionalLinks = Seq(TextLink.internal(Root / "older.md", "Older Versions"))
    )
```

The labels for the dropdown on versioned and unversioned pages were previously hardcoded and could only be adjusted by using custom templates.
Additional links could not be created without resorting to configuring a kind of "fake version" that was used to "smuggle" an additional entry into the menu.
The configuration is optional, omitting it will result in the same type of dropdown as in previous versions with the existing default labels.

This piggy-backs on the `Menu` component introduced in #321, as the version switcher functions in the exact same way apart from having its entries auto-populated via a loaded JSON at runtime.