### PR TITLE
Helium - add new placeholder 'titleLinks' to landing page

### DIFF
--- a/docs/src/03-preparing-content/03-theme-settings.md
+++ b/docs/src/03-preparing-content/03-theme-settings.md
@@ -791,6 +791,14 @@ Helium.defaults
       ReleaseInfo("Latest Milestone Release", "2.4.0-M2")
     ),
     license = Some("MIT"),
+    subtitleLinks = Seq(
+      VersionMenu.create(unversionedLabel = "Getting Started"),
+      LinkGroup.create(
+        IconLink.external("https://github.com/abcdefg/", HeliumIcon.github),
+        IconLink.external("https://gitter.im/abcdefg/", HeliumIcon.chat),
+        IconLink.external("https://twitter.com/abcdefg/", HeliumIcon.twitter)
+      )
+    ),
     documentationLinks = Seq(
       TextLink.internal(Root / "doc-1.md", "Doc 1"),
       TextLink.internal(Root / "doc-2.md", "Doc 2")
@@ -824,6 +832,10 @@ The diagram below shows the positions of these items on the page:
 The left side of the header introduces the project, ideally you would choose at least one of the three options 
 (logo, title and subtitle). 
 In the case of Laika's site for example, the title is omitted as the project name is already part of the logo.
+
+Below the subtitle you can also add a row of links, which may be a menu, icon links, text links or even a
+version menu.
+This is the most prominent position for links on the landing page.
 
 On the right side, the latest release info usually points to one or two releases, the latter if there is also a milestone available.
 The panel for documentation links can be any links right into the content of your site, like Getting Started pages, 

--- a/docs/src/03-preparing-content/03-theme-settings.md
+++ b/docs/src/03-preparing-content/03-theme-settings.md
@@ -791,7 +791,7 @@ Helium.defaults
       ReleaseInfo("Latest Milestone Release", "2.4.0-M2")
     ),
     license = Some("MIT"),
-    subtitleLinks = Seq(
+    titleLinks = Seq(
       VersionMenu.create(unversionedLabel = "Getting Started"),
       LinkGroup.create(
         IconLink.external("https://github.com/abcdefg/", HeliumIcon.github),
@@ -834,7 +834,7 @@ The left side of the header introduces the project, ideally you would choose at 
 In the case of Laika's site for example, the title is omitted as the project name is already part of the logo.
 
 Below the subtitle you can also add a row of links, which may be a menu, icon links, text links or even a
-version menu.
+version menu, by using the `titleLinks` property.
 This is the most prominent position for links on the landing page.
 
 On the right side, the latest release info usually points to one or two releases, the latter if there is also a milestone available.

--- a/io/src/main/resources/laika/helium/css/landing.css
+++ b/io/src/main/resources/laika/helium/css/landing.css
@@ -35,6 +35,16 @@ body {
   margin: 0 0 25px 0;
   padding: 0 35px;
 }
+.teaser h2 {
+  font-size: var(--teaser-title-font-size);
+  margin-bottom: 0.25em;
+  margin-top: 0;
+}
+
+.teaser p {
+  font-size: var(--teaser-body-font-size);
+}
+
 #header-left {
   color: var(--primary-medium);
   margin: 0 auto;
@@ -71,7 +81,7 @@ ul {
 li {
   padding: 0 10px 0 10px;
   display: block;
-  font-size: 17px;
+  font-size: 16px;
 }
 .large {
   font-size: 24px;
@@ -83,16 +93,19 @@ li {
   font-weight: bold;
   margin-bottom: 12px;
 }
-#header-left h2 {
+#header-left h1, #header-left h2 {
   color: var(--primary-medium);
-  font-size: 19px;
-}
-h2 {
-  font-size: 20px;
-  margin-top: 0;
-  line-height: 28px;
+  line-height: 1.5;
   margin-bottom: 5px;
 }
+#header-left h1 {
+  font-size: 48px;
+}
+#header-left h2 {
+  font-size: var(--landing-subtitle-font-size);
+  margin-top: 0.7em;
+}
+
 @media (min-width: 700px) {
   #header {
     display: flex;
@@ -243,10 +256,6 @@ h2 {
 
 #header-left .menu-toggle:hover:after {
   border-top: 8px solid var(--primary-medium);
-}
-
-.menu-content {
-  display: block;
 }
 
 #header-left .menu-content {

--- a/io/src/main/resources/laika/helium/css/landing.css
+++ b/io/src/main/resources/laika/helium/css/landing.css
@@ -140,3 +140,143 @@ h2 {
     height: auto;
   }
 }
+
+/* title links container ======================================================= */
+
+#header-left div.row.links {
+  margin-top: 45px;
+  height: 40px;
+  display: flex;
+  /*justify-content: space-between;*/
+
+  gap: 30px;
+  align-items: center;
+}
+
+#header-left div.row.links > * {
+  flex: 1 1 0;
+}
+
+/* link group ===================================================== */
+
+#header-left div.row.links > .row.links {
+  border: 1px solid var(--primary-medium);
+  border-radius: 8px;
+  height: 100%;
+  padding-top: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: space-evenly;
+  vertical-align: middle;
+}
+
+#header-left .row.links a.icon-link:hover {
+  text-decoration: none;
+  color: var(--secondary-color);
+}
+
+/* icon links ===================================================== */
+
+.icon-link.glyph-link {
+  padding-top: 2px;
+  padding-bottom: 0;
+}
+
+.icon-link.svg-link {
+  padding-top: 0;
+  padding-bottom: 4px;
+}
+
+.svg-shape {
+  fill: var(--primary-medium);
+}
+
+/* menus + button link ======================================================= */
+
+#header-left .menu-container, #header-left .button-link {
+  height: 100%;
+  vertical-align: middle;
+}
+
+#header-left .button-link i.icofont-laika, #header-left .button-link > span {
+  vertical-align: middle;
+  padding-right: 10px;
+  margin-top: -4px;
+  display: inline-block;
+}
+
+#header-left .button-link > span svg {
+  vertical-align: middle;
+  margin-top: -3px;
+}
+
+#header-left .button-link .svg-shape {
+  fill: white;
+}
+#header-left .button-link:hover .svg-shape {
+  fill: var(--primary-medium);
+}
+
+#header-left a.menu-toggle, #header-left .button-link {
+  padding-top: 2px;
+  font-size: 20px;
+  color: white;
+  background-color: var(--secondary-color);
+}
+
+#header-left a.menu-toggle {
+  height: 100%;
+  width: 100%;
+  bottom: 0;
+}
+
+#header-left .menu-container a.menu-toggle:hover, #header-left a.button-link:hover {
+  color: var(--primary-medium);
+  text-decoration: none;
+}
+
+#header-left .menu-toggle:after {
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-top: 8px solid white;
+}
+
+#header-left .menu-toggle:hover:after {
+  border-top: 8px solid var(--primary-medium);
+}
+
+.menu-content {
+  display: block;
+}
+
+#header-left .menu-content {
+  top: 35px;
+}
+
+#header-left .menu-content a, #header-left .menu-content a:hover {
+  color: var(--primary-color);
+}
+
+/* other link types =================================================== */
+
+#header-left a.text-link {
+  padding-top: 3px;
+  font-size: 20px;
+}
+
+#header-left a.image-link {
+  height: 100%;
+  display: inline-block;
+  position: relative;
+}
+
+#header-left a.image-link img {
+  position: absolute;
+  max-height: 100%;
+  max-width: 100%;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin: auto;
+}

