### PR TITLE
Helium: make main navigation configurable via Helium API

### DIFF
--- a/core/shared/src/test/scala/laika/directive/std/NavigationDirectiveSpec.scala
+++ b/core/shared/src/test/scala/laika/directive/std/NavigationDirectiveSpec.scala
@@ -110,17 +110,17 @@ class NavigationDirectiveSpec extends FunSuite with ParagraphCompanionShortcuts 
       p("bbb")
     )
 
-    def extLink (num: Int): NavigationItem = NavigationItem(
+    def extLink (num: Int, level: Int): NavigationItem = NavigationItem(
       SpanSequence(s"Link $num"),
       Nil,
       Some(NavigationLink(ExternalTarget(s"http://domain-$num.com/")))
-    )
+    ).withOptions(Style.level(level))
     
     def section (title: String, entries: NavigationItem*): NavigationItem = NavigationItem(
       SpanSequence(title),
       entries,
       None
-    )
+    ).withOptions(Style.level(1))
   }
   
   import NavModel._
@@ -177,7 +177,7 @@ class NavigationDirectiveSpec extends FunSuite with ParagraphCompanionShortcuts 
         |  ] 
         |} bbb ${cursor.currentDocument.content}""".stripMargin
 
-    runTemplate(template, extLink(1), extLink(2))
+    runTemplate(template, extLink(1, 1), extLink(2, 1))
   }
 
   test("template nav - one manual entry and a section with two manual entries") {
@@ -193,7 +193,7 @@ class NavigationDirectiveSpec extends FunSuite with ParagraphCompanionShortcuts 
         |  ] 
         |} bbb ${cursor.currentDocument.content}""".stripMargin
 
-    runTemplate(template, extLink(1), section("Section", extLink(2), extLink(3)))
+    runTemplate(template, extLink(1, 1), section("Section", extLink(2, 2), extLink(3, 2)))
   }
 
   test("template nav - a manual entry and a generated entry") {
@@ -206,7 +206,7 @@ class NavigationDirectiveSpec extends FunSuite with ParagraphCompanionShortcuts 
         |  ] 
         |} bbb ${cursor.currentDocument.content}""".stripMargin
 
-    runTemplate(template, extLink(1), docList(Root / "tree-2" / "doc-6", 6, 1))
+    runTemplate(template, extLink(1, 1), docList(Root / "tree-2" / "doc-6", 6, 1))
   }
 
   test("template nav - an entry generated from the root of the tree") {
@@ -424,7 +424,7 @@ class NavigationDirectiveSpec extends FunSuite with ParagraphCompanionShortcuts 
         |
         |bbb""".stripMargin
 
