### PR TITLE
Helium: make page nav configurable via Helium API + config headers

### DIFF
--- a/docs/src/03-preparing-content/03-theme-settings.md
+++ b/docs/src/03-preparing-content/03-theme-settings.md
@@ -624,6 +624,47 @@ of the page (darker in light mode and lighter in dark mode).
 @:todo(show Helium's available icons somewhere)
 
 
+### Page Navigation
+
+A Helium site contains a page navigation pane on the right side on bigger screens.
+When running with the default settings, the pane contains the title of the page and links
+to the two top layers of the sections on that page.
+
+The configuration API allows for some customization:
+
+```scala
+Helium.defaults
+  .site.pageNavigation(
+    enabled = true,
+    depth = 1,
+    sourceBaseURL = "https://github.com/my/project",
+    sourceLinkText = "Source for this Page"
+  )
+```
+
+The `enabled` property is true by default. Setting it to false completely removes it from the rendered pages.
+In this case all other properties won't have any effect unless the flag is set to true on individual pages as shown below.
+
+The `depth` property allows to change the navigation depth.
+The default is 2, meaning it will link to all level 1 and level 2 headers of the page.
+
+Finally, the bottom of the pane can contain a link to the markup sources (e.g. on GitHub)
+if you provide a `sourceBaseURL`.
+The `sourceLinkText` can be overridden, too. The example above shows the default value.
+
+The same properties can also be set on individual pages via a HOCON configuration header:
+
+```laika-md
+{%
+  helium.site.pageNavigation.depth = 3
+%}
+```
+
+Note that setting the depth to 0 will not remove the page navigation box as it will still render
+the title and the link to the source if configured.
+To remove the pane entirely, the `enabled` flag has to be set to false instead.
+
+
 ### Table of Contents
 
 All three formats support an additional table of contents. 
@@ -661,20 +702,6 @@ If you increase this setting make sure you verify it's looking good in the targe
 
 @:@
 
-
-### Links to Markup Sources
-
-A Helium site contains a page navigation pane on the right side on bigger screens.
-At the bottom of that pane a link to the source of the current page will be inserted
-if you provide the base URL to link to:
-
-```scala
-Helium.defaults
-  .site.markupEditLinks(
-    text = "Source for this Page", 
-    baseURL = "https://github.com/my/project"
-  )
-```
 
 ### Favicons
 

--- a/io/src/main/resources/laika/helium/css/container.css
+++ b/io/src/main/resources/laika/helium/css/container.css
@@ -53,6 +53,8 @@ main.content {
 @media (min-width: 1450px) {
   main.content {
     max-width: 1125px;
+  }
+  #page-nav + main.content {
     padding: 15px 310px 15px 45px;
   }
 }

--- a/io/src/main/resources/laika/helium/css/nav.css
+++ b/io/src/main/resources/laika/helium/css/nav.css
@@ -265,8 +265,8 @@ ul.nav-list, #page-nav ul {
   margin: 12px;
 }
 #page-nav .level3 {
-  margin-left: 18px;
-  font-size: var(--code-font-size);
+  margin-left: 24px;
+  font-size: 0.9em;
 }
 #page-nav a {
   display: block;
@@ -293,11 +293,11 @@ ul.nav-list, #page-nav ul {
   line-height: 1.5;
 }
 #page-nav .nav-list .level1 {
-  font-size: var(--body-font-size);
+  font-size: 1em;
 }
 #page-nav .nav-list .level2 {
   margin-left: 18px;
-  font-size: var(--code-font-size);
+  font-size: 0.9em;
 }
 #page-nav .nav-list li a {
   padding: 0;

--- a/io/src/main/resources/laika/helium/templates/includes/pageNav.template.html
+++ b/io/src/main/resources/laika/helium/templates/includes/pageNav.template.html
@@ -1,11 +1,13 @@
+@:if(helium.site.pageNavigation.enabled)
 <nav id="page-nav">
   <p class="header"><a href="#">${cursor.currentDocument.title}</a></p>
 
   @:navigationTree {
     entries = [
-      { target = "#", excludeRoot = true, depth = 2 }
+      { target = "#", excludeRoot = true, depth = ${helium.site.pageNavigation.depth} }
     ]
   }
 
-  <p class="footer">@:for(helium.markupEditLinks)<a href="${_.baseURL}${cursor.currentDocument.path}">${_.icon}${_.text}</a>@:@</p>
+  <p class="footer">@:for(helium.site.pageNavigation.sourceBaseURL)<a href="${_}${cursor.currentDocument.path}">${helium.site.pageNavigation.sourceLinkIcon}${helium.site.pageNavigation.sourceLinkText}</a>@:@</p>
 </nav>
