### PR TITLE
Markdown: support spaces in link destinations within angle brackets

### DIFF
--- a/core/shared/src/main/scala/laika/markdown/InlineParsers.scala
+++ b/core/shared/src/main/scala/laika/markdown/InlineParsers.scala
@@ -198,7 +198,7 @@ object InlineParsers {
       delim ~> delimitedBy(delim <~ lookAhead(titleEnd))
     val title                                     = ws.void ~> (enclosedIn("\"") | enclosedIn("'"))
 
-    val url = ("<" ~> text(delimitedBy('>').failOn(' ')).embed(recParsers.escapeSequence)) |
+    val url = ("<" ~> text(delimitedBy('>')).embed(recParsers.escapeSequence)) |
       text(delimitedBy(')', ' ', '\t').keepDelimiter).embed(recParsers.escapeSequence)
 
     val urlWithTitle =

--- a/core/shared/src/test/scala/laika/markdown/InlineParsersSpec.scala
+++ b/core/shared/src/test/scala/laika/markdown/InlineParsersSpec.scala
@@ -185,6 +185,21 @@ class InlineParsersSpec extends FunSuite with TestSourceBuilders {
     )
   }
 
+  test("links - inline link destination within angle brackets") {
+    runEnclosed(
+      """some [link](<http://foo>) here""",
+      SpanLink.external("http://foo")("link")
+    )
+  }
+
+  test("links - inline link destination containing spaces within angle brackets") {
+    val linkSrc = "[link](<foo bar.md>)"
+    val input   = s"some $linkSrc here"
+    val linkAST =
+      LinkPathReference(Seq(Text("link")), RelativePath.parse("foo bar.md"), source(linkSrc, input))
+    runEnclosed(input, linkAST)
+  }
+
   test("links - inline link with an optional title enclosed in single quotes") {
     runEnclosed(
       """some [link](http://foo 'a title') here""",


### PR DESCRIPTION
The classic Markdown spec is ambiguous in this respect, but the CommonMark spec explicitly caters for this scenario.
As a rule of thumb, whenever CommonMark clarifies something that used to be ambiguous in the old Markdown spec, Laika follows the CommonMark spec even for the classic Markdown format to avoid unnecessary differences between the two.