### PR TITLE
ExtensionBundle - improve handling of flags for strict mode and raw content

### DIFF
--- a/core/shared/src/main/scala/laika/api/builder/ParserBuilderOps.scala
+++ b/core/shared/src/main/scala/laika/api/builder/ParserBuilderOps.scala
@@ -28,11 +28,8 @@ trait ParserBuilderOps extends CommonBuilderOps {
 
   /**  Turns strict mode on for the target parser, switching off any
     *  features not part of the original markup syntax.
-    *  This includes the registration of directives (custom tags), custom templates
-    *  with directives, as well as configuration sections at the start of the document.
-    *
-    *  Technically it removes all `ExtensionBundle` instances which do not have
-    *  the `useInStrictMode` flag set to true.
+    *  This includes the registration of markup directives (custom tags)
+    *  as well as configuration sections at the start of the document.
     */
   def strict: ThisType = withConfig(config.forStrictMode)
 
@@ -41,9 +38,6 @@ trait ParserBuilderOps extends CommonBuilderOps {
     *  These are disabled by default as Laika is designed to render to multiple
     *  output formats from a single input document. With raw content embedded
     *  the markup document is tied to a specific output format.
-    *
-    *  Technically it activates all `ExtensionBundle` instances which have
-    *  the `acceptRawContent` flag set to true.
     */
   def withRawContent: ThisType = withConfig(config.forRawContent)
 

--- a/core/shared/src/main/scala/laika/api/builder/RendererBuilderOps.scala
+++ b/core/shared/src/main/scala/laika/api/builder/RendererBuilderOps.scala
@@ -46,7 +46,6 @@ trait RendererBuilderOps[FMT] extends CommonBuilderOps {
     */
   def rendering (customRenderer: PartialFunction[(FMT, Element), String]): ThisType = using(new ExtensionBundle {
     val description: String = "Custom render function"
-    override val useInStrictMode: Boolean = true
     override val renderOverrides = Seq(renderFormat.Overrides(value = customRenderer))
   })
 

--- a/core/shared/src/main/scala/laika/api/builder/TransformerBuilderOps.scala
+++ b/core/shared/src/main/scala/laika/api/builder/TransformerBuilderOps.scala
@@ -50,7 +50,6 @@ trait TransformerBuilderOps[FMT] extends ParserBuilderOps with RendererBuilderOp
     */
   def usingRules (newRules: RewriteRules): ThisType = using(new ExtensionBundle {
     val description: String = "Custom rewrite rules"
-    override val useInStrictMode: Boolean = true
     override def rewriteRules: RewritePhaseBuilder = { 
       case RewritePhase.Build     => Seq(newRules.copy(templateRules = Nil).asBuilder)
       case RewritePhase.Render(_) => Seq(RewriteRules(templateRules = newRules.templateRules).asBuilder)
@@ -152,7 +151,6 @@ trait TransformerBuilderOps[FMT] extends ParserBuilderOps with RendererBuilderOp
     */
   def buildingRules (newRules: RewriteRulesBuilder): ThisType = using(new ExtensionBundle {
     val description: String = "Custom rewrite rules"
-    override val useInStrictMode: Boolean = true
     override def rewriteRules: RewritePhaseBuilder = { 
       case RewritePhase.Render(_) => Seq(newRules) 
     }

--- a/core/shared/src/main/scala/laika/directive/DirectiveRegistry.scala
+++ b/core/shared/src/main/scala/laika/directive/DirectiveRegistry.scala
@@ -42,7 +42,7 @@ import laika.bundle.ExtensionBundle
   *
   * @author Jens Halm
   */
-trait DirectiveRegistry extends ExtensionBundle {
+trait DirectiveRegistry extends ExtensionBundle { self =>
   
   val description: String = "Registry for Laika's directives"
 
@@ -165,6 +165,12 @@ trait DirectiveRegistry extends ExtensionBundle {
     * */
   def linkDirectives: Seq[Links.Directive]
 
+  override def forStrictMode: Option[ExtensionBundle] = Some(new DirectiveRegistry {
+    val spanDirectives = Nil
+    val blockDirectives = Nil
+    val linkDirectives = Nil
+    def templateDirectives = self.templateDirectives
+  })
 
   override def processExtension: PartialFunction[ExtensionBundle, ExtensionBundle] = {
     case ds: DirectiveSupport => ds.withDirectives(blockDirectives, spanDirectives, templateDirectives, linkDirectives)

--- a/core/shared/src/main/scala/laika/format/ReStructuredText.scala
+++ b/core/shared/src/main/scala/laika/format/ReStructuredText.scala
@@ -96,7 +96,6 @@ case object ReStructuredText extends MarkupFormat { self =>
     val description: String = "Default extensions for reStructuredText"
 
     override val origin: BundleOrigin = BundleOrigin.Parser
-    override val useInStrictMode: Boolean = true
 
     override val parsers: ParserBundle = ParserBundle(
       markupParserHooks = Some(ParserHooks(

--- a/core/shared/src/main/scala/laika/markdown/bundle/VerbatimHTML.scala
+++ b/core/shared/src/main/scala/laika/markdown/bundle/VerbatimHTML.scala
@@ -40,8 +40,8 @@ object VerbatimHTML extends ExtensionBundle {
   val description: String = "Support for verbatim HTML in markup"
 
   override val origin: BundleOrigin = BundleOrigin.Parser
-  override val useInStrictMode: Boolean = true
-  override val acceptRawContent: Boolean = true
+
+  override def rawContentDisabled: Option[ExtensionBundle] = None
 
   override def parsers: ParserBundle = ParserBundle(
     blockParsers = Seq(HTMLParsers.htmlBlockFragment),

--- a/core/shared/src/main/scala/laika/markdown/github/GitHubFlavor.scala
+++ b/core/shared/src/main/scala/laika/markdown/github/GitHubFlavor.scala
@@ -57,4 +57,5 @@ object GitHubFlavor extends ExtensionBundle {
     )
   )
 
+  override def forStrictMode: Option[ExtensionBundle] = None
 }

--- a/core/shared/src/main/scala/laika/parse/markup/DocumentParser.scala
+++ b/core/shared/src/main/scala/laika/parse/markup/DocumentParser.scala
@@ -139,11 +139,11 @@ object DocumentParser {
     
   }
 
-  private def create [D, R <: ElementContainer[_]] (rootParser: Parser[R], configProvider: ConfigProvider)
+  private def create [D, R <: ElementContainer[_]] (rootParser: Parser[R], configParser: Parser[ConfigParser])
     (docFactory: (Path, ConfigParser, R) => D): DocumentInput => Either[ParserError, D] = {
 
     forParser { path =>
-      val configHeader = configProvider.configHeader | Parsers.success(ConfigParser.empty)
+      val configHeader = configParser | Parsers.success(ConfigParser.empty)
       (configHeader ~ rootParser).mapN(docFactory(path, _, _))
     }
   }
@@ -166,7 +166,7 @@ object DocumentParser {
     * headers to create a parser function for an entire text markup document.
     */
   def forMarkup (rootParser: Parser[RootElement], configProvider: ConfigProvider): DocumentInput => Either[ParserError, UnresolvedDocument] =
-    create(rootParser, configProvider) { (path, config, root) =>
+    create(rootParser, configProvider.markupConfigHeader) { (path, config, root) =>
       val fragments = root.collect { case f: DocumentFragment => (f.name, f.root) }.toMap
       UnresolvedDocument(Document(path, root, fragments), config)
    }
@@ -175,7 +175,7 @@ object DocumentParser {
     * headers to create a parser function for an entire template document.
     */
   def forTemplate (rootParser: Parser[TemplateRoot], configProvider: ConfigProvider): DocumentInput => Either[ParserError, TemplateDocument] = 
-    create(rootParser, configProvider) { (path, config, root) =>
+    create(rootParser, configProvider.templateConfigHeader) { (path, config, root) =>
       TemplateDocument(path, root, config)
     }
 

--- a/core/shared/src/main/scala/laika/rst/bundle/RstExtensionRegistry.scala
+++ b/core/shared/src/main/scala/laika/rst/bundle/RstExtensionRegistry.scala
@@ -73,8 +73,6 @@ trait RstExtensionRegistry extends ExtensionBundle {
 
   val description: String = "Registry for reStructuredText directives"
   
-  override val useInStrictMode: Boolean = true
-
   /**  Registers the specified span directives.
     *  These span directives can then be referred to by substitution references.
     *
@@ -207,8 +205,9 @@ object RawContentExtensions extends RstExtensionRegistry {
   override val description: String = "Raw content extensions for reStructuredText"
 
   override val origin: BundleOrigin = BundleOrigin.Parser
-  
-  override val acceptRawContent = true
+
+  override def rawContentDisabled: Option[ExtensionBundle] = None
+
   lazy val blockDirectives = Seq((new StandardBlockDirectives).rawDirective)
   lazy val spanDirectives = Seq()
   lazy val textRoles = Seq((new StandardTextRoles).rawTextRole)

--- a/core/shared/src/main/scala/laika/rst/bundle/RstExtensionSupport.scala
+++ b/core/shared/src/main/scala/laika/rst/bundle/RstExtensionSupport.scala
@@ -41,8 +41,6 @@ class RstExtensionSupport (blockDirectives: Seq[Directive[Block]],
 
   override val origin: BundleOrigin = BundleOrigin.Parser
   
-  override val useInStrictMode: Boolean = true
-
   override def rewriteRules: RewritePhaseBuilder = {
     case RewritePhase.Resolve => Seq(new RewriteRules(textRoles))
   }

--- a/core/shared/src/test/scala/laika/config/OperationConfigSpec.scala
+++ b/core/shared/src/test/scala/laika/config/OperationConfigSpec.scala
@@ -186,37 +186,41 @@ class OperationConfigSpec extends FunSuite {
 
   case object Defaults extends TestExtensionBundle
 
-  case object Strict extends TestExtensionBundle { override val useInStrictMode = true }
+  case object NonStrict extends TestExtensionBundle {
+    override def forStrictMode: Option[ExtensionBundle] = None
+  }
 
-  case object RawContent extends TestExtensionBundle { override val acceptRawContent = true }
+  case object RawContent extends TestExtensionBundle {
+    override def rawContentDisabled: Option[ExtensionBundle] = None
+  }
 
   case object Both extends TestExtensionBundle {
-    override val useInStrictMode = true
-    override val acceptRawContent = true
+    override def forStrictMode: Option[ExtensionBundle] = None
+    override def rawContentDisabled: Option[ExtensionBundle] = None
   }
 
   val flagSetup = {
-    val appBundles = Seq(Defaults, Strict, RawContent, Both)
+    val appBundles = Seq(Defaults, NonStrict, RawContent, Both)
     OperationConfig.empty.withBundles(appBundles)
   }
 
   test("strict/raw flags - remove all raw content bundles in the default settings") {
-    assertEquals(flagSetup.bundles.filter(flagSetup.bundleFilter), Seq(Defaults, Strict))
+    assertEquals(flagSetup.filteredBundles, Seq(Defaults, NonStrict))
   }
 
   test("strict/raw flags - keep all bundles if rawContent is set to true") {
     val finalConfig = flagSetup.forRawContent
-    assertEquals(finalConfig.bundles.filter(finalConfig.bundleFilter), Seq(Defaults, Strict, RawContent, Both))
+    assertEquals(finalConfig.filteredBundles, Seq(Defaults, NonStrict, RawContent, Both))
   }
 
   test("strict/raw flags - remove all non-strict and raw content bundles if strict is set to true") {
     val finalConfig = flagSetup.forStrictMode
-    assertEquals(finalConfig.bundles.filter(finalConfig.bundleFilter), Seq(Strict))
+    assertEquals(finalConfig.filteredBundles, Seq(Defaults))
   }
 
   test("strict/raw flags - remove all non-strict bundles if both flags are set to true") {
     val finalConfig = flagSetup.forStrictMode.forRawContent
-    assertEquals(finalConfig.bundles.filter(finalConfig.bundleFilter), Seq(Strict,  Both))
+    assertEquals(finalConfig.filteredBundles, Seq(Defaults, RawContent))
   }
 
 }

--- a/core/shared/src/test/scala/laika/config/ParserBundleSpec.scala
+++ b/core/shared/src/test/scala/laika/config/ParserBundleSpec.scala
@@ -346,17 +346,19 @@ class ParserHookSpec extends FunSuite with ParserSetup {
 class ConfigProviderSpec extends FunSuite with BundleSetup {
 
   object BetweenBraces extends ConfigProvider {
-    def configHeader: Parser[ConfigParser] = ConfigHeaderParser.betweenLines("{{", "}}")
+    def markupConfigHeader: Parser[ConfigParser] = ConfigHeaderParser.betweenLines("{{", "}}")
+    def templateConfigHeader: Parser[ConfigParser] = ConfigHeaderParser.betweenLines("{{", "}}")
     def configDocument (input: String): ConfigParser = ConfigParser.empty
   }
   object BetweenAngles extends ConfigProvider {
-    def configHeader: Parser[ConfigParser] = ConfigHeaderParser.betweenLines("<<", ">>")
+    def markupConfigHeader: Parser[ConfigParser] = ConfigHeaderParser.betweenLines("<<", ">>")
+    def templateConfigHeader: Parser[ConfigParser] = ConfigHeaderParser.betweenLines("<<", ">>")
     def configDocument (input: String): ConfigParser = ConfigParser.empty
   }
 
   def parseWith(opConfig: OperationConfig, input: String): Either[ConfigError, Config] = opConfig
     .configProvider
-    .configHeader
+    .markupConfigHeader
     .parse(input) match {
       case Success(builderRoot, _) =>
         builderRoot.resolve(Origin.root, Config.empty, Map.empty)
@@ -443,9 +445,9 @@ class TemplateParserConfigSpec extends FunSuite with BundleSetup {
     )
   }
 
-  test("return None in strict mode when there is no parser installed") {
+  test("retain the template parser in strict mode") {
     val config = createConfig(createParser())
-    assert(config.forStrictMode.templateParser.isEmpty)
+    assert(config.forStrictMode.templateParser.nonEmpty)
   }
 
 }

--- a/io/src/main/scala/laika/io/descriptor/ParserDescriptor.scala
+++ b/io/src/main/scala/laika/io/descriptor/ParserDescriptor.scala
@@ -55,7 +55,7 @@ object ParserDescriptor {
       .map { inputDesc =>
         apply(
           op.parsers.map(_.format.description),
-          op.config.bundles.filter(op.config.bundleFilter).map(ExtensionBundleDescriptor.apply),
+          op.config.filteredBundles.map(ExtensionBundleDescriptor.apply),
           inputDesc,
           op.config.bundleFilter.strict,
           op.config.bundleFilter.acceptRawContent

--- a/io/src/main/scala/laika/io/descriptor/RendererDescriptor.scala
+++ b/io/src/main/scala/laika/io/descriptor/RendererDescriptor.scala
@@ -58,14 +58,14 @@ object RendererDescriptor {
   
   def create[F[_]: Applicative] (op: TreeRenderer.Op[F]): F[RendererDescriptor] = Applicative[F].pure(apply(
     op.renderer.format.description,
-    op.renderer.config.bundles.filter(op.renderer.config.bundleFilter).map(ExtensionBundleDescriptor.apply),
+    op.renderer.config.filteredBundles.map(ExtensionBundleDescriptor.apply),
     describeOutput(op.output),
     op.renderer.config.renderFormatted
   ))
 
   def create[F[_]: Applicative] (op: BinaryTreeRenderer.Op[F]): F[RendererDescriptor] = Applicative[F].pure(apply(
     op.renderer.description,
-    op.renderer.interimRenderer.config.bundles.filter(op.renderer.interimRenderer.config.bundleFilter).map(ExtensionBundleDescriptor.apply),
+    op.renderer.interimRenderer.config.filteredBundles.map(ExtensionBundleDescriptor.apply),
     describeOutput(op.output),
     op.renderer.interimRenderer.config.renderFormatted
   ))

--- a/sbt/src/main/scala/laika/sbt/LaikaConfig.scala
+++ b/sbt/src/main/scala/laika/sbt/LaikaConfig.scala
@@ -41,18 +41,14 @@ case class LaikaConfig(encoding: Codec = Codec.UTF8,
   def encoding (codec: Codec): LaikaConfig = copy(encoding = codec)
   
   /**  Turns strict mode on for the target parser, switching off any features not part of the original markup syntax.
-    *  This includes the registration of directives (custom tags), custom templates with directives, 
+    *  This includes the registration of markup directives (custom tags)
     *  as well as configuration sections at the start of the document.
-    *
-    *  Technically it removes all `ExtensionBundle` instances which do not have the `useInStrictMode` flag set to true.
     */
   def strict: LaikaConfig = copy(bundleFilter = bundleFilter.copy(strict = true))
 
   /**  Enables all extensions that process raw content embedded into the host markup language.
     *  These are disabled by default as Laika is designed to render to multiple output formats from a single input document. 
     *  With raw content embedded the markup document is tied to a specific output format.
-    *
-    *  Technically it activates all `ExtensionBundle` instances which have the `acceptRawContent` flag set to true.
     */
   def withRawContent: LaikaConfig = copy(bundleFilter = bundleFilter.copy(acceptRawContent = true))
 


### PR DESCRIPTION
The handling of the `strict` flag hasn't been reviewed in any way since its introduction in Laika 0.1 in 2012 and as reported in #310 does not work well with newer features such as theme support (introduced in 2020).

This PR introduces the following improvements:

* Changes the `ExtensionBundle` API to move away from simple boolean flags. By replacing `useInStrictMode: Boolean` with `forStrictMode: Option[ExtensionBundle]` each bundle can remove itself or return a modified copy of itself for strict mode. The same principle applies to replacing `acceptRawContent: Boolean` with `rawContentDisabled: Option[ExtensionBundle]`.
* Changes the defaults of built-in bundles to filter less aggressively: strict mode is only defined as removing everything that extends text markup beyond its original specification to make the parser compatible with other tools for the same markup syntax. But previously many unrelated bundles were actually removed when run in strict mode.
* Specifically adjusts the support for directives to filter less aggressively in strict mode. In detail the behaviour is now as follows:
    * Remove all support for block, span and link directives since those extend the text markup syntax.
    * Remove support for variable substitutions as those extend the text markup syntax, too.
    * Remove support for configuration headers in markup documents.
    * Retain support for template directives and configuration headers in template documents as those are unrelated to markup specifications.

Closes #310.