+@:@

--- a/io/src/main/scala/laika/helium/config/layout.scala
+++ b/io/src/main/scala/laika/helium/config/layout.scala
@@ -34,9 +34,9 @@ private[helium] case class WebLayout(contentWidth: Length,
                                      favIcons: Seq[Favicon] = Nil,
                                      topNavigationBar: TopNavigationBar = TopNavigationBar.default,
                                      mainNavigation: MainNavigation = MainNavigation(),
+                                     pageNavigation: PageNavigation = PageNavigation(),
                                      tableOfContent: Option[TableOfContent] = None,
-                                     downloadPage: Option[DownloadPage] = None,
-                                     markupEditLinks: Option[MarkupEditLinks] = None) extends CommonLayout
+                                     downloadPage: Option[DownloadPage] = None) extends CommonLayout
 
 private[helium] case class PDFLayout (pageWidth: Length, pageHeight: Length,
                                       marginTop: Length, marginRight: Length, marginBottom: Length, marginLeft: Length,
@@ -66,6 +66,11 @@ private[helium] case class MainNavigation (depth: Int = 2,
                                            includePageSections: Boolean = false,
                                            prependLinks: Seq[ThemeNavigationSection] = Nil,
                                            appendLinks: Seq[ThemeNavigationSection] = Nil)
+
+private[helium] case class PageNavigation (enabled: Boolean = true,
+                                           depth: Int = 2,
+                                           sourceBaseURL: Option[String] = None,
+                                           sourceLinkText: String = "Source for this page")
 
 private[helium] case class DownloadPage (title: String, description: Option[String], downloadPath: Path = Root / "downloads", 
                                         includeEPUB: Boolean = true, includePDF: Boolean = true)

--- a/io/src/main/scala/laika/helium/config/settings.scala
+++ b/io/src/main/scala/laika/helium/config/settings.scala
@@ -444,6 +444,15 @@ private[helium] trait SiteOps extends SingleConfigOps with CopyOps {
       .copy(topNavigationBar = TopNavigationBar(homeLink, navLinks, versionMenu, highContrast))
     copyWith(helium.siteSettings.copy(layout = newLayout))
   }
+  
+  def pageNavigation (enabled: Boolean = helium.siteSettings.layout.pageNavigation.enabled, 
+                      depth: Int = helium.siteSettings.layout.pageNavigation.depth,
+                      sourceBaseURL: Option[String] = helium.siteSettings.layout.pageNavigation.sourceBaseURL,
+                      sourceLinkText: String = helium.siteSettings.layout.pageNavigation.sourceLinkText): Helium = {
+    val newLayout = helium.siteSettings.layout
+      .copy(pageNavigation = PageNavigation(enabled, depth, sourceBaseURL, sourceLinkText))
+    copyWith(helium.siteSettings.copy(layout = newLayout))
+  }
 
   /** Adds a dedicated page for a table of content, in addition to the left navigation bar.
     * 
@@ -474,15 +483,11 @@ private[helium] trait SiteOps extends SingleConfigOps with CopyOps {
     copyWith(helium.siteSettings.copy(layout = newLayout))
   }
 
-  /** Adds a link to the markup source of each page on the bottom of the page navigation pane on the right side.
-    *
-    * @param text    the text of the link
-    * @param baseURL the base URL to prepend to the local path of the rendered document
-    */
-  def markupEditLinks (text: String, baseURL: String): Helium = {
-    val newLayout = helium.siteSettings.layout.copy(markupEditLinks = Some(MarkupEditLinks(text, baseURL)))
-    copyWith(helium.siteSettings.copy(layout = newLayout))
-  }
+  @deprecated("0.19.0", "use the corresponding properties of the new pageNavigation method")
+  def markupEditLinks (text: String, baseURL: String): Helium = pageNavigation(
+    sourceLinkText = text,
+    sourceBaseURL = Some(baseURL)
+  )
 
   /** Adds a dedicated landing page to the site that is tailored for software documentation sites.
     * By default no landing page will be included and the site will render the homepage (if present)

--- a/io/src/main/scala/laika/helium/generate/ConfigGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/ConfigGenerator.scala
@@ -84,11 +84,13 @@ private[laika] object ConfigGenerator {
       .build
   }
 
-  implicit val markupEditsEncoder: ConfigEncoder[MarkupEditLinks] = ConfigEncoder[MarkupEditLinks] { links =>
+  implicit val pageNavEncoder: ConfigEncoder[PageNavigation] = ConfigEncoder[PageNavigation] { pageNav =>
     ConfigEncoder.ObjectBuilder.empty
-      .withValue("text", links.text)
-      .withValue("baseURL", links.baseURL.stripSuffix("/"))
-      .withValue("icon", HeliumIcon.edit)
+      .withValue("enabled", pageNav.enabled)
+      .withValue("depth", pageNav.depth)
+      .withValue("sourceBaseURL", pageNav.sourceBaseURL.map(_.stripSuffix("/")))
+      .withValue("sourceLinkText", pageNav.sourceLinkText)
+      .withValue("sourceLinkIcon", HeliumIcon.edit)
       .build
   }
 
@@ -130,8 +132,8 @@ private[laika] object ConfigGenerator {
       .withValue("helium.landingPage", helium.siteSettings.landingPage)
       .withValue("helium.topBar", helium.siteSettings.layout.topNavigationBar)
       .withValue("helium.site.mainNavigation", helium.siteSettings.layout.mainNavigation)
+      .withValue("helium.site.pageNavigation", helium.siteSettings.layout.pageNavigation)
       .withValue("helium.favIcons", helium.siteSettings.layout.favIcons)
-      .withValue("helium.markupEditLinks", helium.siteSettings.layout.markupEditLinks)
       .withValue("helium.site.templates", templatePaths)
       .withValue("laika.site.metadata", helium.siteSettings.metadata)
       .withValue("laika.epub", helium.epubSettings.bookConfig)

--- a/io/src/main/scala/laika/helium/generate/TocPageGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/TocPageGenerator.scala
@@ -60,7 +60,7 @@ private[helium] object TocPageGenerator {
         val navList = NavigationList(navContent, Styles("toc"))
         val title = Title(tocConfig.title).withOptions(Style.title)
         val root = RootElement(Preamble(tocConfig.title), title, navList) // TODO - Preamble should be inserted in PDF.prepareTree
-        val doc = Document(Root / "table-of-content", root, config = tree.root.config.withValue("helium.markupEditLinks", false).build)
+        val doc = Document(Root / "table-of-content", root, config = tree.root.config.withValue("helium.site.pageNavigation.enabled", false).build)
         tree.modifyTree(_.prependContent(doc))
       }
     Sync[F].pure(result)

--- a/io/src/test/scala/laika/helium/HeliumTocPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumTocPageSpec.scala
@@ -95,12 +95,6 @@ class HeliumTocPageSpec extends CatsEffectSuite with InputBuilder with ResultExt
                      |</ul>
                      |</nav>
                      |<div id="container">
-                     |<nav id="page-nav">
-                     |<p class="header"><a href="#">Contents</a></p>
-                     |<ul class="nav-list">
-                     |</ul>
-                     |<p class="footer"></p>
-                     |</nav>
                      |<main class="content">
                      |<h1 class="title">Contents</h1>
                      |<ul class="toc nav-list">


### PR DESCRIPTION
Previously the only configurable aspect of the page navigation box on the right were the links to the markup sources.
This PR adds options to control the navigation depth or to remove the entire box and allows users to override the global defaults for individual pages via HOCON configuration headers in the markup.

----

The new section in the manual:

A Helium site contains a page navigation pane on the right side on bigger screens.
When running with the default settings, the pane contains the title of the page and links
to the two top layers of the sections on that page.

The configuration API allows for some customization:

```scala
Helium.defaults
  .site.pageNavigation(
    enabled = true,
    depth = 1,
    sourceBaseURL = "https://github.com/my/project",
    sourceLinkText = "Source for this Page"
  )
```

The `enabled` property is true by default. Setting it to false completely removes it from the rendered pages.
In this case all other properties won't have any effect unless the flag is set to true on individual pages as shown below.

The `depth` property allows to change the navigation depth.
The default is 2, meaning it will link to all level 1 and level 2 headers of the page.

Finally, the bottom of the pane can contain a link to the markup sources (e.g. on GitHub) if you provide a `sourceBaseURL`.
The `sourceLinkText` can be overridden, too. The example above shows the default value.

The same properties can also be set on individual pages via a HOCON configuration header:

```laika-md
{%
  helium.site.pageNavigation.depth = 3
%}
```

Note that setting the depth to 0 will not remove the page navigation box as it will still render
the title and the link to the source if configured.
To remove the pane entirely, the `enabled` flag has to be set to false instead.