### PR TITLE
Use mdoc for code samples in documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           
       - name: Build and test
         run: |
-          sbt -v +test +mimaReportBinaryIssues scalafmtCheckAll scripted
+          sbt -v +test +mimaReportBinaryIssues scalafmtCheckAll docs/mdoc docs/laikaSite scripted
           rm -rf "$HOME/.ivy2/local" || true
           find $HOME/.ivy2/cache                       -name "ivydata-*.properties" -delete || true
           find $HOME/.ivy2/cache                       -name "*-LM-SNAPSHOT*"       -delete || true

--- a/build.sbt
+++ b/build.sbt
@@ -101,6 +101,7 @@ lazy val docs = project.in(file("docs"))
   .dependsOn(plugin)
   .enablePlugins(LaikaPlugin)
   .enablePlugins(MdocPlugin)
+  .enablePlugins(SbtPlugin)
   .settings(noPublishSettings)
   .settings(
     name                      := "laika-docs",
@@ -112,7 +113,8 @@ lazy val docs = project.in(file("docs"))
     mdocIn                    := baseDirectory.value / "src",
     mdocVariables             := Map(
       "LAIKA_VERSION" -> "0.19.0"
-    )
+    ),
+    mdocExtraArguments        := Seq("--no-link-hygiene")
   )
 
 lazy val core = crossProject(JSPlatform, JVMPlatform)

--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,7 @@ val catsEffect = "org.typelevel" %% "cats-effect"         % versions.catsEffect
 val fs2IO      = "co.fs2"        %% "fs2-io"              % versions.fs2
 val munitCE3   = "org.typelevel" %% "munit-cats-effect-3" % versions.munitCE3 % "test"
 
-val fop    = "org.apache.xmlgraphics" % "fop" % versions.fop
+val fop = "org.apache.xmlgraphics" % "fop" % versions.fop
 
 val http4s = Seq(
   "org.http4s" %% "http4s-dsl"          % versions.http4s,
@@ -98,15 +98,18 @@ lazy val root = project.in(file("."))
   )
 
 lazy val docs = project.in(file("docs"))
+  .dependsOn(plugin)
   .enablePlugins(LaikaPlugin)
+  .enablePlugins(MdocPlugin)
   .settings(noPublishSettings)
   .settings(
     name                      := "laika-docs",
     laikaTheme                := ManualSettings.helium,
     laikaConfig               := ManualSettings.config,
     laikaExtensions           := Seq(GitHubFlavor, SyntaxHighlighting, ManualBundle),
-    Laika / sourceDirectories := Seq(baseDirectory.value / "src"),
-    Laika / target            := baseDirectory.value / "target"
+    Laika / sourceDirectories := Seq(mdocOut.value),
+    Laika / target            := baseDirectory.value / "target",
+    mdocIn                    := baseDirectory.value / "src"
   )
 
 lazy val core = crossProject(JSPlatform, JVMPlatform)

--- a/build.sbt
+++ b/build.sbt
@@ -109,7 +109,10 @@ lazy val docs = project.in(file("docs"))
     laikaExtensions           := Seq(GitHubFlavor, SyntaxHighlighting, ManualBundle),
     Laika / sourceDirectories := Seq(mdocOut.value),
     Laika / target            := baseDirectory.value / "target",
-    mdocIn                    := baseDirectory.value / "src"
+    mdocIn                    := baseDirectory.value / "src",
+    mdocVariables             := Map(
+      "LAIKA_VERSION" -> "0.19.0"
+    )
   )
 
 lazy val core = crossProject(JSPlatform, JVMPlatform)

--- a/docs/src/02-running-laika/01-sbt-plugin.md
+++ b/docs/src/02-running-laika/01-sbt-plugin.md
@@ -21,7 +21,7 @@ supporting that sbt version.
 First add the plugin to `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("org.planet42" % "laika-sbt" % "0.19.0")
+addSbtPlugin("org.planet42" % "laika-sbt" % "%LAIKA_VERSION%")
 ```
 
 Then enable the plugin in your project's `build.sbt`:

--- a/docs/src/02-running-laika/02-library-api.md
+++ b/docs/src/02-running-laika/02-library-api.md
@@ -19,21 +19,21 @@ If you want to stick to pure transformations from string to string and don't nee
 any of the binary output formats like EPUB or PDF, you are fine with just using the `laika-core` module:
 
 ```scala
-libraryDependencies += "org.planet42" %% "laika-core" % "0.19.0" 
+libraryDependencies += "org.planet42" %% "laika-core" % "%LAIKA_VERSION%" 
 ```
 
 This module is also 100% supported for Scala.js, so you can alternatively use the triple `%%%` syntax
 if you want to cross-build for Scala.js and the JVM:
 
 ```scala
-libraryDependencies += "org.planet42" %%% "laika-core" % "0.19.0" 
+libraryDependencies += "org.planet42" %%% "laika-core" % "%LAIKA_VERSION%" 
 ```
 
 If you want to add support for file and stream IO and/or output in the EPUB format, 
 you need to depend on the `laika-io` module instead:
 
 ```scala
-libraryDependencies += "org.planet42" %% "laika-io" % "0.19.0" 
+libraryDependencies += "org.planet42" %% "laika-io" % "%LAIKA_VERSION%" 
 ```
 
 This depends on `laika-core` in turn, so you always only need to add one module as a dependency and will get
@@ -43,7 +43,7 @@ are in JVM land here.
 Finally PDF support comes with its own module as it adds a whole range of additional dependencies:
 
 ```scala
-libraryDependencies += "org.planet42" %% "laika-pdf" % "0.19.0" 
+libraryDependencies += "org.planet42" %% "laika-pdf" % "%LAIKA_VERSION%" 
 ```
 
 Again, this builds on top of the other modules, so adding just this one dependency is sufficient.

--- a/docs/src/02-running-laika/02-library-api.md
+++ b/docs/src/02-running-laika/02-library-api.md
@@ -127,7 +127,7 @@ The instances are immutable and thread-safe.
 
 Example for creating a transformer for Markdown, including the GitHub-Flavor extensions:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.markdown.github.GitHubFlavor
 
 val transformer = Transformer
@@ -139,7 +139,7 @@ val transformer = Transformer
 
 Example for creating a transformer for reStructuredText:
 
-```scala mdoc
+```scala mdoc:silent
 val rstTransformer = Transformer
   .from(ReStructuredText)
   .to(HTML)
