### PR TITLE
Helium: introduce helium.site.pageNavigation.keepOnSmallScreens attribute

### DIFF
--- a/io/src/main/resources/laika/helium/css/nav.css
+++ b/io/src/main/resources/laika/helium/css/nav.css
@@ -353,6 +353,18 @@ ul.nav-list, #page-nav ul {
     display: inline-block;
   }
 }
+@media (max-width: 1450px) {
+  #page-nav.all-screens {
+    display: block;
+    position: static;
+    width: 100%;
+    max-width: var(--content-width);
+    background-color: transparent;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 75px 45px 10px 45px;
+  }
+}
 
 .icofont-laika {
   font-size: 1.75em;

--- a/io/src/main/resources/laika/helium/templates/includes/pageNav.template.html
+++ b/io/src/main/resources/laika/helium/templates/includes/pageNav.template.html
@@ -1,5 +1,5 @@
 @:if(helium.site.pageNavigation.enabled)
-<nav id="page-nav">
+<nav id="page-nav"@:if(helium.site.pageNavigation.keepOnSmallScreens) class="all-screens"@:@>
   <p class="header"><a href="#">${cursor.currentDocument.title}</a></p>
 
   @:navigationTree {

--- a/io/src/main/scala/laika/helium/config/layout.scala
+++ b/io/src/main/scala/laika/helium/config/layout.scala
@@ -104,7 +104,8 @@ private[helium] case class PageNavigation(
     enabled: Boolean = true,
     depth: Int = 2,
     sourceBaseURL: Option[String] = None,
-    sourceLinkText: String = "Source for this page"
+    sourceLinkText: String = "Source for this page",
+    keepOnSmallScreens: Boolean = false
 )
 
 private[helium] case class DownloadPage(

--- a/io/src/main/scala/laika/helium/config/settings.scala
+++ b/io/src/main/scala/laika/helium/config/settings.scala
@@ -627,7 +627,9 @@ private[helium] trait SiteOps extends SingleConfigOps with CopyOps {
       keepOnSmallScreens: Boolean = currentContent.pageNavigation.keepOnSmallScreens
   ): Helium = {
     val newContent = helium.siteSettings.content
-      .copy(pageNavigation = PageNavigation(enabled, depth, sourceBaseURL, sourceLinkText))
+      .copy(pageNavigation =
+        PageNavigation(enabled, depth, sourceBaseURL, sourceLinkText, keepOnSmallScreens)
+      )
     copyWith(helium.siteSettings.copy(content = newContent))
   }
 

--- a/io/src/main/scala/laika/helium/config/settings.scala
+++ b/io/src/main/scala/laika/helium/config/settings.scala
@@ -609,16 +609,42 @@ private[helium] trait SiteOps extends SingleConfigOps with CopyOps {
     copyWith(helium.siteSettings.copy(content = newContent))
   }
 
+  /** Configures the page navigation bar on the top-right side of the content pane
+    *
+    * @param enabled indicates whether the page navigation should be included.
+    * @param depth the of the navigation structure, two by default.
+    * @param sourceBaseURL the base URL for the markup sources of the rendered pages.
+    * @param sourceLinkText the link text to show on links to markup sources.
+    * @param keepOnSmallScreens indicates whether the page navigation should be included on small screens,
+    *                           where it will move from a top-right box to the top of the main content pane.
+    * @return
+    */
   def pageNavigation(
       enabled: Boolean = currentContent.pageNavigation.enabled,
       depth: Int = currentContent.pageNavigation.depth,
       sourceBaseURL: Option[String] = currentContent.pageNavigation.sourceBaseURL,
-      sourceLinkText: String = currentContent.pageNavigation.sourceLinkText
+      sourceLinkText: String = currentContent.pageNavigation.sourceLinkText,
+      keepOnSmallScreens: Boolean = currentContent.pageNavigation.keepOnSmallScreens
   ): Helium = {
     val newContent = helium.siteSettings.content
       .copy(pageNavigation = PageNavigation(enabled, depth, sourceBaseURL, sourceLinkText))
     copyWith(helium.siteSettings.copy(content = newContent))
   }
+
+  @deprecated
+  def pageNavigation(
+      enabled: Boolean,
+      depth: Int,
+      sourceBaseURL: Option[String],
+      sourceLinkText: String
+  ): Helium =
+    pageNavigation(
+      enabled,
+      depth,
+      sourceBaseURL,
+      sourceLinkText,
+      currentContent.pageNavigation.keepOnSmallScreens
+    )
 
   /** Adds a dedicated page for a table of content, in addition to the left navigation bar.
     *

--- a/io/src/main/scala/laika/helium/generate/ConfigGenerator.scala
+++ b/io/src/main/scala/laika/helium/generate/ConfigGenerator.scala
@@ -114,6 +114,7 @@ private[laika] object ConfigGenerator {
         .withValue("enabled", pageNav.enabled)
         .withValue("depth", pageNav.depth)
         .withValue("sourceEditLinks", editLinks)
+        .withValue("keepOnSmallScreens", pageNav.keepOnSmallScreens)
         .build
   }
 

--- a/io/src/test/scala/laika/helium/HeliumHTMLNavSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumHTMLNavSpec.scala
@@ -284,6 +284,27 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
     )
   }
 
+  test("page navigation - show on small screens, configured globally") {
+    val expected =
+      """<p class="header"><a href="#">Doc 1</a></p>
+        |<ul class="nav-list">
+        |<li class="level1 nav-node"><a href="#section-1">Section 1</a></li>
+        |<li class="level2 nav-leaf"><a href="#section-1-1">Section 1.1</a></li>
+        |<li class="level1 nav-node"><a href="#section-2">Section 2</a></li>
+        |<li class="level2 nav-leaf"><a href="#section-2-1">Section 2.1</a></li>
+        |</ul>
+        |<p class="footer"></p>""".stripMargin
+    val helium   = Helium.defaults.site.landingPage().site.pageNavigation(keepOnSmallScreens = true)
+    transformAndExtract(
+      flatInputs,
+      helium,
+      "<nav id=\"page-nav\" class=\"all-screens\">",
+      "</nav>"
+    ).assertEquals(
+      expected
+    )
+  }
+
   test("page navigation - one level only, configured in configuration header in markup") {
     val expected =
       """<p class="header"><a href="#">Doc 1</a></p>
@@ -299,6 +320,28 @@ class HeliumHTMLNavSpec extends CatsEffectSuite with InputBuilder with ResultExt
       "<nav id=\"page-nav\">",
       "</nav>"
     ).assertEquals(expected)
+  }
+
+  test("page navigation - show on small screens, configured in configuration header in markup") {
+    val expected =
+      """<p class="header"><a href="#">Doc 1</a></p>
+        |<ul class="nav-list">
+        |<li class="level1 nav-node"><a href="#section-1">Section 1</a></li>
+        |<li class="level2 nav-leaf"><a href="#section-1-1">Section 1.1</a></li>
+        |<li class="level1 nav-node"><a href="#section-2">Section 2</a></li>
+        |<li class="level2 nav-leaf"><a href="#section-2-1">Section 2.1</a></li>
+        |</ul>
+        |<p class="footer"></p>""".stripMargin
+    val config   = "helium.site.pageNavigation.keepOnSmallScreens = true"
+    val helium   = Helium.defaults.site.landingPage()
+    transformAndExtract(
+      flatInputsWithConfig(config),
+      helium,
+      "<nav id=\"page-nav\" class=\"all-screens\">",
+      "</nav>"
+    ).assertEquals(
+      expected
+    )
   }
 
   test("page navigation - disabled globally") {


### PR DESCRIPTION
Adds a new configuration option for the page navigation in the Helium theme. When setting `keepOnSmallScreens` to true, the page navigation will move to an inline position on top of the page on small screens as opposed to being hidden (which was the original behaviour that still applies when the attribute is set to `false`, which is the default for consistency with previous versions).

The CSS is largely the one proposed by @valencik in #338 apart from adjusting the top and bottom padding.

Closes #338.