--- a/io/src/main/resources/laika/helium/css/nav.css
+++ b/io/src/main/resources/laika/helium/css/nav.css
@@ -62,7 +62,7 @@ nav .row {
   bottom: 2px;
 }
 
-.button-link {
+.button-link, #header-left .menu-toggle {
   position: relative;
   bottom: 2px;
   display: inline-block;

--- a/io/src/main/resources/laika/helium/js/theme.js
+++ b/io/src/main/resources/laika/helium/js/theme.js
@@ -38,7 +38,31 @@ function initNavToggle () {
   }
 }
 
+function initMenuToggles () {
+  // this functionality applies to all types of menus, including the version menu
+  document.querySelectorAll(".menu-container").forEach((container) => {
+    const toggle = container.querySelector(".menu-toggle");
+    const content = container.querySelector(".menu-content");
+    if (toggle && content) {
+      const closeHandler = (evt) => {
+        const contentClicked = evt.target.closest(".menu-content");
+        const toggleClicked = evt.target.closest(".menu-toggle");
+        if ((!toggleClicked || toggleClicked !== toggle) && (!contentClicked || contentClicked !== content)) {
+          content.classList.remove("menu-open");
+          document.removeEventListener("click", closeHandler)
+        }
+      }
+      toggle.onclick = () => {
+        if (content.classList.toggle("menu-open")) {
+          document.addEventListener("click", closeHandler);
+        }
+      };
+    }
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   initNavToggle();
+  initMenuToggles();
   initTabs();
 });

--- a/io/src/main/resources/laika/helium/js/versions.js
+++ b/io/src/main/resources/laika/helium/js/versions.js
@@ -71,29 +71,6 @@ function loadVersions (localRootPrefix, currentPath, currentVersion, siteBaseURL
   req.send();
 }
 
-function initMenuToggles () {
-  // this functionality applies to all types of menus, including the version menu
-  document.querySelectorAll(".menu-container").forEach((container) => {
-    const toggle = container.querySelector(".menu-toggle");
-    const content = container.querySelector(".menu-content");
-    if (toggle && content) {
-      const closeHandler = (evt) => {
-        const contentClicked = evt.target.closest(".menu-content");
-        const toggleClicked = evt.target.closest(".menu-toggle");
-        if ((!toggleClicked || toggleClicked !== toggle) && (!contentClicked || contentClicked !== content)) {
-          content.classList.remove("menu-open");
-          document.removeEventListener("click", closeHandler)
-        }
-      }
-      toggle.onclick = () => {
-        if (content.classList.toggle("menu-open")) {
-          document.addEventListener("click", closeHandler);
-        }
-      };
-    }
-  });
-}
-
 function insertCanonicalLink (linkHref) {
   if (!document.querySelector("link[rel='canonical']")) {
     const head = document.head;
@@ -106,7 +83,7 @@ function insertCanonicalLink (linkHref) {
 
 function initVersions (localRootPrefix, currentPath, currentVersion, siteBaseURL) {
   document.addEventListener('DOMContentLoaded', () => {
-    loadVersions(localRootPrefix, currentPath, currentVersion, siteBaseURL);
-    initMenuToggles();
+    if (document.querySelectorAll(".version-menu").length > 0)
+      loadVersions(localRootPrefix, currentPath, currentVersion, siteBaseURL);
   });
 }

--- a/io/src/main/resources/laika/helium/templates/landing.template.html
+++ b/io/src/main/resources/laika/helium/templates/landing.template.html
@@ -30,6 +30,7 @@
         @:for(helium.landingPage.logo) ${_} @:@
         @:for(helium.landingPage.title) <h1>${_}</h1> @:@
         @:for(helium.landingPage.subtitle) <h2>${_}</h2> @:@
+        ${?helium.landingPage.subtitleLinks}
       </div>
       <div id="header-right">
         @:for(helium.landingPage.latestReleases)

--- a/io/src/main/resources/laika/helium/templates/landing.template.html
+++ b/io/src/main/resources/laika/helium/templates/landing.template.html
@@ -30,7 +30,7 @@
         @:for(helium.landingPage.logo) ${_} @:@
         @:for(helium.landingPage.title) <h1>${_}</h1> @:@
         @:for(helium.landingPage.subtitle) <h2>${_}</h2> @:@
-        ${?helium.landingPage.subtitleLinks}
+        ${?helium.landingPage.titleLinks}
       </div>
       <div id="header-right">
         @:for(helium.landingPage.latestReleases)

--- a/io/src/main/resources/laika/helium/templates/landing.template.html
+++ b/io/src/main/resources/laika/helium/templates/landing.template.html
@@ -20,6 +20,7 @@
     @:@
     @:linkCSS
     @:linkJS
+    @:heliumInitVersions
     <script> /* for avoiding page load transitions */ </script>
   </head>
 

--- a/io/src/main/scala/laika/helium/config/ThemeLink.scala
+++ b/io/src/main/scala/laika/helium/config/ThemeLink.scala
@@ -69,7 +69,16 @@ sealed trait MultiTargetLink extends ThemeLink {
   */
 sealed abstract case class IconLink (target: Target, icon: Icon, text: Option[String] = None, options: Options = NoOpt) extends SingleTargetLink {
   type Self = IconLink
-  protected def createLink (target: Target): Link = SpanLink(icon +: text.map(Text(_)).toSeq, target, options = HeliumStyles.iconLink + options)
+  protected def createLink (target: Target): Link = {
+    val iconTypeStyle = icon match {
+      case _: IconGlyph => "glyph-link"
+      case _: IconStyle => "style-link"
+      case _: InlineSVGIcon => "svg-link"
+      case _: SVGSymbolIcon => "svg-link"
+    }
+    val allOptions = HeliumStyles.iconLink + Styles(iconTypeStyle) + options
+    SpanLink(icon +: text.map(Text(_)).toSeq, target, options = allOptions)
+  }
   def withOptions(newOptions: Options): IconLink = new IconLink(target, icon, text, newOptions) {}
 }
 

--- a/io/src/main/scala/laika/helium/config/layout.scala
+++ b/io/src/main/scala/laika/helium/config/layout.scala
@@ -90,10 +90,11 @@ private[helium] case class LandingPage (logo: Option[Image] = None,
                                         subtitle: Option[String] = None,
                                         latestReleases: Seq[ReleaseInfo] = Nil,
                                         license: Option[String] = None,
-                                        subtitleLinks: Seq[ThemeLink] = Nil,
+                                        titleLinks: Seq[ThemeLink] = Nil,
                                         documentationLinks: Seq[TextLink] = Nil,
                                         projectLinks: Seq[ThemeLinkSpan] = Nil,
-                                        teasers: Seq[Teaser] = Nil)
+                                        teasers: Seq[Teaser] = Nil,
+                                        styles: Seq[Path] = Nil)
 
 /** In contrast to the public `LinkGroup` this UI component allows all types of links as children, including menus.
   */

--- a/io/src/main/scala/laika/helium/config/layout.scala
+++ b/io/src/main/scala/laika/helium/config/layout.scala
@@ -94,7 +94,19 @@ private[helium] case class LandingPage (logo: Option[Image] = None,
                                         documentationLinks: Seq[TextLink] = Nil,
                                         projectLinks: Seq[ThemeLinkSpan] = Nil,
                                         teasers: Seq[Teaser] = Nil,
-                                        styles: Seq[Path] = Nil)
+                                        styles: Seq[Path] = Nil) {
+  
+  import LengthUnit._
+  
+  val subtitleFontSize: Length =
+    if (subtitle.exists(_.length > 75)) px(22)
+    else if (subtitle.exists(_.length > 55)) px(27)
+    else px(32)
+  
+  val teaserTitleFontSize: Length = if (teasers.size <= 4) px(28) else px(20)
+  val teaserBodyFontSize: Length = if (teasers.size <= 4) px(17) else px(15)
+  
+}
 
 /** In contrast to the public `LinkGroup` this UI component allows all types of links as children, including menus.
   */

--- a/io/src/main/scala/laika/helium/config/settings.scala
+++ b/io/src/main/scala/laika/helium/config/settings.scala
@@ -526,6 +526,7 @@ private[helium] trait SiteOps extends SingleConfigOps with CopyOps {
     * @param subtitle            a subtitle to be place right under the title
     * @param latestReleases      a set of release versions to display on the right side of the header
     * @param license             the license info to render right under the release info
+    * @param subtitleLinks       a row of links to render beneath the subtitle on the left side of the header
     * @param documentationLinks  a set of documentation links to render in a dedicated panel on the right side of the header
     * @param projectLinks        a set of project links to render at the bottom of the right side of the header
     * @param teasers             a set of teasers containing of headline and description to render below the header
@@ -535,10 +536,11 @@ private[helium] trait SiteOps extends SingleConfigOps with CopyOps {
                    subtitle: Option[String] = None,
                    latestReleases: Seq[ReleaseInfo] = Nil,
                    license: Option[String] = None,
+                   subtitleLinks: Seq[ThemeLink] = Nil,
                    documentationLinks: Seq[TextLink] = Nil,
                    projectLinks: Seq[ThemeLinkSpan] = Nil,
                    teasers: Seq[Teaser] = Nil): Helium = {
-    val page = LandingPage(logo, title, subtitle, latestReleases, license, documentationLinks, projectLinks, teasers)
+    val page = LandingPage(logo, title, subtitle, latestReleases, license, subtitleLinks, documentationLinks, projectLinks, teasers)
     copyWith(helium.siteSettings.copy(landingPage = Some(page)))
   }
 

--- a/io/src/main/scala/laika/helium/config/settings.scala
+++ b/io/src/main/scala/laika/helium/config/settings.scala
@@ -526,21 +526,23 @@ private[helium] trait SiteOps extends SingleConfigOps with CopyOps {
     * @param subtitle            a subtitle to be place right under the title
     * @param latestReleases      a set of release versions to display on the right side of the header
     * @param license             the license info to render right under the release info
-    * @param subtitleLinks       a row of links to render beneath the subtitle on the left side of the header
+    * @param titleLinks          a row of links to render beneath the subtitle on the left side of the header
     * @param documentationLinks  a set of documentation links to render in a dedicated panel on the right side of the header
     * @param projectLinks        a set of project links to render at the bottom of the right side of the header
     * @param teasers             a set of teasers containing of headline and description to render below the header
+    * @param styles              internal paths to additional CSS files that should be linked to the landing page
     */
   def landingPage (logo: Option[Image] = None,
                    title: Option[String] = None,
                    subtitle: Option[String] = None,
                    latestReleases: Seq[ReleaseInfo] = Nil,
                    license: Option[String] = None,
-                   subtitleLinks: Seq[ThemeLink] = Nil,
+                   titleLinks: Seq[ThemeLink] = Nil,
                    documentationLinks: Seq[TextLink] = Nil,
                    projectLinks: Seq[ThemeLinkSpan] = Nil,
-                   teasers: Seq[Teaser] = Nil): Helium = {
-    val page = LandingPage(logo, title, subtitle, latestReleases, license, subtitleLinks, documentationLinks, projectLinks, teasers)
+                   teasers: Seq[Teaser] = Nil,
+                   styles: Seq[Path] = Nil): Helium = {
+    val page = LandingPage(logo, title, subtitle, latestReleases, license, titleLinks, documentationLinks, projectLinks, teasers, styles)
     copyWith(helium.siteSettings.copy(landingPage = Some(page)))
   }
 

--- a/io/src/main/scala/laika/helium/generate/CSSVarGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/CSSVarGenerator.scala
@@ -18,7 +18,7 @@ package laika.helium.generate
 
 import laika.ast.RelativePath
 import laika.ast.Path.Root
-import laika.helium.config.{ColorSet, CommonSettings, DarkModeSupport, EPUBSettings, SiteSettings}
+import laika.helium.config.{ColorSet, CommonSettings, DarkModeSupport, EPUBSettings, LandingPage, SiteSettings}
 import laika.theme.config.FontDefinition
 
 private[helium] object CSSVarGenerator {
@@ -40,7 +40,7 @@ private[helium] object CSSVarGenerator {
       "nav-width"      -> navigationWidth.displayValue,
       "top-bar-height" -> topBarHeight.displayValue
     )
-    generate(settings, layoutStyles, settings.layout.topNavigationBar.highContrast)
+    generate(settings, layoutStyles, settings.layout.topNavigationBar.highContrast, settings.landingPage)
   }
   
   def generate (settings: EPUBSettings): String = {
@@ -49,7 +49,7 @@ private[helium] object CSSVarGenerator {
         generateFontFace(font, res.path.relativeTo(Root / "helium" / "laika-helium.epub.css"))
       }
     }.mkString("", "\n\n", "\n\n")
-    embeddedFonts + generate(settings, Nil, topBarHighContrast = false)
+    embeddedFonts + generate(settings, Nil, topBarHighContrast = false, landingPage = None)
   }
   
   private def toVars (pairs: Seq[(String, String)]): Seq[(String, String)] = pairs.map { 
@@ -99,8 +99,14 @@ private[helium] object CSSVarGenerator {
       "syntax-wheel5" -> syntaxHighlighting.wheel.c5.displayValue
     )
   }
+  
+  def landingPageLayout (landingPage: LandingPage): Seq[(String, String)] = Seq(
+    "landing-subtitle-font-size" -> landingPage.subtitleFontSize.displayValue,
+    "teaser-title-font-size" -> landingPage.teaserTitleFontSize.displayValue,
+    "teaser-body-font-size" -> landingPage.teaserBodyFontSize.displayValue,
+  )
 
-  def generate (common: DarkModeSupport, additionalVars: Seq[(String, String)], topBarHighContrast: Boolean): String = {
+  def generate (common: DarkModeSupport, additionalVars: Seq[(String, String)], topBarHighContrast: Boolean, landingPage: Option[LandingPage]): String = {
     import common._
     val vars = 
       colorSet(common.colors, topBarHighContrast) ++ 
@@ -118,7 +124,8 @@ private[helium] object CSSVarGenerator {
         "block-spacing" -> common.layout.defaultBlockSpacing.displayValue,
         "line-height" -> common.layout.defaultLineHeight.toString
       ) ++ 
-      additionalVars
+      additionalVars ++
+      landingPage.fold(Seq[(String, String)]())(landingPageLayout)
       
     val (colorScheme, darkModeStyles) = common.darkMode match {
       case Some(darkModeColors) => (Seq(("color-scheme", "light dark")), 

--- a/io/src/main/scala/laika/helium/generate/ConfigGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/ConfigGenerator.scala
@@ -45,12 +45,16 @@ private[laika] object ConfigGenerator {
     }
 
   implicit val landingPageEncoder: ConfigEncoder[LandingPage] = ConfigEncoder[LandingPage] { landingPage =>
+    val subtitleLinks = 
+      if (landingPage.subtitleLinks.isEmpty) None
+      else Some(GenericLinkGroup(landingPage.subtitleLinks))
     ConfigEncoder.ObjectBuilder.empty
       .withValue("logo", landingPage.logo)
       .withValue("title", landingPage.title)
       .withValue("subtitle", landingPage.subtitle)
       .withValue("latestReleases", landingPage.latestReleases)
       .withValue("license", landingPage.license)
+      .withValue("subtitleLinks", subtitleLinks)
       .withValue("documentationLinks", landingPage.documentationLinks)
       .withValue("projectLinks", landingPage.projectLinks)
       .withValue("teaserRows", buildTeaserRows(landingPage.teasers))

--- a/io/src/main/scala/laika/helium/generate/ConfigGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/ConfigGenerator.scala
@@ -45,16 +45,16 @@ private[laika] object ConfigGenerator {
     }
 
   implicit val landingPageEncoder: ConfigEncoder[LandingPage] = ConfigEncoder[LandingPage] { landingPage =>
-    val subtitleLinks = 
-      if (landingPage.subtitleLinks.isEmpty) None
-      else Some(GenericLinkGroup(landingPage.subtitleLinks))
+    val titleLinks = 
+      if (landingPage.titleLinks.isEmpty) None
+      else Some(GenericLinkGroup(landingPage.titleLinks))
     ConfigEncoder.ObjectBuilder.empty
       .withValue("logo", landingPage.logo)
       .withValue("title", landingPage.title)
       .withValue("subtitle", landingPage.subtitle)
       .withValue("latestReleases", landingPage.latestReleases)
       .withValue("license", landingPage.license)
-      .withValue("subtitleLinks", subtitleLinks)
+      .withValue("titleLinks", titleLinks)
       .withValue("documentationLinks", landingPage.documentationLinks)
       .withValue("projectLinks", landingPage.projectLinks)
       .withValue("teaserRows", buildTeaserRows(landingPage.teasers))

--- a/io/src/main/scala/laika/helium/generate/LandingPageGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/LandingPageGenerator.scala
@@ -55,7 +55,7 @@ private[helium] object LandingPageGenerator {
       val configWithTemplate = if (doc.config.hasKey(LaikaKeys.template)) doc.config
         else doc.config.withValue(LaikaKeys.template, "landing.template.html").build
       val titleDocWithTemplate = doc.copy(config = configWithTemplate
-        .withValue(LaikaKeys.site.css.child("searchPaths"), Seq(Root / "helium" / "landing.page.css"))
+        .withValue(LaikaKeys.site.css.child("searchPaths"), (Root / "helium" / "landing.page.css") +: landingPage.styles)
         .build
       )
         

--- a/io/src/test/scala/laika/helium/HeliumDownloadPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumDownloadPageSpec.scala
@@ -92,7 +92,7 @@ class HeliumDownloadPageSpec extends CatsEffectSuite with InputBuilder with Resu
                      |<i class="icofont-laika navigationMenu" title="Navigation">&#xefa2;</i>
                      |</a>
                      |</div>
-                     |<a class="icon-link" href="index.html"><i class="icofont-laika home" title="Home">&#xef47;</i></a>
+                     |<a class="icon-link glyph-link" href="index.html"><i class="icofont-laika home" title="Home">&#xef47;</i></a>
                      |<div class="row links">
                      |</div>
                      |</header>

--- a/io/src/test/scala/laika/helium/HeliumHTMLNavSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumHTMLNavSpec.scala
@@ -302,7 +302,7 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
         |<i class="icofont-laika navigationMenu" title="Navigation">&#xefa2;</i>
         |</a>
         |</div>
-        |<a class="icon-link" href="index.html"><i class="icofont-laika home" title="Home">&#xef47;</i></a>
+        |<a class="icon-link glyph-link" href="index.html"><i class="icofont-laika home" title="Home">&#xef47;</i></a>
         |<div class="row links">
         |</div>""".stripMargin
     transformAndExtract(flatInputs, Helium.defaults.site.landingPage(), "<header id=\"top-bar\">", "</header>").assertEquals(expected)
@@ -317,7 +317,7 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
         |</div>
         |<a class="image-link" href="index.html"><img src="home.png" alt="Homepage" title="Home"></a>
         |<div class="row links">
-        |<a class="icon-link" href="doc-2.html"><i class="icofont-laika demo" title="Demo">&#xeeea;</i></a>
+        |<a class="icon-link glyph-link" href="doc-2.html"><i class="icofont-laika demo" title="Demo">&#xeeea;</i></a>
         |<a class="button-link" href="http://somewhere.com/">Somewhere</a>
         |</div>""".stripMargin
     val imagePath = Root / "home.png"
@@ -382,7 +382,7 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
         |</nav>
         |</div>
         |</div>
-        |<a class="icon-link" href="../"><i class="icofont-laika home" title="Home">&#xef47;</i></a>
+        |<a class="icon-link glyph-link" href="../"><i class="icofont-laika home" title="Home">&#xef47;</i></a>
         |<div class="row links">
         |</div>""".stripMargin
     val config = Root / "directory.conf" -> "laika.versioned = true"
@@ -409,7 +409,7 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
         |</nav>
         |</div>
         |</div>
-        |<a class="icon-link" href="index.html"><i class="icofont-laika home" title="Home">&#xef47;</i></a>
+        |<a class="icon-link glyph-link" href="index.html"><i class="icofont-laika home" title="Home">&#xef47;</i></a>
         |<div class="row links">
         |</div>""".stripMargin
     transformAndExtract(flatInputs, helium, "<header id=\"top-bar\">", "</header>").assertEquals(expected)

--- a/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
@@ -27,12 +27,24 @@ import laika.io.api.TreeTransformer
 import laika.io.helper.{InputBuilder, ResultExtractor, StringOps}
 import laika.io.implicits._
 import laika.io.model.StringTreeOutput
+import laika.rewrite.{Version, Versions}
 import laika.rewrite.link.LinkConfig
 import laika.theme._
 import munit.CatsEffectSuite
 
 class HeliumLandingPageSpec extends CatsEffectSuite with InputBuilder with ResultExtractor with StringOps {
 
+  private val versions = Versions(
+    Version("0.42.x", "0.42"),
+    Seq(
+      Version("0.41.x", "0.41"),
+      Version("0.40.x", "0.40", fallbackLink = "toc.html")
+    ),
+    Seq(
+      Version("0.43.x", "0.43")
+    )
+  )
+  
   def transformer (theme: ThemeProvider): Resource[IO, TreeTransformer[IO]] = Transformer
     .from(Markdown)
     .to(HTML)
@@ -88,6 +100,7 @@ class HeliumLandingPageSpec extends CatsEffectSuite with InputBuilder with Resul
                      |<link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
                      |<link rel="stylesheet" type="text/css" href="helium/landing.page.css" />
                      |<script src="helium/laika-helium.js"></script>
+                     |<script src="helium/laika-versions.js"></script>
                      |<script> /* for avoiding page load transitions */ </script>
                      |</head>
                      |<body>
@@ -96,6 +109,20 @@ class HeliumLandingPageSpec extends CatsEffectSuite with InputBuilder with Resul
                      |<img src="home.png" alt="Project Logo">
                      |<h1>My Project</h1>
                      |<h2>Awesome Hyperbole Overkill</h2>
+                     |<div class="row links">
+                     |<div class="menu-container version-menu">
+                     |<a class="text-link menu-toggle" href="#">Getting Started</a>
+                     |<nav class="menu-content">
+                     |<ul class="nav-list">
+                     |</ul>
+                     |</nav>
+                     |</div>
+                     |<span class="row links"><a class="icon-link" href="https://github.com/abcdefg/"><span class="github" title="Source Code"><svg class="svg-icon" width="100%" height="100%" viewBox="0 0 100 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+                     |<g class="svg-shape">
+                     |<path d="M49.995,1c-27.609,-0 -49.995,22.386 -49.995,50.002c-0,22.09 14.325,40.83 34.194,47.444c2.501,0.458 3.413,-1.086 3.413,-2.412c0,-1.185 -0.043,-4.331 -0.067,-8.503c-13.908,3.021 -16.843,-6.704 -16.843,-6.704c-2.274,-5.773 -5.552,-7.311 -5.552,-7.311c-4.54,-3.103 0.344,-3.042 0.344,-3.042c5.018,0.356 7.658,5.154 7.658,5.154c4.46,7.64 11.704,5.433 14.552,4.156c0.454,-3.232 1.744,-5.436 3.174,-6.685c-11.102,-1.262 -22.775,-5.553 -22.775,-24.713c-0,-5.457 1.949,-9.92 5.147,-13.416c-0.516,-1.265 -2.231,-6.348 0.488,-13.233c0,0 4.199,-1.344 13.751,5.126c3.988,-1.108 8.266,-1.663 12.518,-1.682c4.245,0.019 8.523,0.574 12.517,1.682c9.546,-6.47 13.736,-5.126 13.736,-5.126c2.728,6.885 1.013,11.968 0.497,13.233c3.204,3.496 5.141,7.959 5.141,13.416c0,19.209 -11.691,23.436 -22.83,24.673c1.795,1.544 3.394,4.595 3.394,9.26c0,6.682 -0.061,12.076 -0.061,13.715c0,1.338 0.899,2.894 3.438,2.406c19.853,-6.627 34.166,-25.354 34.166,-47.438c-0,-27.616 -22.389,-50.002 -50.005,-50.002"/>
+                     |</g>
+                     |</svg></span></a><a class="icon-link" href="https://gitter.im/abcdefg/"><i class="icofont-laika chat" title="Chat">&#xeed5;</i></a><a class="icon-link" href="https://twitter.com/abcdefg/"><i class="icofont-laika twitter" title="Twitter">&#xed7a;</i></a></span>
+                     |</div>
                      |</div>
                      |<div id="header-right">
                      |<p>Latest Stable Release</p>
@@ -119,33 +146,43 @@ class HeliumLandingPageSpec extends CatsEffectSuite with InputBuilder with Resul
                      |$teaserHTML
                      |</body>""".stripMargin
     val imagePath = Root / "home.png"
-    val helium = Helium.defaults.site.landingPage(
-      logo = Some(Image.internal(imagePath, alt = Some("Project Logo"))),
-      title = Some("My Project"),
-      subtitle = Some("Awesome Hyperbole Overkill"),
-      latestReleases = Seq(
-        ReleaseInfo("Latest Stable Release", "2.3.5"),
-        ReleaseInfo("Latest Milestone Release", "2.4.0-M2")
-      ),
-      license = Some("MIT"),
-      documentationLinks = Seq(
-        TextLink.internal(Root / "doc-1.md", "Doc 1"),
-        TextLink.internal(Root / "doc-2.md", "Doc 2")
-      ),
-      projectLinks = Seq(
-        TextLink.internal(Root / "doc-1.md", "Text Link"),
-        ButtonLink.external("http://somewhere.com/", "Somewhere"),
-        LinkGroup.create(
-          IconLink.internal(Root / "doc-2.md", HeliumIcon.demo),
-          IconLink.internal(Root / "doc-3.md", HeliumIcon.info)
+    val helium = Helium.defaults
+      .site.versions(versions)
+      .site.landingPage(
+        logo = Some(Image.internal(imagePath, alt = Some("Project Logo"))),
+        title = Some("My Project"),
+        subtitle = Some("Awesome Hyperbole Overkill"),
+        latestReleases = Seq(
+          ReleaseInfo("Latest Stable Release", "2.3.5"),
+          ReleaseInfo("Latest Milestone Release", "2.4.0-M2")
+        ),
+        license = Some("MIT"),
+        subtitleLinks = Seq(
+          VersionMenu.create(unversionedLabel = "Getting Started"),
+          LinkGroup.create(
+            IconLink.external("https://github.com/abcdefg/", HeliumIcon.github),
+            IconLink.external("https://gitter.im/abcdefg/", HeliumIcon.chat),
+            IconLink.external("https://twitter.com/abcdefg/", HeliumIcon.twitter)
+          )
+        ),
+        documentationLinks = Seq(
+          TextLink.internal(Root / "doc-1.md", "Doc 1"),
+          TextLink.internal(Root / "doc-2.md", "Doc 2")
+        ),
+        projectLinks = Seq(
+          TextLink.internal(Root / "doc-1.md", "Text Link"),
+          ButtonLink.external("http://somewhere.com/", "Somewhere"),
+          LinkGroup.create(
+            IconLink.internal(Root / "doc-2.md", HeliumIcon.demo),
+            IconLink.internal(Root / "doc-3.md", HeliumIcon.info)
+          )
+        ),
+        teasers = Seq(
+          Teaser("Teaser 1", "Description 1"),
+          Teaser("Teaser 2", "Description 2"),
+          Teaser("Teaser 3", "Description 3")
         )
-      ),
-      teasers = Seq(
-        Teaser("Teaser 1", "Description 1"),
-        Teaser("Teaser 2", "Description 2"),
-        Teaser("Teaser 3", "Description 3")
       )
-    )
     transformAndExtract(inputs, helium, s"""<html lang="${Locale.getDefault.toLanguageTag}">""", "</html>")
       .assertEquals(expected)
   }

--- a/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
@@ -19,7 +19,7 @@ package laika.helium
 import java.util.Locale
 import cats.effect.{IO, Resource}
 import laika.api.Transformer
-import laika.ast.{Image, Path}
+import laika.ast.{/, Image, Path}
 import laika.ast.Path.Root
 import laika.format.{HTML, Markdown}
 import laika.helium.config._
@@ -56,7 +56,8 @@ class HeliumLandingPageSpec extends CatsEffectSuite with InputBuilder with Resul
   val inputs = Seq(
     Root / "doc-1.md" -> "text",
     Root / "doc-2.md" -> "text",
-    Root / "home.png" -> ""
+    Root / "home.png" -> "",
+    Root / "styles" / "landing-extra.page.css" -> ""
   )
   
   def transformAndExtract(inputs: Seq[(Path, String)], helium: Helium, start: String, end: String): IO[String] = transformer(helium.build).use { t =>
@@ -99,6 +100,7 @@ class HeliumLandingPageSpec extends CatsEffectSuite with InputBuilder with Resul
                      |<link rel="stylesheet" type="text/css" href="helium/icofont.min.css" />
                      |<link rel="stylesheet" type="text/css" href="helium/laika-helium.css" />
                      |<link rel="stylesheet" type="text/css" href="helium/landing.page.css" />
+                     |<link rel="stylesheet" type="text/css" href="styles/landing-extra.page.css" />
                      |<script src="helium/laika-helium.js"></script>
                      |<script src="helium/laika-versions.js"></script>
                      |<script> /* for avoiding page load transitions */ </script>
@@ -157,7 +159,7 @@ class HeliumLandingPageSpec extends CatsEffectSuite with InputBuilder with Resul
           ReleaseInfo("Latest Milestone Release", "2.4.0-M2")
         ),
         license = Some("MIT"),
-        subtitleLinks = Seq(
+        titleLinks = Seq(
           VersionMenu.create(unversionedLabel = "Getting Started"),
           LinkGroup.create(
             IconLink.external("https://github.com/abcdefg/", HeliumIcon.github),
@@ -181,7 +183,8 @@ class HeliumLandingPageSpec extends CatsEffectSuite with InputBuilder with Resul
           Teaser("Teaser 1", "Description 1"),
           Teaser("Teaser 2", "Description 2"),
           Teaser("Teaser 3", "Description 3")
-        )
+        ),
+        styles = Seq(Root / "styles" / "landing-extra.page.css") 
       )
     transformAndExtract(inputs, helium, s"""<html lang="${Locale.getDefault.toLanguageTag}">""", "</html>")
       .assertEquals(expected)

--- a/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
@@ -103,6 +103,7 @@ class HeliumLandingPageSpec extends CatsEffectSuite with InputBuilder with Resul
                      |<link rel="stylesheet" type="text/css" href="styles/landing-extra.page.css" />
                      |<script src="helium/laika-helium.js"></script>
                      |<script src="helium/laika-versions.js"></script>
+                     |<script>initVersions("", "", "", null);</script>
                      |<script> /* for avoiding page load transitions */ </script>
                      |</head>
                      |<body>

--- a/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumLandingPageSpec.scala
@@ -117,11 +117,11 @@ class HeliumLandingPageSpec extends CatsEffectSuite with InputBuilder with Resul
                      |</ul>
                      |</nav>
                      |</div>
-                     |<span class="row links"><a class="icon-link" href="https://github.com/abcdefg/"><span class="github" title="Source Code"><svg class="svg-icon" width="100%" height="100%" viewBox="0 0 100 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+                     |<span class="row links"><a class="icon-link svg-link" href="https://github.com/abcdefg/"><span class="github" title="Source Code"><svg class="svg-icon" width="100%" height="100%" viewBox="0 0 100 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
                      |<g class="svg-shape">
                      |<path d="M49.995,1c-27.609,-0 -49.995,22.386 -49.995,50.002c-0,22.09 14.325,40.83 34.194,47.444c2.501,0.458 3.413,-1.086 3.413,-2.412c0,-1.185 -0.043,-4.331 -0.067,-8.503c-13.908,3.021 -16.843,-6.704 -16.843,-6.704c-2.274,-5.773 -5.552,-7.311 -5.552,-7.311c-4.54,-3.103 0.344,-3.042 0.344,-3.042c5.018,0.356 7.658,5.154 7.658,5.154c4.46,7.64 11.704,5.433 14.552,4.156c0.454,-3.232 1.744,-5.436 3.174,-6.685c-11.102,-1.262 -22.775,-5.553 -22.775,-24.713c-0,-5.457 1.949,-9.92 5.147,-13.416c-0.516,-1.265 -2.231,-6.348 0.488,-13.233c0,0 4.199,-1.344 13.751,5.126c3.988,-1.108 8.266,-1.663 12.518,-1.682c4.245,0.019 8.523,0.574 12.517,1.682c9.546,-6.47 13.736,-5.126 13.736,-5.126c2.728,6.885 1.013,11.968 0.497,13.233c3.204,3.496 5.141,7.959 5.141,13.416c0,19.209 -11.691,23.436 -22.83,24.673c1.795,1.544 3.394,4.595 3.394,9.26c0,6.682 -0.061,12.076 -0.061,13.715c0,1.338 0.899,2.894 3.438,2.406c19.853,-6.627 34.166,-25.354 34.166,-47.438c-0,-27.616 -22.389,-50.002 -50.005,-50.002"/>
                      |</g>
-                     |</svg></span></a><a class="icon-link" href="https://gitter.im/abcdefg/"><i class="icofont-laika chat" title="Chat">&#xeed5;</i></a><a class="icon-link" href="https://twitter.com/abcdefg/"><i class="icofont-laika twitter" title="Twitter">&#xed7a;</i></a></span>
+                     |</svg></span></a><a class="icon-link glyph-link" href="https://gitter.im/abcdefg/"><i class="icofont-laika chat" title="Chat">&#xeed5;</i></a><a class="icon-link glyph-link" href="https://twitter.com/abcdefg/"><i class="icofont-laika twitter" title="Twitter">&#xed7a;</i></a></span>
                      |</div>
                      |</div>
                      |<div id="header-right">
@@ -140,7 +140,7 @@ class HeliumLandingPageSpec extends CatsEffectSuite with InputBuilder with Resul
                      |</div>
                      |<p class="medium"><a class="text-link" href="doc-1.html">Text Link</a></p>
                      |<p class="medium"><a class="button-link" href="http://somewhere.com/">Somewhere</a></p>
-                     |<p class="medium"><span class="row links"><a class="icon-link" href="doc-2.html"><i class="icofont-laika demo" title="Demo">&#xeeea;</i></a><a class="icon-link" href="doc-3.md"><i class="icofont-laika info">&#xef4e;</i></a></span></p>
+                     |<p class="medium"><span class="row links"><a class="icon-link glyph-link" href="doc-2.html"><i class="icofont-laika demo" title="Demo">&#xeeea;</i></a><a class="icon-link glyph-link" href="doc-3.md"><i class="icofont-laika info">&#xef4e;</i></a></span></p>
                      |</div>
                      |</div>
                      |$teaserHTML
@@ -211,7 +211,7 @@ class HeliumLandingPageSpec extends CatsEffectSuite with InputBuilder with Resul
                      |<div id="header-right">
                      |<p>Latest Release</p>
                      |<p class="large">2.3.5</p>
-                     |<p class="medium"><a class="icon-link" href="doc-2.html"><i class="icofont-laika demo" title="Demo">&#xeeea;</i></a></p>
+                     |<p class="medium"><a class="icon-link glyph-link" href="doc-2.html"><i class="icofont-laika demo" title="Demo">&#xeeea;</i></a></p>
                      |<p class="medium"><a class="button-link" href="http://somewhere.com/">Somewhere</a></p>
                      |</div>
                      |</div>

--- a/io/src/test/scala/laika/helium/HeliumSiteCSSSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumSiteCSSSpec.scala
@@ -97,6 +97,10 @@ class HeliumSiteCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
                                  |--content-width: 860px;
                                  |--nav-width: 275px;
                                  |--top-bar-height: 35px;""".stripMargin
+
+  private val landingPage = """--landing-subtitle-font-size: 32px;
+                              |--teaser-title-font-size: 28px;
+                              |--teaser-body-font-size: 17px;""".stripMargin
   
   private val colorScheme = "color-scheme: light dark;"
     
@@ -106,6 +110,7 @@ class HeliumSiteCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
     val expected = s"""$defaultColors
                       |$defaultFonts
                       |$defaultLayout
+                      |$landingPage
                       |$colorScheme""".stripMargin
     transformAndExtract(singleDoc, heliumBase, ":root {", "}").assertEquals(expected)
   }
@@ -122,6 +127,7 @@ class HeliumSiteCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
                               |--header3-font-size: 19px;
                               |--header4-font-size: 14px;
                               |$defaultLayout
+                              |$landingPage
                               |$colorScheme""".stripMargin
 
   test("custom font families and font sizes - via 'site' selector") {
@@ -170,6 +176,7 @@ class HeliumSiteCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
                               |--syntax-wheel5: #110055;
                               |$defaultFonts
                               |$defaultLayout
+                              |$landingPage
                               |$colorScheme""".stripMargin
 
   private val darkModeColors = """}
@@ -266,7 +273,7 @@ class HeliumSiteCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
   
   test("dark mode disabled") {
     val helium = heliumBase.site.darkMode.disabled
-    transformAndExtract(singleDoc, helium, ":root {", "}").assertEquals(defaultColors + "\n" + defaultFonts  + "\n" + defaultLayout)
+    transformAndExtract(singleDoc, helium, ":root {", "}").assertEquals(defaultColors + "\n" + defaultFonts  + "\n" + defaultLayout + "\n" + landingPage)
   }
 
   private val customLayout = s"""$defaultColors
@@ -276,6 +283,7 @@ class HeliumSiteCSSSpec extends CatsEffectSuite with InputBuilder with ResultExt
                                |--content-width: 1000px;
                                |--nav-width: 300px;
                                |--top-bar-height: 55px;
+                               |$landingPage
                                |$colorScheme""".stripMargin
   
   test("layout") {

--- a/io/src/test/scala/laika/helium/HeliumTocPageSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumTocPageSpec.scala
@@ -79,7 +79,7 @@ class HeliumTocPageSpec extends CatsEffectSuite with InputBuilder with ResultExt
                      |<i class="icofont-laika navigationMenu" title="Navigation">&#xefa2;</i>
                      |</a>
                      |</div>
-                     |<a class="icon-link" href="index.html"><i class="icofont-laika home" title="Home">&#xef47;</i></a>
+                     |<a class="icon-link glyph-link" href="index.html"><i class="icofont-laika home" title="Home">&#xef47;</i></a>
                      |<div class="row links">
                      |</div>
                      |</header>


### PR DESCRIPTION
This is a new, prominent location on the landing page, right beneath the logo/title/subtitle (whichever of those is present).
It has previously been used by the http4s home page via a custom template, but I believe having a slot there is generally useful.

The new configuration option allows to place any Helium UI component into this new placeholder, which are version menu, generic menu, buttons, and the other link types (text, icon, image) as well as groupings of those.

Sample code for populating this new area:

```scala
Helium.defaults
  .site.landingPage(
    titleLinks = Seq(
      VersionMenu.create(unversionedLabel = "Getting Started"),
      LinkGroup.create(
        IconLink.external("https://github.com/abcdefg/", HeliumIcon.github),
        IconLink.external("https://gitter.im/abcdefg/", HeliumIcon.chat),
        IconLink.external("https://twitter.com/abcdefg/", HeliumIcon.twitter)
      )
    )
  )
```

It also adds the option to programmatically add CSS files to the landing page for cases where a user wishes to adjust the default styles. This is normally done via configuration headers in markup files, but since the landing page is served from memory, using the API is the only option here.

The PR also includes about 150 new lines of CSS, mostly to adjust the UI components which need to look slightly different on the front page than on the top navigation bar of regular pages. It also contains a number of minor CSS tweaks for the existing elements.

This is the final PR for the planned expansion of the Helium API, therefore this closes #317.