@@ -238,7 +238,7 @@ is not referentially transparent).
 Assuming we reuse the `createTransformer` method from the previous section, you can then run a transformation
 and obtain the resulting effect:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.io.model.RenderedTreeRoot
 
 val result: IO[RenderedTreeRoot[IO]] = createTransformer[IO].use {
@@ -266,7 +266,7 @@ in your application.
 One common scenario is a toolkit like Akka HTTP or Play where you execute a route that is expected to return a `Future`.
 This can achieved by a simple translation:
 
-```scala mdoc
+```scala mdoc:silent
 import scala.concurrent.Future
 
 val futureResult: Future[RenderedTreeRoot[IO]] = result.unsafeToFuture()
@@ -298,7 +298,7 @@ Finally, if you intend to reuse the transformer, for example in a web applicatio
 it is more efficient to split the resource allocation , use and release into three distinct effects that you can run
 independently, as the sample `IO` above would re-create the transformer for each invocation:
 
-```scala mdoc
+```scala mdoc:silent
 val alloc = createTransformer[IO].allocated
 val (transformer: TreeTransformer[IO], releaseF: IO[Unit]) = alloc.unsafeRunSync()
 ```
@@ -306,7 +306,7 @@ val (transformer: TreeTransformer[IO], releaseF: IO[Unit]) = alloc.unsafeRunSync
 You would usually run the above when initializing your web application. 
 The obtained transformer can then be used in your controllers and each transformation would produce a new `Future`:
 
-```scala mdoc:nest
+```scala mdoc:nest:silent
 val futureResult: Future[RenderedTreeRoot[IO]] = transformer
   .fromDirectory("docs")
   .toDirectory("target")
@@ -334,7 +334,7 @@ The effectful transformer is the most powerful variant and also the one that is 
 It expands the functionality beyond just processing markup input to also parsing templates and configuration files
 as well as copying static files over to the target directory.
 
-```scala mdoc:nest
+```scala mdoc:nest:silent
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -345,7 +345,7 @@ val transformer = Transformer
 
 The above transformer can then be used to process a directory of markup, template and configuration files:
 
-```scala mdoc
+```scala mdoc:silent
 val res: IO[RenderedTreeRoot[IO]] = transformer.use {
   _.fromDirectory("src")
    .toDirectory("target")
@@ -362,7 +362,7 @@ This is because these formats always produce a single binary result,
 merging all content from the input directories into a single, linearized e-book:
 
 
-```scala mdoc
+```scala mdoc:silent
 val epubTransformer = Transformer
   .from(Markdown)
   .to(EPUB)
@@ -382,7 +382,7 @@ val epubRes: IO[Unit] = epubTransformer.use {
 
 All previous examples read content from the single input directory. But you can also merge the contents of multiple directories:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.io.model.FilePath
 
 val directories = Seq(
@@ -406,7 +406,7 @@ If you need even more flexibility instead of just configuring one or more input 
 e.g. when there is a need to generate content on-the-fly before starting the transformation,
 you can use the `InputTree` builder. 
 
-```scala mdoc
+```scala mdoc:silent
 import laika.io.model._
 import laika.ast.Path.Root
 import laika.rewrite.DefaultTemplatePath
@@ -511,7 +511,7 @@ The following code example demonstrates the third scenario listed above: Renderi
 
 First we create a parser that reads from a directory:
 
-```scala mdoc
+```scala mdoc:silent
 val parser = MarkupParser
   .of(Markdown)
   .using(GitHubFlavor)
@@ -521,7 +521,7 @@ val parser = MarkupParser
 
 Next we create the renderers for the three output formats:
 
-```scala mdoc
+```scala mdoc:silent
 val htmlRenderer = Renderer.of(HTML).parallel[IO].build
 val epubRenderer = Renderer.of(EPUB).parallel[IO].build
 val pdfRenderer  = Renderer.of(PDF).parallel[IO].build
@@ -529,7 +529,7 @@ val pdfRenderer  = Renderer.of(PDF).parallel[IO].build
 
 Since all four processors are a cats-effect `Resource`, we combine them into one:
 
-```scala mdoc
+```scala mdoc:silent
 val allResources = for {
   parse <- parser
   html  <- htmlRenderer
@@ -540,7 +540,7 @@ val allResources = for {
 
 Finally, we define the actual transformation by wiring the parser and the three renderers:
 
-```scala mdoc
+```scala mdoc:silent
 import cats.syntax.all._
 
 val transformOp: IO[Unit] = allResources.use { 
@@ -583,7 +583,7 @@ You can also specify an empty theme if you want to put all templates and styles 
 
 Example for applying a few Helium settings:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.helium.Helium
 
 val theme = Helium.defaults
@@ -662,7 +662,7 @@ This includes auto-refreshing whenever changes to any input document are detecte
 It is the basis of the `laikaPreview` task of the sbt plugin, 
 but can alternatively be launched via the library API:
 
-```scala mdoc:nest
+```scala mdoc:nest:silent
 import laika.preview.ServerBuilder
 
 val parser = MarkupParser
@@ -683,7 +683,7 @@ The above example creates a server based on its default configuration.
 Open `localhost:4242` for the landing page of your site.
 You can override the defaults by passing a `ServerConfig` instance explicitly:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.preview.ServerConfig
 import com.comcast.ip4s._
 import scala.concurrent.duration.DurationInt

--- a/docs/src/02-running-laika/02-library-api.md
+++ b/docs/src/02-running-laika/02-library-api.md
@@ -116,7 +116,7 @@ as input, and for HTML as output. EPUB and PDF both require additional modules a
 
 For most cases where you don't use any of the customization hooks, you should be fine with just these imports:
 
-```scala
+```scala mdoc
 import laika.api._
 import laika.format._
 ```
@@ -127,7 +127,9 @@ The instances are immutable and thread-safe.
 
 Example for creating a transformer for Markdown, including the GitHub-Flavor extensions:
 
-```scala
+```scala mdoc
+import laika.markdown.github.GitHubFlavor
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -137,8 +139,8 @@ val transformer = Transformer
 
 Example for creating a transformer for reStructuredText:
 
-```scala
-val transformer = Transformer
+```scala mdoc
+val rstTransformer = Transformer
   .from(ReStructuredText)
   .to(HTML)
   .build
@@ -149,7 +151,7 @@ step immediately before calling `build`. They are identical for the pure and IO 
 
 Finally you can use the transformer with text markup as input:
 
-```scala
+```scala mdoc
 val result = transformer.transform("hello *there*")
 ```
 
@@ -168,7 +170,7 @@ This module depends on cats-effect, and models all side effects in an abstract e
 
 With the dependency in place you also need to add a third import to those you used for pure transformations:
 
-```scala
+```scala mdoc:reset
 import laika.api._
 import laika.format._
 import laika.io.implicits._
@@ -189,7 +191,11 @@ and whether you keep all of your code in an abstract `F[_]` instead of coding ag
 The following example assumes the use case of an application written around abstract effect types and using `IOApp`
 from cats.IO for initialization:
 
-```scala
+```scala mdoc
+import cats.effect.{ Async, Resource }
+import laika.io.api.TreeTransformer
+import laika.markdown.github.GitHubFlavor
+
 def createTransformer[F[_]: Async]: Resource[F, TreeTransformer[F]] =
   Transformer
     .from(Markdown)
@@ -203,12 +209,15 @@ def createTransformer[F[_]: Async]: Resource[F, TreeTransformer[F]] =
 
 The setup method above can then be used inside `IOApp` initialization logic:
 
-```scala
+```scala mdoc
+import cats.effect.{ IO, IOApp, ExitCode }
+
 object MyApp extends IOApp {
 
   def run(args: List[String]) = {
     createTransformer[IO].use { transformer =>
       // create modules depending on transformer
+      IO.unit
     }.as(ExitCode.Success)
   }
 }
@@ -229,8 +238,10 @@ is not referentially transparent).
 Assuming we reuse the `createTransformer` method from the previous section, you can then run a transformation
 and obtain the resulting effect:
 
-```scala
-val result: IO[String] = createTransformer[IO].use {
+```scala mdoc
+import laika.io.model.RenderedTreeRoot
+
+val result: IO[RenderedTreeRoot[IO]] = createTransformer[IO].use {
   _.fromDirectory("docs")
    .toDirectory("target")
    .transform
@@ -245,7 +256,7 @@ you have several options depending on the stack you are using.
 
 First, for any of the following options, you need to add the following import:
 
-```scala
+```scala mdoc
 import cats.effect.unsafe.implicits.global
 ```
 
@@ -255,19 +266,24 @@ in your application.
 One common scenario is a toolkit like Akka HTTP or Play where you execute a route that is expected to return a `Future`.
 This can achieved by a simple translation:
 
-```scala
-val futureResult: Future[String] = result.unsafeToFuture()
+```scala mdoc
+import scala.concurrent.Future
+
+val futureResult: Future[RenderedTreeRoot[IO]] = result.unsafeToFuture()
 ```
 
 Other options not involving `Future` are either blocking, synchronous execution:
 
-```scala
-val syncResult: String = result.unsafeRunSync()
+```scala mdoc:compile-only
+val syncResult: RenderedTreeRoot[IO] = result.unsafeRunSync()
 ```
 
 Or asynchronous execution based on a callback:
 
-```scala
+```scala mdoc:compile-only
+def handleError(error: Throwable): Unit = ???
+def handleResult(result: RenderedTreeRoot[IO]): Unit = ???
+
 result.unsafeRunAsync {
   case Left(throwable) => handleError(throwable)
   case Right(result)   => handleResult(result)
@@ -282,7 +298,7 @@ Finally, if you intend to reuse the transformer, for example in a web applicatio
 it is more efficient to split the resource allocation , use and release into three distinct effects that you can run
 independently, as the sample `IO` above would re-create the transformer for each invocation:
 
-```scala
+```scala mdoc
 val alloc = createTransformer[IO].allocated
 val (transformer: TreeTransformer[IO], releaseF: IO[Unit]) = alloc.unsafeRunSync()
 ```
@@ -290,8 +306,8 @@ val (transformer: TreeTransformer[IO], releaseF: IO[Unit]) = alloc.unsafeRunSync
 You would usually run the above when initializing your web application. 
 The obtained transformer can then be used in your controllers and each transformation would produce a new `Future`:
 
-```scala
-val futureResult: Future[String] = transformer
+```scala mdoc:nest
+val futureResult: Future[RenderedTreeRoot[IO]] = transformer
   .fromDirectory("docs")
   .toDirectory("target")
   .transform
@@ -300,8 +316,8 @@ val futureResult: Future[String] = transformer
 
 In this case you also need to ensure you run the release function on shutdown:
 
-```scala
-releaseF.unsfaceRunSync()
+```scala mdoc:compile-only
+releaseF.unsafeRunSync()
 ```
 
 The default Helium theme currently has a no-op release function, but this might change in the future and 3rd-party
@@ -315,10 +331,10 @@ Entire Directories as Input
 ---------------------------
 
 The effectful transformer is the most powerful variant and also the one that is the basis for the sbt plugin.
-It expands the functionality beyond just processing markup files to also parsing templates and configuration files
+It expands the functionality beyond just processing markup input to also parsing templates and configuration files
 as well as copying static files over to the target directory.
 
-```scala
+```scala mdoc:nest
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -329,7 +345,7 @@ val transformer = Transformer
 
 The above transformer can then be used to process a directory of markup, template and configuration files:
 
-```scala
+```scala mdoc
 val res: IO[RenderedTreeRoot[IO]] = transformer.use {
   _.fromDirectory("src")
    .toDirectory("target")
@@ -345,8 +361,16 @@ the API will be slightly different, as the `toDirectory` option is replaced by `
 This is because these formats always produce a single binary result, 
 merging all content from the input directories into a single, linearized e-book:
 
-```scala
-val res: IO[Unit] = transformer.use {
+
+```scala mdoc
+val epubTransformer = Transformer
+  .from(Markdown)
+  .to(EPUB)
+  .using(GitHubFlavor)
+  .parallel[IO]
+  .build
+  
+val epubRes: IO[Unit] = epubTransformer.use {
   _.fromDirectory("src")
    .toFile("output.epub")
    .transform
@@ -358,9 +382,15 @@ val res: IO[Unit] = transformer.use {
 
 All previous examples read content from the single input directory. But you can also merge the contents of multiple directories:
 
-```scala
-val res: IO[RenderedTreeRoot[IO]] = transformer.use {
-  _.fromDirectories("markup", "theme")
+```scala mdoc
+import laika.io.model.FilePath
+
+val directories = Seq(
+  FilePath.parse("markup"),
+  FilePath.parse("theme")
+)
+val mergedRes: IO[RenderedTreeRoot[IO]] = transformer.use {
+  _.fromDirectories(directories)
    .toDirectory("target")
    .transform
 }
@@ -376,12 +406,18 @@ If you need even more flexibility instead of just configuring one or more input 
 e.g. when there is a need to generate content on-the-fly before starting the transformation,
 you can use the `InputTree` builder. 
 
-```scala
-val inputs = InputTree[F]
+```scala mdoc
+import laika.io.model._
+import laika.ast.Path.Root
+import laika.rewrite.DefaultTemplatePath
+
+def generateStyles: String = "???"
+
+val inputs = InputTree[IO]
   .addDirectory("/path-to-my/markup-files")
   .addDirectory("/path-to-my/images", Root / "images")
-  .addClasspathResource("templates/default.html", DefaultTemplatePath.forHTML)
-  .addString(generateStyles(), Root / "css" / "site.css")
+  .addClassResource("templates/default.html", DefaultTemplatePath.forHTML)
+  .addString(generateStyles, Root / "css" / "site.css")
 ```
 
 In the example above we specify two directories, a classpath resource and a string containing CSS generated on the fly.
@@ -419,9 +455,9 @@ For the complete API see @:api(laika.io.model.InputTreeBuilder).
 
 The customized input tree can then be passed to the transformer:
 
-```scala
-val res: IO[RenderedTreeRoot[IO]] = transformer.use {
-  _.fromInputTree(inputs)
+```scala mdoc:compile-only
+val composedRes: IO[RenderedTreeRoot[IO]] = transformer.use {
+  _.fromInput(inputs)
    .toDirectory("target")
    .transform
 }
@@ -475,8 +511,8 @@ The following code example demonstrates the third scenario listed above: Renderi
 
 First we create a parser that reads from a directory:
 
-```scala
-val parserRes = MarkupParser
+```scala mdoc
+val parser = MarkupParser
   .of(Markdown)
   .using(GitHubFlavor)
   .parallel[IO]
@@ -485,26 +521,28 @@ val parserRes = MarkupParser
 
 Next we create the renderers for the three output formats:
 
-```scala
-val htmlRendererRes = Renderer.of(HTML).parallel[IO].build
-val epubRendererRes = Renderer.of(EPUB).parallel[IO].build
-val pdfRendererRes  = Renderer.of(PDF).parallel[IO].build
+```scala mdoc
+val htmlRenderer = Renderer.of(HTML).parallel[IO].build
+val epubRenderer = Renderer.of(EPUB).parallel[IO].build
+val pdfRenderer  = Renderer.of(PDF).parallel[IO].build
 ```
 
 Since all four processors are a cats-effect `Resource`, we combine them into one:
 
-```scala
+```scala mdoc
 val allResources = for {
-  parser <- parserRes
-  html <- htmlRendererRes
-  epub <- epubRendererRes
-  pdf <- pdfRendererRes
-} yield (parser, html, epub, pdf)
+  parse <- parser
+  html  <- htmlRenderer
+  epub  <- epubRenderer
+  pdf   <- pdfRenderer
+} yield (parse, html, epub, pdf)
 ```
 
-Finally we define the actual transformation by wiring the parser and the three renderers:
+Finally, we define the actual transformation by wiring the parser and the three renderers:
 
-```scala
+```scala mdoc
+import cats.syntax.all._
+
 val transformOp: IO[Unit] = allResources.use { 
   case (parser, htmlRenderer, epubRenderer, pdfRenderer) =>
     parser.fromDirectory("source").parse.flatMap { tree =>
@@ -545,7 +583,9 @@ You can also specify an empty theme if you want to put all templates and styles 
 
 Example for applying a few Helium settings:
 
-```scala
+```scala mdoc
+import laika.helium.Helium
+
 val theme = Helium.defaults
   .all.metadata(
     title = Some("Project Name"),
@@ -555,19 +595,13 @@ val theme = Helium.defaults
   .pdf.navigationDepth(4)
   .build
   
-val transformer = Transformer
+val heliumTransformer = Transformer
   .from(Markdown)
   .to(HTML)
   .using(GitHubFlavor)
   .parallel[IO]
   .withTheme(theme)
   .build
-```
-
-Setting an empty theme:
-
-```scala
-laikaTheme := Theme.empty
 ```
 
 If you do not explicitly pass a theme configuration Laika will run with the default settings of the Helium theme, 
@@ -628,7 +662,9 @@ This includes auto-refreshing whenever changes to any input document are detecte
 It is the basis of the `laikaPreview` task of the sbt plugin, 
 but can alternatively be launched via the library API:
 
-```scala
+```scala mdoc:nest
+import laika.preview.ServerBuilder
+
 val parser = MarkupParser
   .of(Markdown)
   .using(GitHubFlavor)
@@ -647,10 +683,14 @@ The above example creates a server based on its default configuration.
 Open `localhost:4242` for the landing page of your site.
 You can override the defaults by passing a `ServerConfig` instance explicitly:
 
-```scala
+```scala mdoc
+import laika.preview.ServerConfig
+import com.comcast.ip4s._
+import scala.concurrent.duration.DurationInt
+
 val config =
   ServerConfig.defaults
-    .withPort(8080)
+    .withPort(port"8080")
     .withPollInterval(5.seconds)
     .withEPUBDownloads
     .withPDFDownloads

--- a/docs/src/02-running-laika/03-configuration.md
+++ b/docs/src/02-running-laika/03-configuration.md
@@ -91,17 +91,25 @@ Markup extensions enabled by default are:
 
 * Support for [Substitution Variables] in markup in the form of `${some.key}`.
 
+```scala mdoc:invisible
+import laika.sbt.LaikaPlugin.autoImport._
+```
+
 To disable all these extensions you can use the `strict` flag:
 
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:compile-only
 laikaConfig := LaikaConfig.defaults.strict
 ```
 
 @:choice(library)
-```scala
+```scala mdoc:compile-only
+import laika.api._
+import laika.format._
+import laika.markdown.github.GitHubFlavor
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -135,12 +143,16 @@ You can enable verbatim HTML and other raw formats explicitly in the configurati
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:compile-only
 laikaConfig := LaikaConfig.defaults.withRawContent
 ```
 
 @:choice(library)
-```scala
+```scala mdoc:compile-only
+import laika.api._
+import laika.format._
+import laika.markdown.github.GitHubFlavor
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -161,13 +173,17 @@ When you need to work with different encodings you can override the default:
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:compile-only
+import scala.io.Codec
+
 laikaConfig := LaikaConfig.defaults.encoding(Codec.ISO8859)
 ```
 
 @:choice(library)
-```scala
-implicit val codec:Codec = Codec.UTF8
+```scala mdoc:compile-only
+import scala.io.Codec
+
+implicit val codec:Codec = Codec.ISO8859
 ```
 
 This has to be in scope where you specify the input and ouput files for your transformer
@@ -225,14 +241,21 @@ You can achieve this by basically flipping the two default values in the configu
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:compile-only
+import laika.ast.MessageFilter
+
 laikaConfig := LaikaConfig.defaults
   .failOnMessages(MessageFilter.None)
   .renderMessages(MessageFilter.Error)
 ```
 
 @:choice(library)
-```scala
+```scala mdoc:compile-only
+import laika.api._
+import laika.format._
+import laika.ast.MessageFilter
+import laika.markdown.github.GitHubFlavor
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -269,10 +292,13 @@ laikaAST
 This task is a shortcut for `laikaGenerate ast`
 
 @:choice(library)
-```scala
+```scala mdoc:compile-only
+import laika.api._
+import laika.format._
+
 val input = "some *text* example"
 
-Transformer
+val res = Transformer
   .from(Markdown)
   .to(AST)
   .build
@@ -311,14 +337,18 @@ This is an example for defining two variables globally:
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:compile-only
 laikaConfig := LaikaConfig.defaults
   .withConfigValue("version.latest", "2.4.6")
   .withConfigValue("license", "Apache 2.0")
 ```
 
 @:choice(library)
-```scala
+```scala mdoc:compile-only
+import laika.api._
+import laika.format._
+import laika.markdown.github.GitHubFlavor
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)

--- a/docs/src/03-preparing-content/01-directory-structure.md
+++ b/docs/src/03-preparing-content/01-directory-structure.md
@@ -39,6 +39,11 @@ Apart from standard markup syntax, markup files in Laika can also contain the fo
 * Directives, which extend the text markup's functionality, either one of the built-in [Standard Directives]
   or your own, custom implementations.
 
+```scala mdoc:invisible
+import laika.sbt.LaikaPlugin.autoImport._
+import sbt.Keys._
+import sbt._
+```
 
 ### Title Documents
 
@@ -53,14 +58,21 @@ The names can be overridden in Laika's global configuration (you need to omit th
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:compile-only
+import laika.config.LaikaKeys
+
 laikaConfig := LaikaConfig.defaults
   .withConfigValue(LaikaKeys.titleDocuments.inputName, "title")
   .withConfigValue(LaikaKeys.titleDocuments.outputName, "title")
 ```
 
 @:choice(library)
-```scala
+```scala mdoc:compile-only
+import laika.config.LaikaKeys
+import laika.api._
+import laika.format._
+import laika.markdown.github.GitHubFlavor
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -226,7 +238,9 @@ For this to work, the library or plugin needs to know where your site is hosted.
 
 If you are using the Helium theme, there is a property you can use for this purpose:
 
-```scala
+```scala mdoc
+import laika.helium.Helium
+
 Helium.defaults.site.baseURL("https://my-docs/site")
 ```
 
@@ -235,13 +249,19 @@ If you are not using Helium, you can use the standard configuration API to set t
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:compile-only
+import laika.config.LaikaKeys
+
 laikaConfig := LaikaConfig.defaults
   .withConfigValue(LaikaKeys.siteBaseURL, "https://my-docs/site")
 ```
 
 @:choice(library)
-```scala
+```scala mdoc
+import laika.config.LaikaKeys
+import laika.api._
+import laika.format._
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -299,7 +319,9 @@ Therefore, configuration for versioned documentation involves two steps:
 
 This is a global configuration artifact that you can define with the Helium configuration API:
 
-```scala
+```scala mdoc
+import laika.rewrite.{ Version, Versions }
+
 val versions = Versions(
   currentVersion = Version("0.42.x", "0.42", canonical = true),
   olderVersions = Seq(
@@ -370,7 +392,7 @@ The index for this flexible switching can be built up in two different ways, dep
    the version configuration for Laika is complete, including all the older versions rendered by other tools
    and the configuration for the version scanner itself:
    
-   ```scala
+   ```scala mdoc:nest
    val versions = Versions(
      currentVersion = Version("0.42.x", "0.42"),
      olderVersions  = Seq(Version("0.41.x", "0.41", label = Some("EOL"))),
@@ -409,7 +431,7 @@ them to originate in the sources for the newest version.
 You can achieve this by setting the `renderUnversioned` flag to `false` in your version config on
 the maintenance branch:
 
-```scala
+```scala mdoc:nest
 val versions = Versions(
   currentVersion = Version("0.42.x", "0.42"),
   olderVersions = Seq(),

--- a/docs/src/03-preparing-content/01-directory-structure.md
+++ b/docs/src/03-preparing-content/01-directory-structure.md
@@ -238,7 +238,7 @@ For this to work, the library or plugin needs to know where your site is hosted.
 
 If you are using the Helium theme, there is a property you can use for this purpose:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.helium.Helium
 
 Helium.defaults.site.baseURL("https://my-docs/site")
@@ -257,7 +257,7 @@ laikaConfig := LaikaConfig.defaults
 ```
 
 @:choice(library)
-```scala mdoc
+```scala mdoc:silent
 import laika.config.LaikaKeys
 import laika.api._
 import laika.format._
@@ -319,7 +319,7 @@ Therefore, configuration for versioned documentation involves two steps:
 
 This is a global configuration artifact that you can define with the Helium configuration API:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.rewrite.{ Version, Versions }
 
 val versions = Versions(
@@ -431,7 +431,7 @@ them to originate in the sources for the newest version.
 You can achieve this by setting the `renderUnversioned` flag to `false` in your version config on
 the maintenance branch:
 
-```scala mdoc:nest
+```scala mdoc:nest:silent
 val versions = Versions(
   currentVersion = Version("0.42.x", "0.42"),
   olderVersions = Seq(),

--- a/docs/src/03-preparing-content/02-navigation.md
+++ b/docs/src/03-preparing-content/02-navigation.md
@@ -2,6 +2,12 @@
 Navigation
 ==========
 
+```scala mdoc:invisible
+import laika.sbt.LaikaPlugin.autoImport._
+import sbt.Keys._
+import sbt._
+```
+
 Laika's functionality for navigation can roughly be divided into four categories:
 
 * Features added on top of the native link syntax of supported markup formats, 
@@ -57,13 +63,22 @@ you can explicitly disable validation for certain paths within the virtual tree:
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:compile-only
+import laika.ast.Path.Root
+import laika.rewrite.link.LinkConfig
+
 laikaConfig := LaikaConfig.defaults
   .withConfigValue(LinkConfig(excludeFromValidation = Seq(Root / "generated")))
 ```
 
 @:choice(library)
-```scala
+```scala mdoc
+import laika.api._
+import laika.ast.Path.Root
+import laika.format._
+import laika.markdown.github.GitHubFlavor
+import laika.rewrite.link.LinkConfig
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -116,7 +131,10 @@ Simply add them to the project's configuration:
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:compile-only
+import laika.ast.ExternalTarget
+import laika.rewrite.link.{ LinkConfig, TargetDefinition }
+
 laikaConfig := LaikaConfig.defaults
   .withConfigValue(LinkConfig(targets = Seq(
     TargetDefinition("Example 1", ExternalTarget("https://example1.com/")),
@@ -125,7 +143,13 @@ laikaConfig := LaikaConfig.defaults
 ```
 
 @:choice(library)
-```scala
+```scala mdoc:nest
+import laika.api._
+import laika.ast.ExternalTarget
+import laika.format._
+import laika.markdown.github.GitHubFlavor
+import laika.rewrite.link.{ LinkConfig, TargetDefinition }
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -228,7 +252,9 @@ This directive requires the base URI to be defined in the project's configuratio
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:compile-only
+import laika.rewrite.link.{ LinkConfig, ApiLinks }
+
 laikaConfig := LaikaConfig.defaults
   .withConfigValue(LinkConfig(apiLinks = Seq(
     ApiLinks(baseUri = "https://example.com/api")
@@ -236,7 +262,12 @@ laikaConfig := LaikaConfig.defaults
 ```
 
 @:choice(library)
-```scala
+```scala mdoc:nest
+import laika.api._
+import laika.format._
+import laika.markdown.github.GitHubFlavor
+import laika.rewrite.link.{ LinkConfig, ApiLinks }
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -254,7 +285,9 @@ while keeping one base URI as a default for all packages that do not match any p
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:compile-only
+import laika.rewrite.link.{ LinkConfig, ApiLinks }
+
 laikaConfig := LaikaConfig.defaults
   .withConfigValue(LinkConfig(apiLinks = Seq(
     ApiLinks(baseUri = "https://example.com/api"),
@@ -263,7 +296,12 @@ laikaConfig := LaikaConfig.defaults
 ```
 
 @:choice(library)
-```scala
+```scala mdoc:nest
+import laika.api._
+import laika.format._
+import laika.markdown.github.GitHubFlavor
+import laika.rewrite.link.{ LinkConfig, ApiLinks }
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -295,7 +333,9 @@ This directive requires the base URI and suffix to be defined in the project's c
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:compile-only
+import laika.rewrite.link.{ LinkConfig, SourceLinks }
+
 laikaConfig := LaikaConfig.defaults
   .withConfigValue(LinkConfig(sourceLinks = Seq(
     SourceLinks(baseUri = "https://github.com/team/project", suffix = "scala")
@@ -303,7 +343,12 @@ laikaConfig := LaikaConfig.defaults
 ```
 
 @:choice(library)
-```scala
+```scala mdoc:nest
+import laika.api._
+import laika.format._
+import laika.markdown.github.GitHubFlavor
+import laika.rewrite.link.{ LinkConfig, SourceLinks }
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -321,7 +366,9 @@ while keeping one base URI as a default for all packages that do not match any p
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:compile-only
+import laika.rewrite.link.{ LinkConfig, SourceLinks }
+
 laikaConfig := LaikaConfig.defaults
   .withConfigValue(LinkConfig(sourceLinks = Seq(
     SourceLinks(
@@ -337,7 +384,12 @@ laikaConfig := LaikaConfig.defaults
 ```
 
 @:choice(library)
-```scala
+```scala mdoc:nest
+import laika.api._
+import laika.format._
+import laika.markdown.github.GitHubFlavor
+import laika.rewrite.link.{ LinkConfig, SourceLinks }
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -547,13 +599,20 @@ Auto-numbering can be switched on per configuration:
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:compile-only
+import laika.rewrite.nav.AutonumberConfig
+
 laikaConfig := LaikaConfig.defaults
   .withConfigValue(AutonumberConfig(maxDepth = 3))
 ```
 
 @:choice(library)
-```scala
+```scala mdoc:nest
+import laika.api._
+import laika.format._
+import laika.markdown.github.GitHubFlavor
+import laika.rewrite.nav.AutonumberConfig
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -591,12 +650,18 @@ It can be enabled like any other extension:
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:compile-only
+import laika.rewrite.nav.PrettyURLs
+
 laikaExtensions += PrettyURLs
 ```
 
 @:choice(library)
-```scala
+```scala mdoc:nest
+import laika.api._
+import laika.format._
+import laika.rewrite.nav.PrettyURLs
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)

--- a/docs/src/03-preparing-content/02-navigation.md
+++ b/docs/src/03-preparing-content/02-navigation.md
@@ -72,7 +72,7 @@ laikaConfig := LaikaConfig.defaults
 ```
 
 @:choice(library)
-```scala mdoc
+```scala mdoc:silent
 import laika.api._
 import laika.ast.Path.Root
 import laika.format._
@@ -143,7 +143,7 @@ laikaConfig := LaikaConfig.defaults
 ```
 
 @:choice(library)
-```scala mdoc:nest
+```scala mdoc:nest:silent
 import laika.api._
 import laika.ast.ExternalTarget
 import laika.format._
@@ -262,7 +262,7 @@ laikaConfig := LaikaConfig.defaults
 ```
 
 @:choice(library)
-```scala mdoc:nest
+```scala mdoc:nest:silent
 import laika.api._
 import laika.format._
 import laika.markdown.github.GitHubFlavor
@@ -296,7 +296,7 @@ laikaConfig := LaikaConfig.defaults
 ```
 
 @:choice(library)
-```scala mdoc:nest
+```scala mdoc:nest:silent
 import laika.api._
 import laika.format._
 import laika.markdown.github.GitHubFlavor
@@ -343,7 +343,7 @@ laikaConfig := LaikaConfig.defaults
 ```
 
 @:choice(library)
-```scala mdoc:nest
+```scala mdoc:nest:silent
 import laika.api._
 import laika.format._
 import laika.markdown.github.GitHubFlavor
@@ -384,7 +384,7 @@ laikaConfig := LaikaConfig.defaults
 ```
 
 @:choice(library)
-```scala mdoc:nest
+```scala mdoc:nest:silent
 import laika.api._
 import laika.format._
 import laika.markdown.github.GitHubFlavor
@@ -607,7 +607,7 @@ laikaConfig := LaikaConfig.defaults
 ```
 
 @:choice(library)
-```scala mdoc:nest
+```scala mdoc:nest:silent
 import laika.api._
 import laika.format._
 import laika.markdown.github.GitHubFlavor
@@ -657,7 +657,7 @@ laikaExtensions += PrettyURLs
 ```
 
 @:choice(library)
-```scala mdoc:nest
+```scala mdoc:nest:silent
 import laika.api._
 import laika.format._
 import laika.rewrite.nav.PrettyURLs

--- a/docs/src/03-preparing-content/03-theme-settings.md
+++ b/docs/src/03-preparing-content/03-theme-settings.md
@@ -41,7 +41,7 @@ laikaTheme := Helium.defaults.build
 ```
 
 @:choice(library)
-```scala mdoc
+```scala mdoc:silent
 import cats.effect.IO
 import laika.api._
 import laika.format._
@@ -91,7 +91,7 @@ Not all options are available for all formats, but the IDE's context help and th
 In the minimal example below we only specify some metadata for all formats as well as the navigation depth
 for EPUB and PDF:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.helium.Helium
 
 val theme = Helium.defaults
@@ -120,7 +120,7 @@ laikaTheme := theme
 ```
 
 @:choice(library)
-```scala mdoc:nest
+```scala mdoc:nest:silent
 val transformer = Transformer
   .from(Markdown)
   .to(EPUB)
@@ -146,7 +146,7 @@ You can override these defaults by defining your own set of fonts.
 
 This is an excerpt of Laika's default configuration as an example:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.theme.config._
 
 val fontPath = "<file-path-to-your-fonts>"
@@ -194,7 +194,7 @@ This ensures that no unused font resources will be embedded.
 
 Additionally you can define the font families and font sizes for the site and e-books:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.ast.LengthUnit._
 
 Helium.defaults
@@ -240,7 +240,7 @@ and backgrounds as well as the syntax coloring scheme to be used for all code bl
 
 The following example overrides Laika's theme colors for all output formats:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.theme.config.Color
 
 Helium.defaults
@@ -332,7 +332,7 @@ a0742d wheel-3
 
 They can be overridden per format or for all at once:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.theme.config.Color._
 import laika.helium.config.ColorQuintet
 
@@ -368,7 +368,7 @@ whenever the user has switched on dark mode in the OS or in the reader software.
 
 The following example defines custom theme colors for dark mode in EPUB output:
 
-```scala mdoc
+```scala mdoc:silent
 Helium.defaults
   .epub.darkMode.themeColors(
     primary = Color.hex("a7d4de"),
@@ -412,7 +412,7 @@ that are the most like candidates for frequent adjustments.
 
 These are the options for the site:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.ast.LengthUnit._
 import laika.helium.config.AnchorPlacement
 
@@ -438,7 +438,7 @@ that override additional styles.
 
 For PDF output you can also define the page size and margins:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.ast.LengthUnit._
 
 Helium.defaults
@@ -473,7 +473,7 @@ in a way that the respective readers understand.
 Like many other options, you can specify metadata either with the `all` selector for all formats,
 or define them separately with the `epub`, `pdf` or `site` selectors.
 
-```scala mdoc
+```scala mdoc:silent
 import java.time.OffsetDateTime
 
 Helium.defaults
@@ -545,7 +545,7 @@ of your input directories and is up to 2 levels deep.
 
 You can override some defaults and add additional menu entries via the configuration API:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.helium.config.{ ThemeNavigationSection, TextLink }
 import laika.ast.Path.Root
 
@@ -584,7 +584,7 @@ The home link, unless overridden, points to `index.html` and uses the `HeliumIco
 The navigation links on the right are empty by default.
 The left corner of the top bar is always reserved for the button to open or close the navigation.
 
-```scala mdoc
+```scala mdoc:silent
 import laika.helium.config._
 import laika.ast.Path.Root
 
@@ -671,7 +671,7 @@ to the two top layers of the sections on that page.
 
 The configuration API allows for some customization:
 
-```scala mdoc
+```scala mdoc:silent
 Helium.defaults
   .site.pageNavigation(
     enabled = true,
@@ -712,7 +712,7 @@ reader's navigation bars in case of EPUB or PDF) which Helium will always produc
 It is an optional, separate page that can be included in e-books or the site.
 For PDF format this is essential, as the reader's navigation would be lost if the user prints the PDF.
 
-```scala mdoc
+```scala mdoc:silent
 Helium.defaults
   .site.tableOfContent(title = "Contents", depth = 3)
   .pdf.tableOfContent(title = "Contents", depth = 4)
@@ -727,7 +727,7 @@ for the site it will become a link at the top of the left navigation pane.
 
 Finally, the navigation depth for the reader's navigation for EPUB and PDF can also be controlled:
 
-```scala mdoc
+```scala mdoc:silent
 Helium.defaults
   .epub.navigationDepth(4)
   .pdf.navigationDepth(4)
@@ -746,7 +746,7 @@ If you increase this setting make sure you verify it's looking good in the targe
 
 You can specify one or more favicons for your site:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.helium.config.Favicon
 
 Helium.defaults
@@ -762,13 +762,13 @@ By default, the theme includes a footer pointing to the Laika project.
 There is no requirement to keep this footer though, and the API gives you the following options:
 
 Set a raw HTML string as the footer:
-```scala mdoc
+```scala mdoc:silent
 Helium.defaults
   .site.footer("""This is a <a href="https://foo.com/">Foo</a> project under the Bar licence.""")
 ```
 
 Set the footer as a sequence of AST nodes:
-```scala mdoc
+```scala mdoc:silent
 import laika.ast._
 
 Helium.defaults
@@ -780,7 +780,7 @@ Helium.defaults
 ```
 
 Remove the footer entirely:
-```scala mdoc
+```scala mdoc:silent
 Helium.defaults
   .site.footer()
 ```
@@ -796,7 +796,7 @@ Download Page
 A page offering generated EPUB and PDF files with the same content and structure as the site for download
 can be added via Helium configuration:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.ast.Path.Root
 
 Helium.defaults
@@ -825,7 +825,7 @@ If you don't mind that users arrive straight at the content pages, you can stick
 Alternatively Helium offers a dedicated landing page tailored for software documentation sites.
 This is the full set of content options available:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.ast.Path.Root
 import laika.ast.{ Image, ExternalTarget }
 import laika.helium.config._
@@ -919,7 +919,7 @@ Cover Images for E-books
 You can include cover images for EPUB and PDF files. 
 They will also be used to display little thumbnails on the download page.
 
-```scala mdoc
+```scala mdoc:silent
 import laika.ast.Path.Root
 import laika.rewrite.nav.CoverImage
 
@@ -946,7 +946,7 @@ They will always be included in a way that they have higher precedence than the 
 If you want to prevent Helium from scanning all input directories for CSS files, 
 you can alternatively specify one or more directories explicitly:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.ast.Path.Root
 
 Helium.defaults

--- a/docs/src/03-preparing-content/03-theme-settings.md
+++ b/docs/src/03-preparing-content/03-theme-settings.md
@@ -2,6 +2,12 @@
 Theme Settings
 ==============
 
+```scala mdoc:invisible
+import laika.sbt.LaikaPlugin.autoImport._
+import sbt.Keys._
+import sbt._
+```
+
 If you use the sbt plugin or the parsers, renderers or transformers from the `laika-io` module,
 each transformation is based on a theme that provides a set of default templates and styles for all output formats.
 
@@ -17,7 +23,7 @@ The Helium Theme
 The name of Laika's default theme reflects its lightweight nature as it is not based on any CSS or JavaScript libraries
 like Bootstrap, but instead only comes with a minimal set of hand-crafted CSS and JavaScript.
 
-Helium includes default styles for web sites, EPUB and PDF documents, 
+Helium includes default styles for websites, EPUB and PDF documents, 
 so you can generate a documentation site complete with a download page for e-book formats in one go.
 
 The generated site is responsive and designed to work well on smaller devices.
@@ -28,17 +34,25 @@ which is equivalent to the following configuration:
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:compile-only
+import laika.helium.Helium
+
 laikaTheme := Helium.defaults.build
 ```
 
 @:choice(library)
-```scala
+```scala mdoc
+import cats.effect.IO
+import laika.api._
+import laika.format._
+import laika.io.implicits._
+import laika.helium.Helium
+
 val transformer = Transformer
   .from(Markdown)
   .to(EPUB)
   .parallel[IO]
-  .witTheme(Helium.defaults.build)
+  .withTheme(Helium.defaults.build)
   .build
 ```
 @:@
@@ -77,7 +91,9 @@ Not all options are available for all formats, but the IDE's context help and th
 In the minimal example below we only specify some metadata for all formats as well as the navigation depth
 for EPUB and PDF:
 
-```scala
+```scala mdoc
+import laika.helium.Helium
+
 val theme = Helium.defaults
   .all.metadata(
     title = Some("Project Name"),
@@ -99,17 +115,17 @@ or the `laikaTheme` sbt setting:
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:compile-only
 laikaTheme := theme
 ```
 
 @:choice(library)
-```scala
+```scala mdoc:nest
 val transformer = Transformer
   .from(Markdown)
   .to(EPUB)
   .parallel[IO]
-  .witTheme(theme)
+  .withTheme(theme)
   .build
 ```
 @:@
@@ -130,7 +146,10 @@ You can override these defaults by defining your own set of fonts.
 
 This is an excerpt of Laika's default configuration as an example:
 
-```scala
+```scala mdoc
+import laika.theme.config._
+
+val fontPath = "<file-path-to-your-fonts>"
 val latoURL = "http://fonts.googleapis.com/css?family=Lato:400,700"
 val firaURL = 
   "https://cdn.jsdelivr.net/gh/tonsky/FiraCode@1.207/distr/fira_code.css"
@@ -175,7 +194,9 @@ This ensures that no unused font resources will be embedded.
 
 Additionally you can define the font families and font sizes for the site and e-books:
 
-```scala
+```scala mdoc
+import laika.ast.LengthUnit._
+
 Helium.defaults
   .all.fontFamilies(
     body = "MyBodyFont",
@@ -219,7 +240,9 @@ and backgrounds as well as the syntax coloring scheme to be used for all code bl
 
 The following example overrides Laika's theme colors for all output formats:
 
-```scala
+```scala mdoc
+import laika.theme.config.Color
+
 Helium.defaults
   .all.themeColors(
     primary = Color.hex("007c99"),
@@ -309,7 +332,10 @@ a0742d wheel-3
 
 They can be overridden per format or for all at once:
 
-```scala
+```scala mdoc
+import laika.theme.config.Color._
+import laika.helium.config.ColorQuintet
+
 Helium.defaults
   .all.syntaxHighlightingColors(
     base = ColorQuintet(
@@ -342,7 +368,7 @@ whenever the user has switched on dark mode in the OS or in the reader software.
 
 The following example defines custom theme colors for dark mode in EPUB output:
 
-```scala
+```scala mdoc
 Helium.defaults
   .epub.darkMode.themeColors(
     primary = Color.hex("a7d4de"),
@@ -386,7 +412,10 @@ that are the most like candidates for frequent adjustments.
 
 These are the options for the site:
 
-```scala
+```scala mdoc
+import laika.ast.LengthUnit._
+import laika.helium.config.AnchorPlacement
+
 Helium.defaults
   .site.layout(
     contentWidth = px(860),
@@ -409,7 +438,9 @@ that override additional styles.
 
 For PDF output you can also define the page size and margins:
 
-```scala
+```scala mdoc
+import laika.ast.LengthUnit._
+
 Helium.defaults
   .pdf.layout(
     pageWidth = cm(21),
@@ -442,7 +473,9 @@ in a way that the respective readers understand.
 Like many other options, you can specify metadata either with the `all` selector for all formats,
 or define them separately with the `epub`, `pdf` or `site` selectors.
 
-```scala
+```scala mdoc
+import java.time.OffsetDateTime
+
 Helium.defaults
   .pdf.metadata(
     title = Some("Project Name"),
@@ -450,7 +483,7 @@ Helium.defaults
     identifier = Some("XSD-9876-XVT"),
     authors = Seq("Maria Green", "Helena Brown"),
     language = Some("de"),
-    datePublished = Some(Instant.now),
+    datePublished = Some(OffsetDateTime.now),
     version = Some("2.3.4") 
   )
 ```
@@ -512,7 +545,10 @@ of your input directories and is up to 2 levels deep.
 
 You can override some defaults and add additional menu entries via the configuration API:
 
-```scala
+```scala mdoc
+import laika.helium.config.{ ThemeNavigationSection, TextLink }
+import laika.ast.Path.Root
+
 Helium.defaults.site
   .mainNavigation(
     depth = 3,
@@ -548,7 +584,10 @@ The home link, unless overridden, points to `index.html` and uses the `HeliumIco
 The navigation links on the right are empty by default.
 The left corner of the top bar is always reserved for the button to open or close the navigation.
 
-```scala
+```scala mdoc
+import laika.helium.config._
+import laika.ast.Path.Root
+
 Helium.defaults.site
   .topNavigationBar(
     homeLink = IconLink.internal(Root / "README.md", HeliumIcon.home),
@@ -632,12 +671,12 @@ to the two top layers of the sections on that page.
 
 The configuration API allows for some customization:
 
-```scala
+```scala mdoc
 Helium.defaults
   .site.pageNavigation(
     enabled = true,
     depth = 1,
-    sourceBaseURL = "https://github.com/my/project",
+    sourceBaseURL = Some("https://github.com/my/project"),
     sourceLinkText = "Source for this Page"
   )
 ```
@@ -673,7 +712,7 @@ reader's navigation bars in case of EPUB or PDF) which Helium will always produc
 It is an optional, separate page that can be included in e-books or the site.
 For PDF format this is essential, as the reader's navigation would be lost if the user prints the PDF.
 
-```scala
+```scala mdoc
 Helium.defaults
   .site.tableOfContent(title = "Contents", depth = 3)
   .pdf.tableOfContent(title = "Contents", depth = 4)
@@ -688,7 +727,7 @@ for the site it will become a link at the top of the left navigation pane.
 
 Finally, the navigation depth for the reader's navigation for EPUB and PDF can also be controlled:
 
-```scala
+```scala mdoc
 Helium.defaults
   .epub.navigationDepth(4)
   .pdf.navigationDepth(4)
@@ -707,7 +746,9 @@ If you increase this setting make sure you verify it's looking good in the targe
 
 You can specify one or more favicons for your site:
 
-```scala
+```scala mdoc
+import laika.helium.config.Favicon
+
 Helium.defaults
   .site.favIcons(
     Favicon.internal(Root / "favicon32x32.png", sizes = "32x32"),
@@ -721,13 +762,15 @@ By default, the theme includes a footer pointing to the Laika project.
 There is no requirement to keep this footer though, and the API gives you the following options:
 
 Set a raw HTML string as the footer:
-```scala
+```scala mdoc
 Helium.defaults
   .site.footer("""This is a <a href="https://foo.com/">Foo</a> project under the Bar licence.""")
 ```
 
 Set the footer as a sequence of AST nodes:
-```scala
+```scala mdoc
+import laika.ast._
+
 Helium.defaults
   .site.footer(
     TemplateString("This is a "),
@@ -737,7 +780,7 @@ Helium.defaults
 ```
 
 Remove the footer entirely:
-```scala
+```scala mdoc
 Helium.defaults
   .site.footer()
 ```
@@ -753,7 +796,9 @@ Download Page
 A page offering generated EPUB and PDF files with the same content and structure as the site for download
 can be added via Helium configuration:
 
-```scala
+```scala mdoc
+import laika.ast.Path.Root
+
 Helium.defaults
   .site.downloadPage(
     title = "Documentation Downloads",
@@ -780,10 +825,14 @@ If you don't mind that users arrive straight at the content pages, you can stick
 Alternatively Helium offers a dedicated landing page tailored for software documentation sites.
 This is the full set of content options available:
 
-```scala
+```scala mdoc
+import laika.ast.Path.Root
+import laika.ast.{ Image, ExternalTarget }
+import laika.helium.config._
+
 Helium.defaults
   .site.landingPage(
-    logo = Some(Image()),
+    logo = Some(Image(ExternalTarget("http://my-site/my-image.jpg"))),
     title = Some("Project Name"),
     subtitle = Some("Fancy Hyperbole Goes Here"),
     latestReleases = Seq(
@@ -870,7 +919,10 @@ Cover Images for E-books
 You can include cover images for EPUB and PDF files. 
 They will also be used to display little thumbnails on the download page.
 
-```scala
+```scala mdoc
+import laika.ast.Path.Root
+import laika.rewrite.nav.CoverImage
+
 Helium.defaults
   .epub.coverImages(CoverImage(Root / "cover.png"))
   .pdf.coverImages(CoverImage(Root / "cover.png"))
@@ -894,7 +946,9 @@ They will always be included in a way that they have higher precedence than the 
 If you want to prevent Helium from scanning all input directories for CSS files, 
 you can alternatively specify one or more directories explicitly:
 
-```scala
+```scala mdoc
+import laika.ast.Path.Root
+
 Helium.defaults
   .site.autoLinkCSS(Root / "my-css")
   .site.autoLinkJS(Root / "my-js")

--- a/docs/src/03-preparing-content/04-ebooks.md
+++ b/docs/src/03-preparing-content/04-ebooks.md
@@ -30,7 +30,7 @@ See [sbt Plugin] for more details.
 
 When using the library API, the `EPUB` and `PDF` renderers can be passed to the `Transformer` or `Renderer` APIs:
 
-```scala mdoc
+```scala mdoc:silent
 import cats.effect.IO
 import laika.api._
 import laika.format._
@@ -125,7 +125,7 @@ EPUB Navigation in iBooks:
 
 The navigation depth can be configured with the Helium API:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.helium.Helium
 
 Helium.defaults

--- a/docs/src/03-preparing-content/04-ebooks.md
+++ b/docs/src/03-preparing-content/04-ebooks.md
@@ -30,7 +30,13 @@ See [sbt Plugin] for more details.
 
 When using the library API, the `EPUB` and `PDF` renderers can be passed to the `Transformer` or `Renderer` APIs:
 
-```scala
+```scala mdoc
+import cats.effect.IO
+import laika.api._
+import laika.format._
+import laika.io.implicits._
+import laika.markdown.github.GitHubFlavor
+
 val transformer = Transformer
   .from(Markdown)
   .to(EPUB)
@@ -119,7 +125,9 @@ EPUB Navigation in iBooks:
 
 The navigation depth can be configured with the Helium API:
 
-```scala
+```scala mdoc
+import laika.helium.Helium
+
 Helium.defaults
   .epub.navigationDepth(4)
   .pdf.navigationDepth(4)

--- a/docs/src/03-preparing-content/05-syntax-highlighting.md
+++ b/docs/src/03-preparing-content/05-syntax-highlighting.md
@@ -39,7 +39,7 @@ When using reStructuredText input only the `SyntaxHighlighting` extension is nee
 
 When using the Library API highlighting can be activated like all other extension bundles:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.api._
 import laika.format._
 import laika.markdown.github.GitHubFlavor

--- a/docs/src/03-preparing-content/05-syntax-highlighting.md
+++ b/docs/src/03-preparing-content/05-syntax-highlighting.md
@@ -12,7 +12,12 @@ Not relying on external tools for this task has several advantages:
   
 This manual itself is a showcase for this functionality. 
 All code samples shown are highlighted by Laika's own syntax support. 
-  
+
+```scala mdoc:invisible
+import laika.sbt.LaikaPlugin.autoImport._
+import sbt.Keys._
+import sbt._
+```
   
 Configuration
 -------------
@@ -22,7 +27,10 @@ so that you can still choose other existing solutions if you prefer.
 
 When using the sbt plugin it can be added to the `laikaExtensions` setting:
 
-```scala
+```scala mdoc:compile-only
+import laika.markdown.github.GitHubFlavor
+import laika.parse.code.SyntaxHighlighting
+
 laikaExtensions ++= Seq(GitHubFlavor, SyntaxHighlighting)  
 ```
 
@@ -31,7 +39,12 @@ When using reStructuredText input only the `SyntaxHighlighting` extension is nee
 
 When using the Library API highlighting can be activated like all other extension bundles:
 
-```scala
+```scala mdoc
+import laika.api._
+import laika.format._
+import laika.markdown.github.GitHubFlavor
+import laika.parse.code.SyntaxHighlighting
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -136,7 +149,19 @@ as a starting point.
 
 Once you have implemented and tested your highlighter you can add it to the built-in ones like this:
 
-```scala
+```scala mdoc:compile-only
+import laika.api._
+import laika.format._
+import laika.markdown.github.GitHubFlavor
+import laika.parse.code.{SyntaxHighlighting, CodeSpanParser }
+import laika.bundle.SyntaxHighlighter
+import cats.data.NonEmptyList
+
+object MyHighlighter extends SyntaxHighlighter {
+  def language: NonEmptyList[String] = NonEmptyList.of("my-language")
+  def spanParsers: Seq[CodeSpanParser] = ???
+}
+
 laikaExtensions ++= Seq(
   GitHubFlavor, 
   SyntaxHighlighting.withSyntax(MyHighlighter)

--- a/docs/src/04-customizing-laika/04-document-ast.md
+++ b/docs/src/04-customizing-laika/04-document-ast.md
@@ -342,10 +342,19 @@ They also add an `empty` constructor and a vararg constructor for passing the co
 
 If you create a custom element type you can use these base traits to get all these shortcuts with a few lines:
 
-```scala
+```scala mdoc
+import laika.ast._
+
+case class MyElement(content: Seq[Block], options: Options = NoOpt) extends Block
+    with BlockContainer {
+  type Self = MyElement
+  def withContent(newContent: Seq[Block]): MyElement = copy(content = newContent)
+  def withOptions(options: Options): MyElement       = copy(options = options)
+}
+
 object MyElement extends BlockContainerCompanion {
   type ContainerType = MyElement
-  override protected def createBlockContainer (blocks: Seq[Block]) = 
+  override protected def createBlockContainer (blocks: Seq[Block]): ContainerType = 
     MyElement(blocks)
 }
 ```
@@ -363,7 +372,9 @@ assembled into a `DocumentTree`, consisting of nested `DocumentTree` nodes and l
 
 This is the signature of the `Document` class:
 
-```scala
+```scala:reset
+import laika.ast.{Path, RootElement, Element, Config, TreePosition, DocumentStructure, TreeContent}
+
 case class Document (
   path: Path,
   content: RootElement,
@@ -407,7 +418,9 @@ The `DocumentStructure` mixin provides additional methods as shortcuts for selec
 In a multi-input transformation all `Document` instances get assembled 
 into a recursive structure of `DocumentTree` instances:
   
-```scala
+```scala:reset
+import laika.ast.{Path, Document, TemplateDocument, Config, TreePosition, TreeStructure, TreeContent}
+
 case class DocumentTree (
   path: Path,
   content: Seq[TreeContent],

--- a/docs/src/04-customizing-laika/05-ast-rewriting.md
+++ b/docs/src/04-customizing-laika/05-ast-rewriting.md
@@ -52,7 +52,13 @@ on nodes obtained by a separate parse operation. All three options are described
 The following example of an sbt build file shows how to turn each `Emphasized` node
 into a `Strong` node while processing everything else with default rules:
 
-```scala
+```scala mdoc:invisible
+import laika.sbt.LaikaPlugin.autoImport._
+import sbt.Keys._
+import sbt._
+```
+
+```scala mdoc:compile-only
 import laika.ast._
 
 laikaExtensions += laikaSpanRewriteRule { 
@@ -69,7 +75,11 @@ the Transformer API offers a hook to do this in one go, as a step in the transfo
 
 Again we replace all `Emphasized` nodes with `Strong` nodes:
 
-```scala
+```scala mdoc
+import laika.api._
+import laika.ast._
+import laika.format._
+
 val transformer = Transformer
   .from(ReStructuredText)
   .to(HTML)
@@ -91,7 +101,9 @@ instead of using a full transformer. This is described in detail in [Separate Pa
 
 Once again we are turning all `Emphasized` nodes in the text to `Strong` nodes for our example:
 
-```scala
+```scala mdoc:compile-only
+import laika.ast._
+
 val doc: Document = ??? // obtained through the Parser API
 
 val newDoc = doc.rewrite(RewriteRules.forSpans {
@@ -102,7 +114,11 @@ val newDoc = doc.rewrite(RewriteRules.forSpans {
 For a slightly more advanced example, let's assume you only want to replace `Emphasized` nodes inside headers. 
 To accomplish this you need to nest a rewrite operation inside another one:
 
-```scala
+```scala mdoc:compile-only
+import laika.ast._
+
+val doc: Document = ??? // obtained through the Parser API
+
 val newDoc = doc.rewrite(RewriteRules.forBlocks {
   case h: Header => Replace(h.rewriteSpans {
     case Emphasized(content, opts) => Replace(Strong(content, opts))

--- a/docs/src/04-customizing-laika/05-ast-rewriting.md
+++ b/docs/src/04-customizing-laika/05-ast-rewriting.md
@@ -75,7 +75,7 @@ the Transformer API offers a hook to do this in one go, as a step in the transfo
 
 Again we replace all `Emphasized` nodes with `Strong` nodes:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.api._
 import laika.ast._
 import laika.format._

--- a/docs/src/04-customizing-laika/06-overriding-renderers.md
+++ b/docs/src/04-customizing-laika/06-overriding-renderers.md
@@ -43,7 +43,10 @@ show the three different ways to register such a function.
 In the following example only the HTML output for emphasized text will be modified,
 adding a specific style class:
 
-```scala
+```scala mdoc
+import laika.ast._
+import laika.render.HTMLFormatter
+
 val renderer: PartialFunction[(HTMLFormatter, Element), String] = {
   case (fmt, Emphasized(content, opt)) => 
     fmt.element("em", opt, content, "class" -> "big") 
@@ -76,10 +79,16 @@ In case you want to combine it with other extensions, a render override can also
 
 @:choice(sbt)
 
-```scala
+```scala mdoc:invisible
+import laika.sbt.LaikaPlugin.autoImport._
+import sbt.Keys._
+import sbt._
+```
+
+```scala mdoc:compile-only
 import laika.ast._
 
-laikaSiteRenderers += laikaSiteRenderer {
+laikaExtensions += laikaHtmlRenderer {
   case (fmt, Emphasized(content, opt)) => 
     fmt.element("em", opt, content, "class" -> "big")
 }
@@ -89,7 +98,11 @@ laikaSiteRenderers += laikaSiteRenderer {
 
 **Using the Transformer API**
 
-```scala
+```scala mdoc
+import laika.api._
+import laika.ast._
+import laika.format._
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -101,8 +114,8 @@ val transformer = Transformer
 
 **Using the Renderer API**
 
-```scala
-val doc: Document = ...
+```scala mdoc:compile-only
+val doc: Document = ???
 
 val renderer = Renderer
   .of(HTML)

--- a/docs/src/04-customizing-laika/06-overriding-renderers.md
+++ b/docs/src/04-customizing-laika/06-overriding-renderers.md
@@ -43,7 +43,7 @@ show the three different ways to register such a function.
 In the following example only the HTML output for emphasized text will be modified,
 adding a specific style class:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.ast._
 import laika.render.HTMLFormatter
 
@@ -98,7 +98,7 @@ laikaExtensions += laikaHtmlRenderer {
 
 **Using the Transformer API**
 
-```scala mdoc
+```scala mdoc:silent
 import laika.api._
 import laika.ast._
 import laika.format._

--- a/docs/src/05-extending-laika/01-overview.md
+++ b/docs/src/05-extending-laika/01-overview.md
@@ -51,12 +51,15 @@ See @:api(laika.bundle.ExtensionBundle) for its API documentation.
 The trait comes with empty default implementations for most of its properties,
 so that you only need to override the ones you intend to use.
 
-```scala
+```scala mdoc
+import laika.bundle.ExtensionBundle
+import laika.ast.{ DocumentType, Path }
+
 object MyExtensions extends ExtensionBundle {
 
-  override val docTypeMatcher: PartialFunction[Path, DocumentType] = ???
+  val description: String = "My Sample Bundle"
 
-  // ... optionally other customizations
+  // ... customizations
 }
 ```
 
@@ -65,7 +68,15 @@ Such a bundle can then be passed to the transformer:
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:invisible
+import laika.sbt.LaikaPlugin.autoImport._
+import sbt.Keys._
+import sbt._
+```
+
+```scala mdoc:compile-only
+import laika.markdown.github.GitHubFlavor
+
 laikaExtensions := Seq(
   GitHubFlavor,
   MyExtensions
@@ -73,7 +84,11 @@ laikaExtensions := Seq(
 ```
 
 @:choice(library)
-```scala
+```scala mdoc
+import laika.api._
+import laika.format._
+import laika.markdown.github.GitHubFlavor
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)

--- a/docs/src/05-extending-laika/01-overview.md
+++ b/docs/src/05-extending-laika/01-overview.md
@@ -84,7 +84,7 @@ laikaExtensions := Seq(
 ```
 
 @:choice(library)
-```scala mdoc
+```scala mdoc:silent
 import laika.api._
 import laika.format._
 import laika.markdown.github.GitHubFlavor

--- a/docs/src/05-extending-laika/02-creating-themes.md
+++ b/docs/src/05-extending-laika/02-creating-themes.md
@@ -28,7 +28,7 @@ laikaTheme := Theme.empty
 
 @:choice(library)
 
-```scala mdoc
+```scala mdoc:silent
 import cats.effect.IO
 import laika.api._
 import laika.format._
@@ -135,7 +135,7 @@ for the PDF output so that the content looks good when printed.
 The Helium API solves this by requiring a selector in front of all configuration methods which is either
 `all`, `site`, `epub` or `pdf`:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.helium.Helium
 
 val theme = Helium.defaults
@@ -237,7 +237,7 @@ allowing you to reduce the boilerplate and stringly logic of rendering the forma
 
 The below example shows how the `ThemeBuilder` API can be used to pre-populate the transformer configuration:
 
-```scala mdoc
+```scala mdoc:silent
 import cats.effect.IO
 import laika.ast.Image
 import laika.ast.Path.Root

--- a/docs/src/05-extending-laika/02-creating-themes.md
+++ b/docs/src/05-extending-laika/02-creating-themes.md
@@ -14,19 +14,32 @@ and simply place all necessary templates and CSS files in your regular input dir
 @:select(config)
 
 @:choice(sbt)
+```scala mdoc:invisible
+import laika.sbt.LaikaPlugin.autoImport._
+import sbt.Keys._
+import sbt._
+```
 
-```scala
+```scala mdoc:compile-only
+import laika.theme.Theme
+
 laikaTheme := Theme.empty
 ```
 
 @:choice(library)
 
-```scala
+```scala mdoc
+import cats.effect.IO
+import laika.api._
+import laika.format._
+import laika.io.implicits._
+import laika.theme.Theme
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
   .parallel[IO]
-  .witTheme(Theme.empty)
+  .withTheme(Theme.empty)
   .build
 ```
 
@@ -39,8 +52,17 @@ The Theme Trait
 Before describing the typical steps for implementing a theme, let's have a quick look at the (simple) `Theme` trait,
 to get an idea of what a theme represents in technical terms.
 
-```scala
+```scala mdoc:compile-only
+import cats.data.Kleisli
+import laika.bundle.ExtensionBundle
+import laika.factory.Format
+import laika.io.descriptor.ThemeDescriptor
+import laika.io.model.{ InputTree, ParsedTree }
+import laika.theme.Theme.TreeProcessor
+
 trait Theme[F[_]] {
+
+  def descriptor: ThemeDescriptor
 
   def inputs: InputTree[F]
   
@@ -113,7 +135,9 @@ for the PDF output so that the content looks good when printed.
 The Helium API solves this by requiring a selector in front of all configuration methods which is either
 `all`, `site`, `epub` or `pdf`:
 
-```scala
+```scala mdoc
+import laika.helium.Helium
+
 val theme = Helium.defaults
   .all.metadata(
     title = Some("Project Name"),
@@ -159,6 +183,9 @@ There are two approaches you can choose from:
   add the result to the `InputTreeBuilder`:
   
     ```scala
+    import laika.io.model.InputTreeBuilder
+    import laika.rewrite.DefaultTemplatePath
+  
     val builder: InputTreeBuilder[F] = ???
     val templateString: String = MyTemplateGenerator.generate(config)
     builder.addString(templateString, DefaultTemplatePath.forHTML)
@@ -170,9 +197,12 @@ There are two approaches you can choose from:
 * Or place the entire default template into the resource folder of your library and load it from there:
 
     ```scala
+    import laika.io.model.InputTreeBuilder
+    import laika.rewrite.DefaultTemplatePath
+  
     val builder: InputTreeBuilder[F] = ???
     val resourcePath = "my-theme/templates/default.template.html"
-    builder.addClasspathResource(resourcePath, DefaultTemplatePath.forHTML)
+    builder.addClassResource(resourcePath, DefaultTemplatePath.forHTML)
     ```
   
   In this case you would use Laika's template syntax to access your theme's configuration, 
@@ -207,8 +237,14 @@ allowing you to reduce the boilerplate and stringly logic of rendering the forma
 
 The below example shows how the `ThemeBuilder` API can be used to pre-populate the transformer configuration:
 
-```scala
-val logo = Logo.internal(
+```scala mdoc
+import cats.effect.IO
+import laika.ast.Image
+import laika.ast.Path.Root
+import laika.config.ConfigBuilder
+import laika.theme.ThemeBuilder
+
+val logo = Image.internal(
   path = Root / "logo.png", 
   alt = Some("Project Logo")
 )
@@ -217,14 +253,14 @@ val baseConfig = ConfigBuilder.empty
   .withValue("theme-name.logo", logo)
   .build
 
-ThemeBuilder("Theme Name")
+ThemeBuilder[IO]("Theme Name")
   .addBaseConfig(baseConfig)
   .build
 ```
 
 It defines a logo AST element, based on the virtual path `Root / "logo.png"` and associates it with the key
 `theme-name.logo`.
-Finally it passes the configuration to the theme builder, making the logo available for templates via a
+Finally, it passes the configuration to the theme builder, making the logo available for templates via a
 substitution reference (`${theme-name.logo}`).
 
 The indirection via the configuration key means that even if the user customizes the default templates
@@ -241,13 +277,17 @@ Here the most convenient approach might be to place static CSS files into the re
 and use CSS variables to capture all aspects which the user can configure. 
 This is the approach that Helium has also chosen.
 
-```scala
-val builder: InputTreeBuilder[F] = ???
+```scala mdoc:compile-only
+import cats.effect.IO
+import laika.ast.Path.Root
+import laika.io.model.InputTreeBuilder
+
+val builder: InputTreeBuilder[IO] = ???
 val resourcePath = "my-theme/css/theme.css"
-val vars: String = MyCSSVarsGenerator.generate(config)
+val vars: String = "<... generated-CSS ...>"
 builder
   .addString(vars, Root / "my-theme" / "vars.css")
-  .addClasspathResource(resourcePath, Root / "my-theme" / "theme.css")
+  .addClassResource(resourcePath, Root / "my-theme" / "theme.css")
 ```
 
 
@@ -268,14 +308,19 @@ The API should accept a sequence of `FontDefinition` instances that define the f
 These definitions can then be passed to the base configuration of the theme (which will be merged with the 
 user configuration):
 
-```scala
+```scala mdoc:compile-only
+import cats.effect.IO
+import laika.config.ConfigBuilder
+import laika.theme.ThemeBuilder
+import laika.theme.config.FontDefinition
+
 val fonts: Seq[FontDefinition] = ???
 val baseConfig = ConfigBuilder.empty
   .withValue("laika.epub.fonts", fonts)
   .withValue("laika.pdf.fonts", fonts)
   .build
   
-ThemeBuilder("Theme Name")
+ThemeBuilder[IO]("Theme Name")
   .addBaseConfig(baseConfig)
   .build
 ```
@@ -288,33 +333,41 @@ Of course, like with Laika's default Helium theme, you can allow to define diffe
 Constructing a Theme Instance
 -----------------------------
 
-Finally all the templates, styles, configuration and fonts that you gather from the user's theme configuration
+Finally, all the templates, styles, configuration and fonts that you gather from the user's theme configuration
 or from your defaults if omitted, need to be assembled into a theme provider instance.
 
 This step will be very different for each theme depending on its feature set, 
-so we just show Laika's own Helium theme builder as an example:
+so we just show an excerpt of Laika's own Helium theme builder as an example:
 
 ```scala
+package laika.helium.builder
+
+import cats.effect.{ Async, Resource }
+import laika.format.{ EPUB, HTML, XSLFO }
+import laika.helium.Helium
+import laika.helium.generate._
+import laika.theme.{ Theme, ThemeBuilder, ThemeProvider }
+
 class HeliumThemeBuilder (helium: Helium) extends ThemeProvider {
 
-  def build[F[_]: Sync]: Resource[F, Theme[F]] = {
+  def build[F[_]: Async]: Resource[F, Theme[F]] = {
 
     import helium._
-
+    
     val treeProcessor = new HeliumTreeProcessor[F](helium)
-    val htmlOverrides = HeliumRenderOverrides
-                          .forHTML(siteSettings.layout.anchorPlacement)
 
     ThemeBuilder("Helium")
       .addInputs(HeliumInputBuilder.build(helium))
       .addBaseConfig(ConfigGenerator.populateConfig(helium))
       .addRewriteRules(HeliumRewriteRules.build(helium))
-      .addRenderOverrides(HTML.Overrides(htmlOverrides))
+      .addRenderOverrides(
+        HTML.Overrides(HeliumRenderOverrides.forHTML(siteSettings.layout.anchorPlacement))
+      )
+      .addRenderOverrides(EPUB.XHTML.Overrides(HeliumRenderOverrides.forEPUB))
       .addRenderOverrides(XSLFO.Overrides(HeliumRenderOverrides.forPDF))
       .processTree(treeProcessor.forHTML, HTML)
       .processTree(treeProcessor.forAllFormats)
       .build
-
   }
 }
 ```

--- a/docs/src/05-extending-laika/03-implementing-directives.md
+++ b/docs/src/05-extending-laika/03-implementing-directives.md
@@ -159,7 +159,7 @@ a directive has to stick to the standard directive syntax, for which we'll pick 
 
 Let's walk through the implementation of our little ticket directive:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.ast._
 import laika.directive.Spans
 import Spans.dsl._

--- a/docs/src/05-extending-laika/03-implementing-directives.md
+++ b/docs/src/05-extending-laika/03-implementing-directives.md
@@ -159,7 +159,9 @@ a directive has to stick to the standard directive syntax, for which we'll pick 
 
 Let's walk through the implementation of our little ticket directive:
 
-```scala
+```scala mdoc
+import laika.ast._
+import laika.directive.Spans
 import Spans.dsl._
 
 val ticketDirective = Spans.create("ticket") {
@@ -197,7 +199,9 @@ This is a sub-trait of `ExtensionBundle`.
 
 For our case we only need to register our ticket directive, which is a span directive: 
 
-```scala
+```scala mdoc
+import laika.directive.DirectiveRegistry
+
 object MyDirectives extends DirectiveRegistry {
   val spanDirectives = Seq(ticketDirective)
   val blockDirectives = Seq()
@@ -211,7 +215,15 @@ Finally we need to register our registry together with any built-in extensions y
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:invisible
+import laika.sbt.LaikaPlugin.autoImport._
+import sbt.Keys._
+import sbt._
+```
+
+```scala mdoc:compile-only
+import laika.markdown.github.GitHubFlavor
+
 laikaExtensions := Seq(
   GitHubFlavor,
   MyDirectives
@@ -219,7 +231,11 @@ laikaExtensions := Seq(
 ```
 
 @:choice(library)
-```scala
+```scala mdoc:silent
+import laika.api._
+import laika.format._
+import laika.markdown.github.GitHubFlavor
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -239,13 +255,16 @@ This will enhance the previous example by making the base URL configurable.
 One of the combinators we can use when defining the directive can ask for a document cursor to be
 provided alongside the expected attribute value:
 
-```scala
+```scala mdoc:silent
+import cats.syntax.all._
+import laika.ast._
+import laika.directive.Spans
 import Spans.dsl._
 
-val ticketDirective = Spans.create("ticket") {
-  (attribute(0).as[Int], cursor).mapN { (num, cursor) => 
+val spanDirective = Spans.create("ticket") {
+  (attribute(0).as[Int], cursor, source).mapN { (num, cursor, source) => 
     cursor.config.get[String]("ticket.baseURL").fold(
-      error => InvalidElement(s"Invalid base URL: $error", "#" + num).asSpan,
+      error   => InvalidSpan(s"Invalid base URL: $error", source),
       baseURL => SpanLink(Seq(Text("#"+num)), ExternalTarget(s"$baseURL$num"))
     )
   }
@@ -272,13 +291,13 @@ With this change in place, the user can now provide the base URL in the builder 
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:compile-only
 laikaConfig := LaikaConfig.defaults
   .withConfigValue("ticket.baseURL", "https://example.com/issues")
 ```
 
 @:choice(library)
-```scala
+```scala mdoc:compile-only
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -327,7 +346,7 @@ Combinators:
   
 Combinator Example:
 
-```scala
+```scala mdoc:compile-only
 val ticketDirective = Spans.create("directive-name") {
   attribute(0).as[Int].map { ticketNo => 
     ??? // produce AST span node
@@ -368,7 +387,7 @@ Combinator Example:
 
 We'll use the `allAttributes` combinator together with the one for accessing body elements:
 
-```scala
+```scala mdoc:compile-only
 val directive = Spans.create("custom") {
   (allAttributes, parsedBody).mapN { (attributes, bodyContent) => 
     val path = attributes.getOpt[Path]("filePath")
@@ -385,7 +404,7 @@ Positional and named attributes can be marked as optional.
 
 Combinator Example:
 
-```scala
+```scala mdoc:compile-only
 attribute("width").as[Int].optional
 ```
 
@@ -397,7 +416,7 @@ from `T` to `Option[T]` where `T` is either the type returned by your converter 
 
 You can specify a decoder for all attributes with the `as[T]` method:
 
-```scala
+```scala mdoc:compile-only
 attribute("depth").as[Int].optional
 ```
 
@@ -421,7 +440,7 @@ you can set the `inherited` flag:
 
 Combinator Example:
 
-```scala
+```scala mdoc:compile-only
 attribute("width").as[Int].inherited
 ```
 
@@ -458,7 +477,7 @@ Combinators:
   
 Combinator Example:
 
-```scala
+```scala mdoc:compile-only
 val directive = Spans.create("custom") {
   (attribute("name"), parsedBody).mapN { (nameAttribute, bodyContent) => 
     ??? // produce AST span node, bodyContent will be Seq[Span] here
@@ -473,11 +492,14 @@ Access to the Parser
 You can request access to the parser of the host language with all extensions the user had installed
 with an overload of the `parsedBody` combinator:
 
-```scala
-val bodyPart = parsedBody { recursiveParsers =>
+```scala mdoc:compile-only
+import laika.parse.implicits._
+import laika.parse.text.TextParsers._
+
+val bodyPart = parsedBody { recParsers =>
   anyChars.take(3) ~> recParsers.recursiveSpans(anyChars.line)
 }
-(defaultAttribute, bodyPart).mapN { (attrValue, bodyContent) =>
+(attribute(0), bodyPart).mapN { (attrValue, bodyContent) =>
   ??? // produce AST span node, bodyContent will be Seq[Span] here
 }
 ```
@@ -526,7 +548,9 @@ The directive implementation you need to provide is then merely a simple functio
 
 Example:
 
-```scala
+```scala mdoc:compile-only
+import laika.directive.Links
+
 val directive = Links.create("github") { (path, _) =>
   val url = s"https://github.com/our-project/$path"
   SpanLink(Seq(Text(s"GitHub ($path)")), ExternalTarget(url))
@@ -583,7 +607,7 @@ In this section we'll just show a very small, contrived example.
 Declaring a separator directive looks just like declaring a normal directive, 
 only that you call `separator` instead of `create`:
 
-```scala
+```scala mdoc:silent
 case class Child (content: Seq[Span])
 
 val sepDir = Spans.separator("child", min = 1) { parsedBody.map(Child) }   
@@ -596,7 +620,7 @@ in this case only the `parsedBody` that you map to the `Child` type.
 
 Now you can use this directive in the parent:
 
-```scala
+```scala mdoc:compile-only
 val directive = Spans.create("parent") { 
   separatedBody(Seq(sepDir)) map { multipart =>
     val seps = multipart.children.flatMap { sep => 

--- a/docs/src/05-extending-laika/06-adding-syntax-highlighters.md
+++ b/docs/src/05-extending-laika/06-adding-syntax-highlighters.md
@@ -164,7 +164,7 @@ Like with our string literal example, we define two kinds of escapes that can oc
 
 There are shortcuts for the most common types of decimal, hex, octal and binary number literals:
 
-```scala mdoc
+```scala mdoc:silent
 import laika.parse.code.CodeSpanParser
 import laika.parse.code.common._
 

--- a/docs/src/05-extending-laika/06-adding-syntax-highlighters.md
+++ b/docs/src/05-extending-laika/06-adding-syntax-highlighters.md
@@ -118,7 +118,10 @@ You can examine the source code of Laika's built-in highlighters for more comple
 
 There are shortcuts for defining single- and multi-line strings together with escape sequences:
 
-```scala
+```scala mdoc:compile-only
+import laika.parse.code.CodeSpanParser
+import laika.parse.code.common._
+
 val spanParsers: Seq[CodeSpanParser] = Seq(
   StringLiteral.multiLine("\"\"\""),
   StringLiteral.singleLine('"').embed(
@@ -142,7 +145,10 @@ e.g. Scala's `s"some $ref"` syntax.
 
 Character literals have fewer options than string literals, but are otherwise quite similar:
 
-```scala
+```scala mdoc:compile-only
+import laika.parse.code.CodeSpanParser
+import laika.parse.code.common._
+
 val spanParsers: Seq[CodeSpanParser] = Seq(
   CharLiteral.standard.embed(
     StringLiteral.Escape.unicode ++ StringLiteral.Escape.char
@@ -158,7 +164,10 @@ Like with our string literal example, we define two kinds of escapes that can oc
 
 There are shortcuts for the most common types of decimal, hex, octal and binary number literals:
 
-```scala
+```scala mdoc
+import laika.parse.code.CodeSpanParser
+import laika.parse.code.common._
+
 val spanParsers: Seq[CodeSpanParser] = Seq(
   NumberLiteral.hex
     .withUnderscores
@@ -181,7 +190,7 @@ existing parsers for widely used syntax (`NumericSuffix.long` parses `L` or `l` 
 
 This is how the identifier category is defined for the Scala highlighter:
 
-```scala
+```scala mdoc:compile-only
 val identifier = Identifier.alphaNum
   .withIdStartChars('_','$')
   .withCategoryChooser(Identifier.upperCaseTypeName)
@@ -205,10 +214,9 @@ Many highlighters you might be using with other tools are equally pragmatic.
 
 Keywords can simply be listed as string literals:
 
-```scala
-val spanParsers: Seq[CodeSpanParser] = Seq(
+```scala mdoc:compile-only
+val keywords =
   Keywords("abstract", "case", "catch", "class", "def")
-)
 ```
 
 It detects word boundaries so that it will not match on sub-strings.
@@ -216,7 +224,9 @@ It detects word boundaries so that it will not match on sub-strings.
 By default the parser will assign `CodeCategory.Keyword` to any matching string.
 If you want to use literal matches, but with a different code category, there is an alternative constructor:
 
-```scala
+```scala mdoc:compile-only
+import laika.parse.code.CodeCategory
+
 Keywords(CodeCategory.BooleanLiteral)("true", "false")
 ```
 
@@ -225,7 +235,7 @@ Keywords(CodeCategory.BooleanLiteral)("true", "false")
 
 Shortcuts exist for defining single- and multi-line comments:
 
-```scala
+```scala mdoc:compile-only
 val spanParsers: Seq[CodeSpanParser] = Seq(
   Comment.singleLine("//"),
   Comment.multiLine("/*", "*/")
@@ -245,9 +255,10 @@ but in most cases you end up with the need to have at least a handful of hand-wr
 For a little example, let's implement a highlighter for Scala's backtick identifiers (e.g. `` `tag-name` ``)
 which is quite straightforward, but not included in the reusable builders since it's not a very common construct:
 
-```scala
+```scala mdoc:compile-only
 import laika.parse.builders._
 import laika.parse.implicits._
+import laika.parse.code.CodeCategory
 
 val backtickId: CodeSpanParser = CodeSpanParser(CodeCategory.Identifier) {
     (oneOf('`') ~ anyNot('\n', '`') ~ oneOf('`')).source
@@ -284,7 +295,14 @@ Laika comes with a parser builder that helps with the creation of such a parser.
 
 Let's pick CSS in HTML as an example and show a simplified definition for a such a style tag:
 
-```scala
+```scala mdoc:compile-only
+import laika.ast.CodeSpan
+import laika.parse.builders._
+import laika.parse.code.CodeCategory
+import laika.parse.code.common.EmbeddedCodeSpans
+import laika.parse.code.languages.CSSSyntax
+import laika.parse.text.PrefixedParser
+
 val styleTagParser: PrefixedParser[Seq[CodeSpan]] = {
   val cat = CodeCategory.Tag.Name
   val bodyAndEndTag = 
@@ -293,6 +311,7 @@ val styleTagParser: PrefixedParser[Seq[CodeSpan]] = {
   (literal("<style>") ~> bodyAndEndTag).map { css =>
     CodeSpan("<style>", cat) +: css :+ CodeSpan("</style>", cat)
   }
+}
 ``` 
 
 The key here is the third line.
@@ -336,7 +355,11 @@ Registering a Highlighter
 
 First you have to assemble all the parsers in a `SyntaxHighlighter` implementation:
 
-```scala
+```scala mdoc:silent
+import cats.data.NonEmptyList
+import laika.bundle.SyntaxHighlighter
+import laika.parse.code.CodeSpanParser
+
 object FooHighlighter extends SyntaxHighlighter {
 
   val language: NonEmptyList[String] = NonEmptyList.one("foo")
@@ -350,8 +373,12 @@ object FooHighlighter extends SyntaxHighlighter {
 
 Finally, like all other types of extensions, the highlighter needs to be registered with an `ExtensionBundle`:
 
-```scala
+```scala mdoc:silent
+import laika.bundle.{ ExtensionBundle, ParserBundle }
+
 case object MyExtensions extends ExtensionBundle {
+  
+  val description: String = "Foo Syntax Highlighter"
   
   override def parsers: ParserBundle = ParserBundle(
     syntaxHighlighters = Seq(
@@ -363,12 +390,20 @@ case object MyExtensions extends ExtensionBundle {
 
 You can bundle multiple highlighters in a single instance.
 
-Finally you can register your extension together with any built-in extensions you may use:
+Finally, you can register your extension together with any built-in extensions you may use:
 
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:invisible
+import laika.sbt.LaikaPlugin.autoImport._
+import sbt.Keys._
+import sbt._
+```
+
+```scala mdoc:compile-only
+import laika.markdown.github.GitHubFlavor
+
 laikaExtensions := Seq(
   GitHubFlavor,
   MyExtensions
@@ -376,7 +411,11 @@ laikaExtensions := Seq(
 ```
 
 @:choice(library)
-```scala
+```scala mdoc:silent
+import laika.api._
+import laika.format._
+import laika.markdown.github.GitHubFlavor
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)

--- a/docs/src/05-extending-laika/07-new-markup-output-formats.md
+++ b/docs/src/05-extending-laika/07-new-markup-output-formats.md
@@ -52,7 +52,9 @@ while the parsers for a new format need to be registered in a `MarkupFormat`.
 
 The contract a markup implementation has to adhere to is captured in the following trait:
 
-```scala
+```scala mdoc
+import laika.bundle.{ BlockParserBuilder, ExtensionBundle, SpanParserBuilder }
+
 trait MarkupFormat {
 
   def fileSuffixes: Set[String]
@@ -92,7 +94,7 @@ These are the four abstract method each parser has to implement.
   Whenever a format that defines extensions is used, they are merged with the user-supplied extensions.
   This collection may very well remain empty for some formats.
 
-Finally there are three concrete methods that may be overridden if required:
+Finally, there are three concrete methods that may be overridden if required:
 
 ```scala
 def description: String = toString
@@ -165,7 +167,10 @@ not just a subset like an override.
 
 A renderer has to implement the following trait:
 
-```scala
+```scala mdoc
+import laika.ast.Element
+import laika.factory.RenderContext
+
 trait RenderFormat[FMT] {
   
   def fileSuffix: String
@@ -221,7 +226,10 @@ This `defaultRenderer` function should usually adhere to these rules:
   
 Let's look at a minimal excerpt of a hypothetical HTML render function:
 
-```scala
+```scala mdoc
+import laika.ast._
+import laika.render.HTMLFormatter
+
 def renderElement (fmt: HTMLFormatter, elem: Element): String = {
 
   elem match {

--- a/docs/src/07-reference/01-standard-directives.md
+++ b/docs/src/07-reference/01-standard-directives.md
@@ -220,13 +220,27 @@ The available icon set can be registered as part of the transformer setup:
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:invisible
+import laika.sbt.LaikaPlugin.autoImport._
+import sbt.Keys._
+import sbt._
+```
+```scala mdoc:compile-only
+import laika.ast._
+import laika.rewrite.link.IconRegistry
+
 laikaConfig := LaikaConfig.defaults
   .withConfigValue(IconRegistry("open" -> IconStyle("open"), "close" -> IconGlyph('\ueedd')))
 ```
 
 @:choice(library)
-```scala
+```scala mdoc:compile-only
+import laika.ast._
+import laika.api._
+import laika.format._
+import laika.markdown.github.GitHubFlavor
+import laika.rewrite.link.IconRegistry
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -362,7 +376,9 @@ This is how the settings for Laika's manual look:
 
 @:choice(sbt)
 
-```scala
+```scala mdoc:compile-only
+import laika.rewrite.nav.{ ChoiceConfig, SelectionConfig, Selections }
+
 laikaConfig := LaikaConfig.defaults
   .withConfigValue(Selections(
     SelectionConfig("config",
@@ -374,7 +390,13 @@ laikaConfig := LaikaConfig.defaults
 
 @:choice(library)
 
-```scala
+```scala mdoc:compile-only
+import laika.ast._
+import laika.api._
+import laika.format._
+import laika.markdown.github.GitHubFlavor
+import laika.rewrite.nav.{ ChoiceConfig, SelectionConfig, Selections }
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -426,7 +448,7 @@ the corresponding parent directive to mark specific sections within the directiv
 Can only be used in block elements in text markup.
 
 Produces a block element which is not part of the main body of the markup document.
-Instead it can be referred to by `${cursor.currentDocument.fragments.<fragmentName>}`.
+Instead, it can be referred to by `${cursor.currentDocument.fragments.<fragmentName>}`.
 
 This allows to keep some sections of your document separate, to be rendered
 in different locations of the output, like headers, footers or sidebars.

--- a/docs/src/07-reference/02-substitution-variables.md
+++ b/docs/src/07-reference/02-substitution-variables.md
@@ -134,13 +134,22 @@ You can add arbitrary configuration values when building a `Parser`, `Renderer` 
 @:select(config)
 
 @:choice(sbt)
-```scala
+```scala mdoc:invisible
+import laika.sbt.LaikaPlugin.autoImport._
+import sbt.Keys._
+import sbt._
+```
+```scala mdoc:compile-only
 laikaConfig := LaikaConfig.defaults
   .withConfigValue("project.version", "2.4.6")
 ```
 
 @:choice(library)
-```scala
+```scala mdoc:compile-only
+import laika.api._
+import laika.format._
+import laika.markdown.github.GitHubFlavor
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -199,7 +208,10 @@ are also available programmatically if you are working with a document tree.
 The `DocumentCursor`, `DocumentTree`, `Document` and `TemplateDocument` types 
 all have a `config` property that exposes those values:
 
-```scala
+```scala mdoc:compile-only
+import laika.ast.Document
+import laika.config.ConfigError
+
 val doc: Document = ???
 val version: Either[ConfigError, String] = 
   doc.config.get[String]("project.version")

--- a/docs/src/07-reference/07-migration-guide.md
+++ b/docs/src/07-reference/07-migration-guide.md
@@ -43,7 +43,13 @@ val transformer = Transformer
 
 After:
 
-```scala
+```scala mdoc:compile-only
+import cats.effect.IO
+import laika.api._
+import laika.format._
+import laika.io.implicits._
+import laika.markdown.github.GitHubFlavor
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -68,7 +74,8 @@ If you are using the sbt plugin, you are not affected by this API change.
 When using the library API the necessary code changes are quite trivial. Change:
 
 ```scala
-val transformer = ??? // build your transformer like before
+// build your transformer like before
+val transformer = ???
 
 transformer
   .fromDirectory("docs")
@@ -78,8 +85,12 @@ transformer
 
 to
 
-```scala
-val transformer = ??? // build your transformer like before
+```scala mdoc:compile-only
+import cats.effect.{ IO, Resource }
+import laika.io.api.TreeTransformer
+
+// build your transformer like before
+val transformer: Resource[IO, TreeTransformer[IO]] = ???
 
 transformer.use {
   _.fromDirectory("docs")
@@ -231,7 +242,12 @@ val res: String = transformer
 
 After
 
-```scala
+```scala mdoc:compile-only
+import laika.api._
+import laika.format._
+import laika.markdown.github.GitHubFlavor
+import laika.parse.markup.DocumentParser.TransformationError
+
 val input = "some *text* example"
 
 val transformer = Transformer
@@ -240,7 +256,7 @@ val transformer = Transformer
   .using(GitHubFlavor)
   .build
   
-val res: Either[ParserError, String] = transformer
+val res: Either[TransformationError, String] = transformer
   .transform(input)
 ```
 
@@ -264,7 +280,11 @@ val res: Unit = transformer
 
 After (ensure you added the new `laika-io` dependency):
 
-```scala
+```scala mdoc:compile-only
+import cats.effect.IO
+import laika.api._
+import laika.format._
+import laika.markdown.github.GitHubFlavor
 import laika.io.implicits._
 
 val transformer = Transformer
@@ -278,6 +298,7 @@ val res: IO[Unit] = transformer.use {
   _.fromDirectory("src")
    .toDirectory("target")
    .transform
+   .void
 }
 ```
 
@@ -307,7 +328,11 @@ val transformer = Transform
 
 After
 
-```scala
+```scala mdoc:compile-only
+import laika.ast.Emphasized
+import laika.api._
+import laika.format._
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -350,7 +375,11 @@ val transformer = Transform
 
 After
 
-```scala
+```scala mdoc:compile-only
+import laika.ast._
+import laika.api._
+import laika.format._
+
 val transformer = Transformer
   .from(Markdown)
   .to(HTML)
@@ -443,15 +472,20 @@ val spanDirective = Spans.create("note") {
 
 After
 
-```scala
+```scala mdoc:compile-only
 import cats.implicits._
 import laika.ast._
+import laika.directive.Spans
 import Spans.dsl._
 
 case class Note (title: String, 
                  content: Seq[Span], 
                  options: Options = NoOpt) extends Span 
-                                           with SpanContainer[Note]
+                                           with SpanContainer {
+  type Self = Note  
+  def withOptions(options: Options): Self = copy(options = options)  
+  def withContent(content: Seq[Span]): Self = copy(content = content)                                  
+}
  
 val spanDirective = Spans.create("note") {
   (attribute(0).as[String], parsedBody).mapN(Note(_,_))

--- a/io/src/main/scala/laika/helium/Helium.scala
+++ b/io/src/main/scala/laika/helium/Helium.scala
@@ -63,7 +63,7 @@ import laika.theme._
   *   .from(Markdown)
   *   .to(EPUB)
   *   .parallel[IO]
-  *   .witTheme(theme)
+  *   .withTheme(theme)
   *   .build
   * }}}
   *

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.1")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
 
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.7" )
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.7")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.1")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,6 +8,8 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.1")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
 
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.7" )
+
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.1")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")


### PR DESCRIPTION
Introduces mdoc for nearly all code samples in the manual (except for some edge cases where this is not possible, e.g. where showing snippets of Laika source code).

Prefers the `silent` modifier in almost all cases as the runtime output for the samples is not useful in the specific types of examples shown in the manual.

Includes several fixes which surfaced in the process and also introduces imports to the code samples where necessary which closes #274.

This is the final tweak to the build that was necessary before branching. The next PR that is not binary-compatible will trigger branching for 0.19 maintenance and 1.0 development.