### PR TITLE
Helium: smarter defaults for home link + better error message

### DIFF
--- a/docs/src/03-preparing-content/03-theme-settings.md
+++ b/docs/src/03-preparing-content/03-theme-settings.md
@@ -530,20 +530,33 @@ Helium.defaults.site
 ```
 
 All the properties shown above have default values, so you don't have to specify them all.
-The link to the homepage can be customized, by default it is pointing to `index.html` and using the Helium home icon.
+Details for each of these options are described in the sections below.
 
-The links for the right navigation bar (`navLinks`, by default empty) can be an `IconLink` with optional text,
-a `ButtonLink` with an optional icon, a plain `TextLink`, an `ImageLink` or a drop-down `Menu`.
+
+#### Home Link
+
+The link to the homepage can be customized as shown in the example above.
+It accepts the same type of links as the `navLinks` property described below.
+
+If it is not configured explicitly, Laika attempts to apply the following defaults in this order:
+
+* If the site has a landing page (configured via `Helium.defaults.site.landingPage(...)`) then the home link
+  will point to that page with the default home icon.
+* If the site input has a `README.md` or `README.rst` then the home link
+  will point to that page with the default home icon.
+  The page recognized as the title page per directory might be different in case the user overrides
+  the `laika.titleDocuments.inputName` setting as shown in [Title Documents].
+* If the home link is neither configured explicitly nor any of the default home link targets mentioned above exist
+  in the input tree, the transformation will fail with an error pointing to this part of the documentation.
+
+
+#### Right Navigation Links
+
+The links for the right side of the top navigation bar (`navLinks`, by default empty) can be 
+an `IconLink` with optional text, a `ButtonLink` with an optional icon, a plain `TextLink`, an `ImageLink` 
+or a drop-down `Menu`.
 All links can be external or internal, in case of the latter, it is always a path from the perspective 
 of Laika's virtual root, not a file system path, and will be validated (dead links will cause the transformation to fail).
-
-The `versionMenu` property allows to override the defaults for the version dropdown. 
-You can specify the label prefix for versioned pages (the actual current version number will be appended),
-the label for the menu on unversioned pages (in the example "Choose Version") and optionally additional links
-like "Help me choose..." that point to static pages instead of a versioned sub-site.
-
-Finally, the `highContrast` option indicates whether the background color should have a high contrast to the background
-of the page (darker in light mode and lighter in dark mode).
 
 With the default Helium settings the three link types from our code example render as shown below:
 
@@ -553,6 +566,24 @@ With the default Helium settings the three link types from our code example rend
   intrinsicWidth = 270
   intrinsicHeight = 35
 }
+
+On very small screens (e.g. portrait mode on phones) the links will move into the left navigation pane instead
+and larger controls like menus will be removed.
+
+
+#### Version Menu
+
+The `versionMenu` property allows to override the defaults for the version dropdown.
+
+You can specify the label prefix for versioned pages (the actual current version number will be appended),
+the label for the menu on unversioned pages (in the example "Choose Version") and optionally additional links
+like "Help me choose..." that point to static pages instead of a versioned sub-site.
+
+
+#### Navigation Bar Styling
+
+Finally, the `highContrast` option indicates whether the background color should have a high contrast to the background
+of the page (darker in light mode and lighter in dark mode).
 
 @:todo(show Helium's available icons somewhere)
 

--- a/io/src/main/scala/laika/helium/config/ThemeLink.scala
+++ b/io/src/main/scala/laika/helium/config/ThemeLink.scala
@@ -133,6 +133,29 @@ object ImageLink {
     new ImageLink(InternalTarget(path), image, options) {}
 }
 
+/** A home link that inserts a link to the title page of the root document tree (if available)
+  * or otherwise an invalid element.
+  */
+final case class DynamicHomeLink (options: Options = NoOpt) extends ThemeLinkSpan {
+  type Self = DynamicHomeLink
+
+  def resolve (cursor: DocumentCursor): Span = {
+    cursor.root.tree.titleDocument match {
+      case Some(homePage) => 
+        IconLink.internal(homePage.path, HeliumIcon.home).resolve(cursor)
+      case None => 
+        val message = "No target for home link found - for options see 'Theme Settings / Top Navigation Bar' in the manual" 
+        InvalidSpan(message, GeneratedSource)
+    }
+  }
+  
+  def withOptions(newOptions: Options): DynamicHomeLink = copy(options = newOptions)
+}
+
+object DynamicHomeLink {
+  val default: DynamicHomeLink = DynamicHomeLink()
+}
+
 /** A generic group of theme links.
   *
   * Can be used to create structures like a row of icon links in a vertical column of text links. 

--- a/io/src/main/scala/laika/helium/config/layout.scala
+++ b/io/src/main/scala/laika/helium/config/layout.scala
@@ -58,7 +58,7 @@ private[helium] case class TopNavigationBar (homeLink: ThemeLink,
 
 private[helium] object TopNavigationBar {
   def withHomeLink (path: Path): TopNavigationBar = TopNavigationBar(IconLink.internal(path, HeliumIcon.home), Nil)
-  val default: TopNavigationBar = withHomeLink(Root / "README.md")
+  val default: TopNavigationBar = TopNavigationBar(DynamicHomeLink.default, Nil)
 }
 
 private[helium] case class DownloadPage (title: String, description: Option[String], downloadPath: Path = Root / "downloads", 

--- a/io/src/main/scala/laika/helium/config/settings.scala
+++ b/io/src/main/scala/laika/helium/config/settings.scala
@@ -404,7 +404,7 @@ private[helium] trait SiteOps extends SingleConfigOps with CopyOps {
     * @param highContrast indicates whether the background color should have a high contrast to the background
     *                     of the page (darker in light mode and lighter in dark mode).
     */
-  def topNavigationBar (homeLink: ThemeLink = TopNavigationBar.default.homeLink, 
+  def topNavigationBar (homeLink: ThemeLink = DynamicHomeLink.default, 
                         navLinks: Seq[ThemeLink] = Nil,
                         versionMenu: VersionMenu = VersionMenu.default,
                         highContrast: Boolean = false): Helium = {
@@ -485,14 +485,7 @@ private[helium] trait SiteOps extends SingleConfigOps with CopyOps {
                    projectLinks: Seq[ThemeLinkSpan] = Nil,
                    teasers: Seq[Teaser] = Nil): Helium = {
     val page = LandingPage(logo, title, subtitle, latestReleases, license, documentationLinks, projectLinks, teasers)
-    val oldTopBar = helium.siteSettings.layout.topNavigationBar
-    val newLayout = 
-      if (oldTopBar.homeLink != TopNavigationBar.default.homeLink) helium.siteSettings.layout
-      else helium.siteSettings.layout.copy(
-        topNavigationBar = oldTopBar.copy(homeLink = IconLink.internal(Root / "README", HeliumIcon.home))
-      )
-      
-    copyWith(helium.siteSettings.copy(landingPage = Some(page), layout = newLayout))
+    copyWith(helium.siteSettings.copy(landingPage = Some(page)))
   }
 
   /** Specify the configuration for versioned documentation, a core Laika feature simply exposed via the Helium Config API.

--- a/io/src/test/scala/laika/helium/HeliumDownloadPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumDownloadPageSpec.scala
@@ -61,7 +61,7 @@ class HeliumDownloadPageSpec extends CatsEffectSuite with InputBuilder with Resu
     }
     
   test("no download page configured") {
-    transformAndExtract(singleDoc, Helium.defaults, "", "")
+    transformAndExtract(singleDoc, Helium.defaults.site.landingPage(), "", "")
       .interceptMessage[RuntimeException]("Missing document under test")
   }
   
@@ -153,12 +153,14 @@ class HeliumDownloadPageSpec extends CatsEffectSuite with InputBuilder with Resu
   }
 
   test("include only EPUB") {
-    val heliumWithEPUBDownloads = Helium.defaults.site.downloadPage(
-      title = "Downloads",
-      description = Some("EPUB & PDF"),
-      downloadPath = Root / "documents",
-      includePDF = false,
-    )
+    val heliumWithEPUBDownloads = Helium.defaults
+      .site.downloadPage(
+        title = "Downloads",
+        description = Some("EPUB & PDF"),
+        downloadPath = Root / "documents",
+        includePDF = false,
+      )
+      .site.landingPage()
     val expected = """<h1 class="title">Downloads</h1>
                      |<p>EPUB &amp; PDF</p>
                      |<div class="downloads">
@@ -178,6 +180,7 @@ class HeliumDownloadPageSpec extends CatsEffectSuite with InputBuilder with Resu
         description = Some("EPUB & PDF"),
         downloadPath = Root / "documents"
       )
+      .site.landingPage()
       .pdf.coverImages(CoverImage(Root / "cover.png"))
       .epub.coverImages(CoverImage(Root / "cover.png"))
     val expected = """<h1 class="title">Downloads</h1>
@@ -205,6 +208,7 @@ class HeliumDownloadPageSpec extends CatsEffectSuite with InputBuilder with Resu
         description = Some("EPUB & PDF"),
         downloadPath = Root / "documents"
       )
+      .site.landingPage()
       .pdf.coverImages(CoverImage(Root / "cover-sbt.png", Some("sbt")), CoverImage(Root / "cover-library.png", Some("library")))
       .epub.coverImages(CoverImage(Root / "cover-sbt.png", Some("sbt")), CoverImage(Root / "cover-library.png", Some("library")))
     val expected = """<h1 class="title">Downloads</h1>

--- a/io/src/test/scala/laika/helium/HeliumHTMLNavSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumHTMLNavSpec.scala
@@ -99,7 +99,7 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
                      |<li class="level1 nav-leaf-entry"><a href="doc-2.html">Doc 2</a></li>
                      |<li class="level1 nav-leaf-entry"><a href="doc-3.html">Doc 3</a></li>
                      |</ul>""".stripMargin
-    transformAndExtract(inputs, Helium.defaults, "<nav id=\"sidebar\">", "</nav>").assertEquals(expected)
+    transformAndExtract(inputs, Helium.defaults.site.landingPage(), "<nav id=\"sidebar\">", "</nav>").assertEquals(expected)
   }
 
   test("page navigation - two levels") {
@@ -112,7 +112,7 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
         |<li class="level2 nav-leaf-entry"><a href="#section-2-1">Section 2.1</a></li>
         |</ul>
         |<p class="footer"></p>""".stripMargin
-    transformAndExtract(inputs, Helium.defaults, "<nav id=\"page-nav\">", "</nav>").assertEquals(expected)
+    transformAndExtract(inputs, Helium.defaults.site.landingPage(), "<nav id=\"page-nav\">", "</nav>").assertEquals(expected)
   }
 
   test("page navigation - with footer link") {
@@ -125,7 +125,7 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
         |<li class="level2 nav-leaf-entry"><a href="#section-2-1">Section 2.1</a></li>
         |</ul>
         |<p class="footer"><a href="https://github.com/my-project/doc-1.md"><i class="icofont-laika" title="Edit">&#xef10;</i>Source for this page</a></p>""".stripMargin
-    val helium = Helium.defaults.site.markupEditLinks("Source for this page", "https://github.com/my-project")
+    val helium = Helium.defaults.site.markupEditLinks("Source for this page", "https://github.com/my-project").site.landingPage()
     transformAndExtract(inputs, helium, "<nav id=\"page-nav\">", "</nav>").assertEquals(expected)
   }
 
@@ -138,6 +138,7 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
     val helium = Helium.defaults
       .site.markupEditLinks("Source for this page", "https://github.com/my-project")
       .site.tableOfContent("Table of Content", 2)
+      .site.landingPage()
     transformAndExtract(inputs, helium, "<nav id=\"page-nav\">", "</nav>", Root / "table-of-content.html").assertEquals(expected)
   }
 

--- a/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
@@ -71,7 +71,7 @@ class HeliumLandingPageSpec extends CatsEffectSuite with InputBuilder with Resul
                              |</div>""".stripMargin
     
   test("no landing page configured") {
-    transformAndExtract(inputs, Helium.defaults, "", "")
+    transformAndExtract(inputs, Helium.defaults.site.topNavigationBar(homeLink = IconLink.external("http://foo.com", HeliumIcon.home)), "", "")
       .interceptMessage[RuntimeException]("Missing document under test")
   }
   

--- a/io/src/test/scala/laika/helium/HeliumRenderOverridesSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumRenderOverridesSpec.scala
@@ -37,6 +37,8 @@ class HeliumRenderOverridesSpec extends CatsEffectSuite with InputBuilder with R
 
   type ConfigureTransformer = TransformerBuilder[HTMLFormatter] => TransformerBuilder[HTMLFormatter]
   
+  private val heliumBase = Helium.defaults.site.landingPage()
+  
   def transformer (theme: ThemeProvider, configure: ConfigureTransformer): Resource[IO, TreeTransformer[IO]] = {
     val builder = Transformer.from(Markdown).to(HTML)
       .withConfigValue(LinkConfig(excludeFromValidation = Seq(Root)))
@@ -56,7 +58,7 @@ class HeliumRenderOverridesSpec extends CatsEffectSuite with InputBuilder with R
       } yield res
     }
   
-  def transformAndExtract(input: String, helium: Helium = Helium.defaults, configure: ConfigureTransformer = identity): IO[String] = {
+  def transformAndExtract(input: String, helium: Helium = heliumBase, configure: ConfigureTransformer = identity): IO[String] = {
     transformAndExtract(Seq(Root / "doc.md" -> input), helium, "<main class=\"content\">", "</main>", configure)
   }
   
@@ -141,7 +143,7 @@ class HeliumRenderOverridesSpec extends CatsEffectSuite with InputBuilder with R
       s"""<h1 id="title" class="title">Title</h1>
          |<h2 id="some-headline" class="section">Some Headline<a class="anchor-link right" href="#some-headline"><i class="icofont-laika">${entity(HeliumIcon.link)}</i></a></h2>""".stripMargin
     val layout = Helium.defaults.siteSettings.layout
-    val helium = Helium.defaults.site.layout(layout.contentWidth, layout.navigationWidth, layout.topBarHeight,
+    val helium = heliumBase.site.layout(layout.contentWidth, layout.navigationWidth, layout.topBarHeight,
       layout.defaultBlockSpacing, layout.defaultLineHeight, AnchorPlacement.Right)
     transformAndExtract(headlineInput, helium).assertEquals(expected)
   }
@@ -151,7 +153,7 @@ class HeliumRenderOverridesSpec extends CatsEffectSuite with InputBuilder with R
       """<h1 id="title" class="title">Title</h1>
         |<h2 id="some-headline" class="section">Some Headline</h2>""".stripMargin
     val layout = Helium.defaults.siteSettings.layout
-    val helium = Helium.defaults.site.layout(layout.contentWidth, layout.navigationWidth, layout.topBarHeight,
+    val helium = heliumBase.site.layout(layout.contentWidth, layout.navigationWidth, layout.topBarHeight,
       layout.defaultBlockSpacing, layout.defaultLineHeight, AnchorPlacement.None)
     transformAndExtract(headlineInput, helium).assertEquals(expected)
   }

--- a/io/src/test/scala/laika/helium/HeliumSiteCSSSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumSiteCSSSpec.scala
@@ -100,12 +100,14 @@ class HeliumSiteCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
   
   private val colorScheme = "color-scheme: light dark;"
     
+  private val heliumBase = Helium.defaults.site.landingPage()
+  
   test("defaults") {
     val expected = s"""$defaultColors
                       |$defaultFonts
                       |$defaultLayout
                       |$colorScheme""".stripMargin
-    transformAndExtract(singleDoc, Helium.defaults, ":root {", "}").assertEquals(expected)
+    transformAndExtract(singleDoc, heliumBase, ":root {", "}").assertEquals(expected)
   }
   
   private val customFonts = s"""$defaultColors
@@ -123,7 +125,7 @@ class HeliumSiteCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
                               |$colorScheme""".stripMargin
 
   test("custom font families and font sizes - via 'site' selector") {
-    val helium = Helium.defaults
+    val helium = heliumBase
       .site.fontFamilies(body = "Custom-Body", headlines = "Custom-Header", code = "Custom-Code")
       .site.fontSizes(body = px(14), code = px(13), title = px(33), 
         header2 = px(27), header3 = px(19), header4 = px(14), small = px(11))
@@ -131,7 +133,7 @@ class HeliumSiteCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
   }
 
   test("custom font families and font sizes - via 'all' selector") {
-    val helium = Helium.defaults
+    val helium = heliumBase
       .all.fontFamilies(body = "Custom-Body", headlines = "Custom-Header", code = "Custom-Code")
       .all.fontSizes(body = px(14), code = px(13), title = px(33),
       header2 = px(27), header3 = px(19), header4 = px(14), small = px(11))
@@ -204,7 +206,7 @@ class HeliumSiteCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
   
   test("custom colors - via 'site' selector") {
     import laika.theme.config.Color._
-    val helium = Helium.defaults
+    val helium = heliumBase
       .site.themeColors(primary = rgb(1,1,1), primaryLight = rgb(2,2,2), primaryMedium = rgb(4,4,4),
         secondary = rgb(212,212,212), text = rgb(10,10,10), background = rgb(11,11,11), bgGradient = (rgb(0,0,0), rgb(9,9,9)))
       .site.messageColors(info = hex("aaaaaa"), infoLight = hex("aaaaab"), 
@@ -220,7 +222,7 @@ class HeliumSiteCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
 
   test("custom colors - via 'all' selector") {
     import laika.theme.config.Color._
-    val helium = Helium.defaults
+    val helium = heliumBase
       .all.themeColors(primary = rgb(1,1,1), primaryLight = rgb(2,2,2), primaryMedium = rgb(4,4,4),
         secondary = rgb(212,212,212), text = rgb(10,10,10), background = rgb(11,11,11), bgGradient = (rgb(0,0,0), rgb(9,9,9)))
       .all.messageColors(info = hex("aaaaaa"), infoLight = hex("aaaaab"),
@@ -236,7 +238,7 @@ class HeliumSiteCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
 
   test("custom colors in dark mode") {
     import laika.theme.config.Color._
-    val helium = Helium.defaults
+    val helium = heliumBase
       .site.themeColors(primary = rgb(1,1,1), primaryLight = rgb(2,2,2), primaryMedium = rgb(4,4,4),
         secondary = rgb(212,212,212), text = rgb(10,10,10), background = rgb(11,11,11), bgGradient = (rgb(0,0,0), rgb(9,9,9)))
       .site.messageColors(
@@ -263,7 +265,7 @@ class HeliumSiteCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
   }
   
   test("dark mode disabled") {
-    val helium = Helium.defaults.site.darkMode.disabled
+    val helium = heliumBase.site.darkMode.disabled
     transformAndExtract(singleDoc, helium, ":root {", "}").assertEquals(defaultColors + "\n" + defaultFonts  + "\n" + defaultLayout)
   }
 
@@ -277,7 +279,7 @@ class HeliumSiteCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
                                |$colorScheme""".stripMargin
   
   test("layout") {
-    val helium = Helium.defaults
+    val helium = heliumBase
       .site.layout(contentWidth = px(1000), navigationWidth = px(300), topBarHeight = px(55),
         defaultBlockSpacing = px(9), defaultLineHeight = 1.2, anchorPlacement = AnchorPlacement.None)
     transformAndExtract(singleDoc, helium, ":root {", "}").assertEquals(customLayout)


### PR DESCRIPTION
The enhanced mechanism will attempt to set the home link in the following order:

* A target that has been set explicitly via the existing option in the Helium API (`.site.topNavigationBar(homeLink = ...)`)
* The landing page of the site if available (configured via `Helium.defaults.site.landingPage(...)`)
* Any `README.md` or `README.rst` files in the root directory of the input sources.
  The page recognized as the title page per directory might be different in case the user overrides
  the `laika.titleDocuments.inputName` setting.
* If the home link is neither configured explicitly nor any of the default home link targets mentioned above exist
  in the input tree, the transformation will fail with an error pointing to this part of the documentation instead of the existing, unhelpful error message.

@noelwelsh, @Ostrzyciel - this should improve the situation you reported in #309 - there will be fewer scenarios where the error will occur, and if it does there will be a clearer message.