### PR TITLE
normalize whitespace in PlatformDateDirectiveSpec for Scala.js

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import laika.markdown.github.GitHubFlavor
 import laika.parse.code.SyntaxHighlighting
 import sbt.Keys.{artifactPath, crossScalaVersions}
+import org.scalajs.linker.interface.ESVersion
 import Dependencies._
 
 lazy val basicSettings = Seq(
@@ -121,7 +122,9 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies += jTidy
   )
   .jsSettings(
-    Test / scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
+    Test / scalaJSLinkerConfig ~= { 
+      _.withModuleKind(ModuleKind.CommonJSModule).withESFeatures(_.withESVersion(ESVersion.ES2018)) 
+    }
   )
 
 lazy val io = project.in(file("io"))


### PR DESCRIPTION
Unit tests for Scala.js starting failing in recent scala-steward PRs due to a recent change in time formatting in Node 18.13:

https://github.com/nodejs/node/issues/46123

The space character before AM/PM had been replaced by a non-breaking space character (`\\u202f`).
Since the linked ticket hints at this change potentially getting reverted in the future, this PR normalizes whitespace in the date formatter specs for Scala.js so that it is expected to work with the old and new versions of Node.