-    runDocument(input, extLink(1), extLink(2))
+    runDocument(input, extLink(1, 1), extLink(2, 1))
   }
 
   test("block nav - entry generated from a document referred to with a relative path") {

--- a/docs/src/03-preparing-content/02-navigation.md
+++ b/docs/src/03-preparing-content/02-navigation.md
@@ -371,7 +371,11 @@ tables of contents and navigation bars.
 The default Helium theme provides a main navigation tree in the left sidebar and page navigation on the 
 right out of the box.
 
-If you include your own templates, either for overriding the Helium templates or when not using a theme at all,
+For minor customizations like changing the depth of the generated navigation tree or manually adding
+entries to the auto-generated ones, you can use the Helium API as documented in [Main Navigation].
+
+If you need more advanced customization and want to include your own templates, 
+either for overriding the Helium templates or when not using a theme at all,
 you can easily generate custom navigation structures with the `@:navigationTree` directive described below. 
 
 For more details on templating, see [Creating Templates].

--- a/docs/src/03-preparing-content/03-theme-settings.md
+++ b/docs/src/03-preparing-content/03-theme-settings.md
@@ -505,6 +505,42 @@ like the option to centralize all definitions of external links.
 They are described in a dedicated [Navigation] chapter.
 
 
+### Main Navigation
+
+By default the Helium theme includes a left navigation pane that is auto-generated based on the structure
+of your input directories and is up to 2 levels deep.
+
+You can override some defaults and add additional menu entries via the configuration API:
+
+```scala
+Helium.defaults.site
+  .mainNavigation(
+    depth = 3,
+    includePageSections = true,
+    appendLinks = Seq(ThemeNavigationSection("Additional Links",
+      TextLink.internal(Root / "doc-1.md", "Link 1"),
+      TextLink.external("https://foo.com", "Link 2")
+    ))
+  )
+```
+
+The theme includes full styling for up to three levels. 
+More than 3 levels will probably lead to confusing UX, 
+but if you do want to use more you need to add additional CSS to your inputs. 
+You can use the classes Helium adds to the `<li>` tags (`level4`, `level5`, etc.) for the custom styles.
+
+If the `includePageSections` parameter is set to true (it's `false` by default), the navigation structure will not only 
+reflect the directory structure and the documents within, but also the section headers on individual pages.
+This option may be attractive if you only have very few pages in your site and want to make better use
+of the space in the left navigation pane.
+Note that sections may still be filtered based on your setting for the overall navigation depth.
+
+Finally, you can also append or prepend additional sections of links, each with a section header and one or more links. 
+Prepending may not be desirable if you also configure a table of content or a download page,
+as the prepended links would appear before them.
+
+
+
 ### Top Navigation Bar
 
 You can replace the home link in the middle of the bar and a row of buttons or icons with links at the right corner.

--- a/io/src/main/resources/laika/helium/templates/includes/mainNav.template.html
+++ b/io/src/main/resources/laika/helium/templates/includes/mainNav.template.html
@@ -7,9 +7,9 @@
   </div>
 
   @:navigationTree {
-    entries = [
-      { target = "/", excludeRoot = true, excludeSections = true, depth = 2 }
-    ]
+    entries = ${helium.site.mainNavigation.prependLinks} [
+      { target = "/", excludeRoot = true, excludeSections = ${helium.site.mainNavigation.excludeSections}, depth = ${helium.site.mainNavigation.depth} }
+    ] ${helium.site.mainNavigation.appendLinks}
   }
 
 </nav>

--- a/io/src/main/scala/laika/helium/config/ThemeLink.scala
+++ b/io/src/main/scala/laika/helium/config/ThemeLink.scala
@@ -16,6 +16,7 @@
 
 package laika.helium.config
 
+import cats.data.NonEmptyList
 import laika.ast.RelativePath.CurrentDocument
 import laika.ast._
 import laika.config.LaikaKeys
@@ -230,4 +231,11 @@ object VersionMenu {
     
   val default: VersionMenu = create("Version", "Choose Version")
   
+}
+
+final case class ThemeNavigationSection (title: String, links: NonEmptyList[TextLink])
+
+object ThemeNavigationSection {
+  def apply (title: String, link: TextLink, links: TextLink*): ThemeNavigationSection =
+    ThemeNavigationSection(title, NonEmptyList.of(link, links:_*))
 }

--- a/io/src/main/scala/laika/helium/config/layout.scala
+++ b/io/src/main/scala/laika/helium/config/layout.scala
@@ -33,6 +33,7 @@ private[helium] case class WebLayout(contentWidth: Length,
                                      anchorPlacement: AnchorPlacement,
                                      favIcons: Seq[Favicon] = Nil,
                                      topNavigationBar: TopNavigationBar = TopNavigationBar.default,
+                                     mainNavigation: MainNavigation = MainNavigation(),
                                      tableOfContent: Option[TableOfContent] = None,
                                      downloadPage: Option[DownloadPage] = None,
                                      markupEditLinks: Option[MarkupEditLinks] = None) extends CommonLayout
@@ -60,6 +61,11 @@ private[helium] object TopNavigationBar {
   def withHomeLink (path: Path): TopNavigationBar = TopNavigationBar(IconLink.internal(path, HeliumIcon.home), Nil)
   val default: TopNavigationBar = TopNavigationBar(DynamicHomeLink.default, Nil)
 }
+
+private[helium] case class MainNavigation (depth: Int = 2,
+                                           includePageSections: Boolean = false,
+                                           prependLinks: Seq[ThemeNavigationSection] = Nil,
+                                           appendLinks: Seq[ThemeNavigationSection] = Nil)
 
 private[helium] case class DownloadPage (title: String, description: Option[String], downloadPath: Path = Root / "downloads", 
                                         includeEPUB: Boolean = true, includePDF: Boolean = true)

--- a/io/src/main/scala/laika/helium/config/settings.scala
+++ b/io/src/main/scala/laika/helium/config/settings.scala
@@ -395,6 +395,38 @@ private[helium] trait SiteOps extends SingleConfigOps with CopyOps {
     copyWith(helium.siteSettings.copy(layout = newLayout))
   }
 
+  /** Configures the main (left) navigation pane.
+    * 
+    * By default the navigation is auto-generated from the available sources to a navigation depth of 2.
+    * This API allows to override some defaults and to prepend or append additional navigation links.
+    * 
+    * If the `includePageSections` parameter is set to true, the navigation structure will not only
+    * reflect the directory structure and the documents within, but also the section headers on individual pages.
+    * This option may be attractive if you only have very few pages in your site and want to make better use
+    * of the space in the left navigation pane. 
+    * Note that sections may still be filtered based on your setting for the overall navigation depth. 
+    * 
+    * You can also append or prepend additional sections of links, each with a section header and one or more
+    * links. Prepending may not be desirable if you also configure a table of content or a download page,
+    * as the prepended links would appear before them.
+    * 
+    * If you increase the depth to a value higher than 3 you might want to include custom CSS for the
+    * levels 4 and higher as Laika comes with styling for three layers out of the box.
+    * 
+    * @param depth               the depth of the navigation structure, two by default
+    * @param includePageSections indicates whether sections on pages should be included (false by default)
+    * @param prependLinks        navigation sections to place above the auto-generated navigation structure
+    * @param appendLinks         navigation sections to place below the auto-generated navigation structure
+    */
+  def mainNavigation (depth: Int = 2, 
+                      includePageSections: Boolean = false, 
+                      prependLinks: Seq[ThemeNavigationSection] = Nil, 
+                      appendLinks: Seq[ThemeNavigationSection] = Nil): Helium = {
+    val newLayout = helium.siteSettings.layout
+      .copy(mainNavigation = MainNavigation(depth, includePageSections, prependLinks, appendLinks))
+    copyWith(helium.siteSettings.copy(layout = newLayout))
+  }
+
   /** Configures the top navigation bar of the main content pages.
     * 
     * @param homeLink the link to the homepage, by default pointing to `index.html` and using the Helium home icon.

--- a/io/src/test/scala/laika/helium/HeliumHTMLNavSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumHTMLNavSpec.scala
@@ -72,12 +72,32 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
       |### Section 2.1
     """.stripMargin
   
-  val inputs = Seq(
+  val flatInputs = Seq(
     Root / "doc-1.md" -> inputWithTitle(1),
     Root / "doc-2.md" -> inputWithTitle(2),
     Root / "doc-3.md" -> inputWithTitle(3),
     Root / "home.png" -> ""
   )
+
+  val nestedInputs = Seq(
+    Root / "dir-A" / "doc-1.md" -> inputWithTitle(1),
+    Root / "dir-A" / "doc-2.md" -> inputWithTitle(2),
+    Root / "dir-B" / "doc-3.md" -> inputWithTitle(3),
+    Root / "dir-B" / "doc-4.md" -> inputWithTitle(4),
+    Root / "home.png" -> ""
+  )
+
+  val nestedAndRootInputs = Seq(
+    Root / "doc-1.md" -> inputWithTitle(1),
+    Root / "doc-2.md" -> inputWithTitle(2),
+    Root / "dir-A" / "doc-3.md" -> inputWithTitle(3),
+    Root / "dir-A" / "doc-4.md" -> inputWithTitle(4),
+    Root / "dir-B" / "doc-5.md" -> inputWithTitle(5),
+    Root / "dir-B" / "doc-6.md" -> inputWithTitle(6),
+    Root / "home.png" -> ""
+  )
+  
+  val nestedPathUnderTest = Root / "dir-A" / "doc-1.html"
   
   def transformAndExtract(inputs: Seq[(Path, String)], 
                           helium: Helium, 
@@ -99,7 +119,88 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
                      |<li class="level1 nav-leaf-entry"><a href="doc-2.html">Doc 2</a></li>
                      |<li class="level1 nav-leaf-entry"><a href="doc-3.html">Doc 3</a></li>
                      |</ul>""".stripMargin
-    transformAndExtract(inputs, Helium.defaults.site.landingPage(), "<nav id=\"sidebar\">", "</nav>").assertEquals(expected)
+    transformAndExtract(flatInputs, Helium.defaults.site.landingPage(), "<nav id=\"sidebar\">", "</nav>").assertEquals(expected)
+  }
+
+  test("main navigation - two levels") {
+    val expected = """<div class="row">
+                     |</div>
+                     |<ul class="nav-list">
+                     |<li class="level1 nav-section-header">dir-A</li>
+                     |<li class="level2 active nav-leaf-entry"><a href="#">Doc 1</a></li>
+                     |<li class="level2 nav-leaf-entry"><a href="doc-2.html">Doc 2</a></li>
+                     |<li class="level1 nav-section-header">dir-B</li>
+                     |<li class="level2 nav-leaf-entry"><a href="../dir-B/doc-3.html">Doc 3</a></li>
+                     |<li class="level2 nav-leaf-entry"><a href="../dir-B/doc-4.html">Doc 4</a></li>
+                     |</ul>""".stripMargin
+    transformAndExtract(nestedInputs, Helium.defaults.site.landingPage(), "<nav id=\"sidebar\">", "</nav>", nestedPathUnderTest).assertEquals(expected)
+  }
+
+  test("main navigation - customized depth") {
+    val expected = """<div class="row">
+                     |</div>
+                     |<ul class="nav-list">
+                     |<li class="level1 active nav-leaf-entry"><a href="#">Doc 1</a></li>
+                     |<li class="level1 nav-leaf-entry"><a href="doc-2.html">Doc 2</a></li>
+                     |</ul>""".stripMargin
+    val helium = Helium.defaults.site.landingPage().site.mainNavigation(depth = 1)
+    transformAndExtract(nestedAndRootInputs, helium, "<nav id=\"sidebar\">", "</nav>").assertEquals(expected)
+  }
+
+  test("main navigation - include page sections") {
+    val expected = """<div class="row">
+                     |</div>
+                     |<ul class="nav-list">
+                     |<li class="level1 active nav-title-page"><a href="#">Doc 1</a></li>
+                     |<li class="level2 nav-leaf-entry"><a href="#section-1">Section 1</a></li>
+                     |<li class="level2 nav-leaf-entry"><a href="#section-2">Section 2</a></li>
+                     |<li class="level1 nav-title-page"><a href="doc-2.html">Doc 2</a></li>
+                     |<li class="level2 nav-leaf-entry"><a href="doc-2.html#section-1">Section 1</a></li>
+                     |<li class="level2 nav-leaf-entry"><a href="doc-2.html#section-2">Section 2</a></li>
+                     |<li class="level1 nav-title-page"><a href="doc-3.html">Doc 3</a></li>
+                     |<li class="level2 nav-leaf-entry"><a href="doc-3.html#section-1">Section 1</a></li>
+                     |<li class="level2 nav-leaf-entry"><a href="doc-3.html#section-2">Section 2</a></li>
+                     |</ul>""".stripMargin
+    val helium = Helium.defaults.site.landingPage().site.mainNavigation(includePageSections = true)
+    transformAndExtract(flatInputs, helium, "<nav id=\"sidebar\">", "</nav>").assertEquals(expected)
+  }
+
+  test("main navigation - append links") {
+    val expected = """<div class="row">
+                     |</div>
+                     |<ul class="nav-list">
+                     |<li class="level1 active nav-leaf-entry"><a href="#">Doc 1</a></li>
+                     |<li class="level1 nav-leaf-entry"><a href="doc-2.html">Doc 2</a></li>
+                     |<li class="level1 nav-leaf-entry"><a href="doc-3.html">Doc 3</a></li>
+                     |<li class="level1 nav-section-header">Additional Links</li>
+                     |<li class="level2 active nav-leaf-entry"><a href="#">Add Link 1</a></li>
+                     |<li class="level2 nav-leaf-entry"><a href="https://foo.com">Add Link 2</a></li>
+                     |</ul>""".stripMargin
+    val section = ThemeNavigationSection("Additional Links", 
+      TextLink.internal(Root / "doc-1.md", "Add Link 1"),
+      TextLink.external("https://foo.com", "Add Link 2")
+    )
+    val helium = Helium.defaults.site.landingPage().site.mainNavigation(appendLinks = Seq(section))
+    transformAndExtract(flatInputs, helium, "<nav id=\"sidebar\">", "</nav>").assertEquals(expected)
+  }
+
+  test("main navigation - prepend links") {
+    val expected = """<div class="row">
+                     |</div>
+                     |<ul class="nav-list">
+                     |<li class="level1 nav-section-header">Additional Links</li>
+                     |<li class="level2 active nav-leaf-entry"><a href="#">Add Link 1</a></li>
+                     |<li class="level2 nav-leaf-entry"><a href="https://foo.com">Add Link 2</a></li>
+                     |<li class="level1 active nav-leaf-entry"><a href="#">Doc 1</a></li>
+                     |<li class="level1 nav-leaf-entry"><a href="doc-2.html">Doc 2</a></li>
+                     |<li class="level1 nav-leaf-entry"><a href="doc-3.html">Doc 3</a></li>
+                     |</ul>""".stripMargin
+    val section = ThemeNavigationSection("Additional Links",
+      TextLink.internal(Root / "doc-1.md", "Add Link 1"),
+      TextLink.external("https://foo.com", "Add Link 2")
+    )
+    val helium = Helium.defaults.site.landingPage().site.mainNavigation(prependLinks = Seq(section))
+    transformAndExtract(flatInputs, helium, "<nav id=\"sidebar\">", "</nav>").assertEquals(expected)
   }
 
   test("page navigation - two levels") {
@@ -112,7 +213,7 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
         |<li class="level2 nav-leaf-entry"><a href="#section-2-1">Section 2.1</a></li>
         |</ul>
         |<p class="footer"></p>""".stripMargin
-    transformAndExtract(inputs, Helium.defaults.site.landingPage(), "<nav id=\"page-nav\">", "</nav>").assertEquals(expected)
+    transformAndExtract(flatInputs, Helium.defaults.site.landingPage(), "<nav id=\"page-nav\">", "</nav>").assertEquals(expected)
   }
 
   test("page navigation - with footer link") {
@@ -126,7 +227,7 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
         |</ul>
         |<p class="footer"><a href="https://github.com/my-project/doc-1.md"><i class="icofont-laika" title="Edit">&#xef10;</i>Source for this page</a></p>""".stripMargin
     val helium = Helium.defaults.site.markupEditLinks("Source for this page", "https://github.com/my-project").site.landingPage()
-    transformAndExtract(inputs, helium, "<nav id=\"page-nav\">", "</nav>").assertEquals(expected)
+    transformAndExtract(flatInputs, helium, "<nav id=\"page-nav\">", "</nav>").assertEquals(expected)
   }
 
   test("page navigation - without footer link on generated page") {
@@ -139,7 +240,7 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
       .site.markupEditLinks("Source for this page", "https://github.com/my-project")
       .site.tableOfContent("Table of Content", 2)
       .site.landingPage()
-    transformAndExtract(inputs, helium, "<nav id=\"page-nav\">", "</nav>", Root / "table-of-content.html").assertEquals(expected)
+    transformAndExtract(flatInputs, helium, "<nav id=\"page-nav\">", "</nav>", Root / "table-of-content.html").assertEquals(expected)
   }
 
   test("top navigation - defaults") {
@@ -152,7 +253,7 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
         |<a class="icon-link" href="index.html"><i class="icofont-laika" title="Home">&#xef47;</i></a>
         |<div class="row links">
         |</div>""".stripMargin
-    transformAndExtract(inputs, Helium.defaults.site.landingPage(), "<header id=\"top-bar\">", "</header>").assertEquals(expected)
+    transformAndExtract(flatInputs, Helium.defaults.site.landingPage(), "<header id=\"top-bar\">", "</header>").assertEquals(expected)
   }
 
   test("top navigation - with custom links") {
@@ -175,7 +276,7 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
           IconLink.internal(Root / "doc-2.md", HeliumIcon.demo),
           ButtonLink.external("http://somewhere.com/", "Somewhere")
         ))
-    transformAndExtract(inputs, helium, "<header id=\"top-bar\">", "</header>").assertEquals(expected)
+    transformAndExtract(flatInputs, helium, "<header id=\"top-bar\">", "</header>").assertEquals(expected)
   }
 
   test("top navigation - with menu") {
@@ -207,7 +308,7 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
           TextLink.internal(Root / "doc-3.md", "Link 2")  
         )
       ))
-    transformAndExtract(inputs, helium, "<header id=\"top-bar\">", "</header>").assertEquals(expected)
+    transformAndExtract(flatInputs, helium, "<header id=\"top-bar\">", "</header>").assertEquals(expected)
   }
 
   test("top navigation - with version dropdown on a versioned page") {
@@ -233,7 +334,7 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
         |<div class="row links">
         |</div>""".stripMargin
     val config = Root / "directory.conf" -> "laika.versioned = true"
-    transformAndExtract(inputs :+ config, helium, "<header id=\"top-bar\">", "</header>", Root / "0.42" / "doc-1.html").assertEquals(expected)
+    transformAndExtract(flatInputs :+ config, helium, "<header id=\"top-bar\">", "</header>", Root / "0.42" / "doc-1.html").assertEquals(expected)
   }
 
   test("top navigation - with version dropdown on an unversioned page") {
@@ -259,7 +360,7 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
         |<a class="icon-link" href="index.html"><i class="icofont-laika" title="Home">&#xef47;</i></a>
         |<div class="row links">
         |</div>""".stripMargin
-    transformAndExtract(inputs, helium, "<header id=\"top-bar\">", "</header>").assertEquals(expected)
+    transformAndExtract(flatInputs, helium, "<header id=\"top-bar\">", "</header>").assertEquals(expected)
   }
 
 }


### PR DESCRIPTION
The left navigation pane in the default Helium theme is auto-generated based on the structure of the user's input directories.  Any kind of customization previously required a custom template, which is an unnecessarily high burden.

This PR expands the Helium API to allow users to tweak the following aspects of the left navigation pane:

* Change the default navigation depth (2 levels)
* Allow to include page section titles (may be attractive if a user has only very few pages in their site and wants to make better use of the space in the left navigation pane).
* Allow to prepend or append additional sections of links, either internal or external, with a custom header.

Example:

```scala
Helium.defaults.site
  .mainNavigation(
    depth = 3,
    includePageSections = true,
    appendLinks = Seq(ThemeNavigationSection("Additional Links",
      TextLink.internal(Root / "doc-1.md", "Link 1"),
      TextLink.external("https://foo.com", "Link 2")
    ))
  )
```