### PR TITLE
mima-setup for 0.19.x maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           
       - name: Build and test
         run: |
-          sbt -v +test mimaReportBinaryIssues scripted
+          sbt -v +test +mimaReportBinaryIssues scripted
           rm -rf "$HOME/.ivy2/local" || true
           find $HOME/.ivy2/cache                       -name "ivydata-*.properties" -delete || true
           find $HOME/.ivy2/cache                       -name "*-LM-SNAPSHOT*"       -delete || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           
       - name: Build and test
         run: |
-          sbt -v +test scripted
+          sbt -v +test mimaReportBinaryIssues scripted
           rm -rf "$HOME/.ivy2/local" || true
           find $HOME/.ivy2/cache                       -name "ivydata-*.properties" -delete || true
           find $HOME/.ivy2/cache                       -name "*-LM-SNAPSHOT*"       -delete || true

--- a/build.sbt
+++ b/build.sbt
@@ -23,15 +23,21 @@ lazy val basicSettings = Seq(
                            
 )
 
+val mimaPreviousVersions = Set("0.19.0")
+
+val previousArtifacts = Seq(
+  mimaPreviousArtifacts := mimaPreviousVersions
+    .map(v => projectID.value.withRevision(v).withExplicitArtifacts(Vector.empty))
+)
+
 def priorTo2_13(version: String): Boolean =
   CrossVersion.partialVersion(version) match {
     case Some((2, minor)) if minor < 13 => true
     case _                              => false
   }
 
-lazy val moduleSettings = basicSettings ++ Seq(
-  crossScalaVersions    := Seq(versions.scala2_12, versions.scala2_13, versions.scala3),
-  mimaPreviousArtifacts := Set(organization.value %% moduleName.value % "0.19.0")
+lazy val moduleSettings = basicSettings ++ previousArtifacts ++ Seq(
+  crossScalaVersions := Seq(versions.scala2_12, versions.scala2_13, versions.scala3)
 )
 
 lazy val publishSettings = Seq(
@@ -149,6 +155,7 @@ lazy val plugin = project.in(file("sbt"))
   .dependsOn(core.jvm, io, pdf, preview)
   .enablePlugins(SbtPlugin)
   .settings(basicSettings)
+  .settings(previousArtifacts)
   .settings(publishSettings)
   .settings(
     name := "laika-sbt",
@@ -160,12 +167,7 @@ lazy val plugin = project.in(file("sbt"))
       "-Duser.language=en",
       "-Duser.country=GB"
     ),
-    scriptedBufferLog := false,
-    mimaPreviousArtifacts := {
-      val sbtV = (pluginCrossBuild / sbtBinaryVersion).value
-      val scalaV = (update / scalaBinaryVersion).value
-      Set(Defaults.sbtPluginExtra(organization.value % moduleName.value % "0.19.0", sbtV, scalaV))
-    }
+    scriptedBufferLog := false
   )
 
 lazy val demo = crossProject(JSPlatform, JVMPlatform)

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,8 @@ def priorTo2_13(version: String): Boolean =
   }
 
 lazy val moduleSettings = basicSettings ++ Seq(
-  crossScalaVersions := Seq(versions.scala2_12, versions.scala2_13, versions.scala3)
+  crossScalaVersions    := Seq(versions.scala2_12, versions.scala2_13, versions.scala3),
+  mimaPreviousArtifacts := Set(organization.value %% moduleName.value % "0.19.0")
 )
 
 lazy val publishSettings = Seq(
@@ -79,6 +80,7 @@ lazy val root = project.in(file("."))
   .settings(basicSettings)
   .settings(noPublishSettings)
   .enablePlugins(ScalaUnidocPlugin)
+  .disablePlugins(MimaPlugin)
   .settings(
     crossScalaVersions := Nil,
     ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(plugin, core.js, demo.jvm, demo.js),
@@ -100,7 +102,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   .withoutSuffixFor(JVMPlatform)
   .crossType(CrossType.Full)
   .in(file("core"))
-  .settings(basicSettings)
+  .settings(moduleSettings)
   .settings(publishSettings)
   .settings(
     name := "laika-core",
@@ -110,12 +112,10 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
     )
   )
   .jvmSettings(
-    libraryDependencies += jTidy, 
-    crossScalaVersions := Seq(versions.scala2_12, versions.scala2_13, versions.scala3)
+    libraryDependencies += jTidy
   )
   .jsSettings(
-    Test / scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
-    crossScalaVersions := Seq(versions.scala2_12, versions.scala2_13, versions.scala3)
+    Test / scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
   )
 
 lazy val io = project.in(file("io"))
@@ -160,7 +160,12 @@ lazy val plugin = project.in(file("sbt"))
       "-Duser.language=en",
       "-Duser.country=GB"
     ),
-    scriptedBufferLog := false
+    scriptedBufferLog := false,
+    mimaPreviousArtifacts := {
+      val sbtV = (pluginCrossBuild / sbtBinaryVersion).value
+      val scalaV = (update / scalaBinaryVersion).value
+      Set(Defaults.sbtPluginExtra(organization.value % moduleName.value % "0.19.0", sbtV, scalaV))
+    }
   )
 
 lazy val demo = crossProject(JSPlatform, JVMPlatform)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,6 +5,8 @@ addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.8.2")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.11")
 
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.1")
+
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.1")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")


### PR DESCRIPTION
The 1.0 milestone series will switch to CI releases and will see a wider range of build changes, but for 0.19 maintenance I intend to keep the current manual approach and only add a minimal mima setup (scalafmt and mdoc will follow before branching).