### PR TITLE
Helium PDF: default to relative font size for code (fix code spans in headlines)

### DIFF
--- a/core/shared/src/main/scala/laika/render/FOFormatter.scala
+++ b/core/shared/src/main/scala/laika/render/FOFormatter.scala
@@ -317,6 +317,15 @@ case class FOFormatter(
   */
 object FOFormatter extends (RenderContext[FOFormatter] => FOFormatter) {
 
+  /** A wrapper around pre-rendered content which can be used to set default
+    * attributes that can be inherited by any node in the document.
+    */
+  case class ContentWrapper(content: String, options: Options = NoOpt) extends Block {
+    type Self = ContentWrapper
+
+    def withOptions(options: Options): ContentWrapper = copy(options = options)
+  }
+
   /** A preamble for a document, only used in PDF output where multiple XSL-FO documents get concatenated
     * before being passed to the PDF renderer.
     */

--- a/core/shared/src/main/scala/laika/render/FOProperties.scala
+++ b/core/shared/src/main/scala/laika/render/FOProperties.scala
@@ -402,7 +402,7 @@ trait FOProperties {
     "bookmark-tree"   -> Set.empty,
     "bookmark"        -> Set("external-destination", "internal-destination", "starting-state"),
     "bookmark-title"  -> Set("color", "font-style", "font-weight"),
-    "wrapper"         -> Set("id"),
+    "wrapper"         -> Set("id", "font-size"),
     "declarations"    -> Set.empty,
     "color-profile"   -> Set("src")
   ).withDefaultValue(Set())

--- a/core/shared/src/main/scala/laika/render/FORenderer.scala
+++ b/core/shared/src/main/scala/laika/render/FORenderer.scala
@@ -217,6 +217,7 @@ object FORenderer extends ((FOFormatter, Element) => String) {
     }
 
     def renderSimpleBlock(block: Block): String = block match {
+      case e: ContentWrapper             => renderContentWrapper(e)
       case e: Preamble                   => renderPreamble(e)
       case e @ ListItemLabel(content, _) => fmt.listItemLabel(e, content)
       case e: Rule                       =>
@@ -369,6 +370,11 @@ object FORenderer extends ((FOFormatter, Element) => String) {
       fmt.forMessage(message) {
         fmt.text(message.withStyle(message.level.toString.toLowerCase), message.content)
       }
+    }
+
+    def renderContentWrapper(cw: ContentWrapper): String = {
+      val inner = fmt.newLine + cw.content + fmt.newLine
+      fmt.rawElement("fo:wrapper", cw, inner)
     }
 
     def renderPreamble(p: Preamble): String = {

--- a/io/src/main/scala/laika/helium/config/HeliumDefaults.scala
+++ b/io/src/main/scala/laika/helium/config/HeliumDefaults.scala
@@ -217,7 +217,7 @@ private[helium] object HeliumDefaults {
     themeFonts = defaultThemeFonts,
     fontSizes = FontSizes(
       body = pt(10),
-      code = pt(9),
+      code = em(0.9),
       title = pt(24),
       header2 = pt(14),
       header3 = pt(12),

--- a/io/src/main/scala/laika/helium/generate/FOStyles.scala
+++ b/io/src/main/scala/laika/helium/generate/FOStyles.scala
@@ -30,6 +30,10 @@ private[laika] class FOStyles(helium: Helium) {
 
   val input: String =
     s"""
+       |ContentWrapper {
+       |  font-size: ${fontSizes.body.displayValue};
+       |}
+       |
        |Paragraph {
        |  font-family: ${themeFonts.body};
        |  font-size: ${fontSizes.body.displayValue};

--- a/io/src/test/scala/laika/helium/HeliumFORendererSpec.scala
+++ b/io/src/test/scala/laika/helium/HeliumFORendererSpec.scala
@@ -256,7 +256,7 @@ class HeliumFORendererSpec extends CatsEffectSuite with InputBuilder with Result
         ColorQuintet(hex("990011"), hex("990022"), hex("990033"), hex("990044"), hex("990055"))
     )
     val expected =
-      """<fo:block background-color="#000011" color="#000055" font-family="Fira Mono" font-size="9pt" fox:border-radius="2mm" line-height="1.4" linefeed-treatment="preserve" margin-left="2mm" margin-right="2mm" padding="2mm" page-break-inside="avoid" space-after="6mm" white-space-collapse="false" white-space-treatment="preserve"><fo:inline color="#990022">val</fo:inline> <fo:inline color="#000044">stuff</fo:inline> = <fo:inline color="#990055">Seq</fo:inline>(
+      """<fo:block background-color="#000011" color="#000055" font-family="Fira Mono" font-size="0.9em" fox:border-radius="2mm" line-height="1.4" linefeed-treatment="preserve" margin-left="2mm" margin-right="2mm" padding="2mm" page-break-inside="avoid" space-after="6mm" white-space-collapse="false" white-space-treatment="preserve"><fo:inline color="#990022">val</fo:inline> <fo:inline color="#000044">stuff</fo:inline> = <fo:inline color="#990055">Seq</fo:inline>(
         |<fo:inline color="#990044">&quot;text&quot;</fo:inline>,
         |<fo:inline color="#990044">7</fo:inline>,
         |<fo:inline color="#990022">new</fo:inline> <fo:inline color="#990055">Foo</fo:inline>

--- a/io/src/test/scala/laika/render/fo/XSLFORendererSpec.scala
+++ b/io/src/test/scala/laika/render/fo/XSLFORendererSpec.scala
@@ -624,8 +624,8 @@ class XSLFORendererSpec extends FunSuite with ParagraphCompanionShortcuts with T
     val fo   =
       s"""<fo:block space-after="6mm">
          |  <fo:block space-after="3mm" text-align="center"><fo:external-graphic content-width="scale-down-to-fit" height="auto" scaling="uniform" src="/image.jpg" width="85%"/></fo:block>
-         |  <fo:block font-family="serif" font-size="9pt" font-style="italic" space-after="3mm">some <fo:inline font-style="italic">caption</fo:inline> text</fo:block>
-         |  <fo:block font-size="9pt" font-style="italic">
+         |  <fo:block font-family="serif" font-size="0.9em" font-style="italic" space-after="3mm">some <fo:inline font-style="italic">caption</fo:inline> text</fo:block>
+         |  <fo:block font-size="0.9em" font-style="italic">
          |    <fo:block $defaultParagraphStyles>aaa</fo:block>
          |    $ruleBlock
          |    <fo:block $defaultParagraphStyles>bbb</fo:block>
@@ -749,14 +749,14 @@ class XSLFORendererSpec extends FunSuite with ParagraphCompanionShortcuts with T
   test("render a paragraph containing a literal span") {
     val elem = p(Text("some "), Literal("code"), Text(" span"))
     val fo   =
-      s"""<fo:block $defaultParagraphStyles>some <fo:inline font-family="monospaced" font-size="9pt">code</fo:inline> span</fo:block>"""
+      s"""<fo:block $defaultParagraphStyles>some <fo:inline font-family="monospaced" font-size="0.9em">code</fo:inline> span</fo:block>"""
     run(elem, fo)
   }
 
   test("render a paragraph containing a code span") {
     val elem = p(Text("some "), InlineCode("banana-script", List(Text("code"))), Text(" span"))
     val fo   =
-      s"""<fo:block $defaultParagraphStyles>some <fo:inline font-family="monospaced" font-size="9pt">code</fo:inline> span</fo:block>"""
+      s"""<fo:block $defaultParagraphStyles>some <fo:inline font-family="monospaced" font-size="0.9em">code</fo:inline> span</fo:block>"""
     run(elem, fo)
   }
 
@@ -943,7 +943,7 @@ class XSLFORendererSpec extends FunSuite with ParagraphCompanionShortcuts with T
     val elem =
       p(Text("some "), LinkIdReference("id", generatedSource("[link] [id]"))("link"), Text(" span"))
     val fo   =
-      s"""<fo:block $defaultParagraphStyles>some <fo:inline font-family="monospaced" font-size="9pt">[link] [id]</fo:inline> span</fo:block>"""
+      s"""<fo:block $defaultParagraphStyles>some <fo:inline font-family="monospaced" font-size="0.9em">[link] [id]</fo:inline> span</fo:block>"""
     run(elem, fo)
   }
 
@@ -954,7 +954,7 @@ class XSLFORendererSpec extends FunSuite with ParagraphCompanionShortcuts with T
       Text(" span")
     )
     val fo   =
-      s"""<fo:block $defaultParagraphStyles>some <fo:inline font-family="monospaced" font-size="9pt">![img] [id]</fo:inline> span</fo:block>"""
+      s"""<fo:block $defaultParagraphStyles>some <fo:inline font-family="monospaced" font-size="0.9em">![img] [id]</fo:inline> span</fo:block>"""
     run(elem, fo)
   }
 
@@ -1075,7 +1075,7 @@ class XSLFORendererSpec extends FunSuite with ParagraphCompanionShortcuts with T
   }
 
   val defaultCodeBlockStyles =
-    """background-color="#F6F1EF" color="#362E21" font-family="monospaced" font-size="9pt" fox:border-radius="2mm" line-height="1.4" linefeed-treatment="preserve" margin-left="2mm" margin-right="2mm" padding="2mm" space-after="6mm" white-space-collapse="false" white-space-treatment="preserve""""
+    """background-color="#F6F1EF" color="#362E21" font-family="monospaced" font-size="0.9em" fox:border-radius="2mm" line-height="1.4" linefeed-treatment="preserve" margin-left="2mm" margin-right="2mm" padding="2mm" space-after="6mm" white-space-collapse="false" white-space-treatment="preserve""""
 
   val monoBlock = s"""<fo:block $defaultCodeBlockStyles>"""
 

--- a/pdf/src/main/scala/laika/render/pdf/FOConcatenation.scala
+++ b/pdf/src/main/scala/laika/render/pdf/FOConcatenation.scala
@@ -16,23 +16,16 @@
 
 package laika.render.pdf
 
-import cats.data.NonEmptySet
 import cats.implicits._
 import laika.api.Renderer
 import laika.api.builder.OperationConfig
-import laika.ast.Path.Root
 import laika.ast._
-import laika.config.{ Config, ConfigException, LaikaKeys, ValidationError }
+import laika.config.{ Config, ConfigException }
 import laika.format.{ PDF, XSLFO }
 import laika.io.model.RenderedTreeRoot
 import laika.parse.markup.DocumentParser.InvalidDocument
-import laika.rewrite.{ DefaultTemplatePath, OutputContext, TemplateRewriter }
-import laika.rewrite.nav.{
-  ConfigurablePathTranslator,
-  PathAttributes,
-  PathTranslator,
-  TranslatorConfig
-}
+import laika.render.FOFormatter.ContentWrapper
+import laika.rewrite.{ DefaultTemplatePath, OutputContext }
 
 /** Concatenates the XSL-FO that serves as a basis for producing the final PDF output
   * and applies the default XSL-FO template to the entire result.
@@ -66,12 +59,11 @@ object FOConcatenation {
     }
 
     def applyTemplate(foString: String, template: TemplateDocument): Either[Throwable, String] = {
-      val foElement       = RawContent(NonEmptySet.one("fo"), foString)
       val finalConfig     = ensureAbsoluteCoverImagePath
       val virtualPath     = Path.Root / "merged.fo"
       val finalDoc        = Document(
         virtualPath,
-        RootElement(foElement),
+        RootElement(ContentWrapper(foString)),
         fragments = PDFNavigation.generateBookmarks(result, config.navigationDepth),
         config = finalConfig
       )

--- a/pdf/src/test/scala/laika/render/FOConcatenationSpec.scala
+++ b/pdf/src/test/scala/laika/render/FOConcatenationSpec.scala
@@ -62,7 +62,7 @@ class FOConcatenationSpec extends FunSuite with TestSourceBuilders {
       failOnMessages = MessageFilter.None
     )
     val expected =
-      """<fo:inline background-color="#ffe9e3" border="1pt solid #d83030" color="#d83030" padding="1pt 2pt">WRONG</fo:inline> <fo:inline font-family="monospaced" font-size="9pt">faulty input</fo:inline>"""
+      """<fo:inline background-color="#ffe9e3" border="1pt solid #d83030" color="#d83030" padding="1pt 2pt">WRONG</fo:inline> <fo:inline font-family="monospaced" font-size="0.9em">faulty input</fo:inline>"""
     assertEquals(FOConcatenation(result, PDF.BookConfig(), config), Right(expected))
   }
 

--- a/pdf/src/test/scala/laika/render/PDFNavigationSpec.scala
+++ b/pdf/src/test/scala/laika/render/PDFNavigationSpec.scala
@@ -93,6 +93,11 @@ class PDFNavigationSpec extends CatsEffectSuite with FileIO with PDFTreeModel {
 
   def results(range: Range): String = range.map(result).reduceLeft(_ + _)
 
+  def wrapped(content: String): String =
+    s"""<fo:wrapper font-size="10pt">
+       |$content
+       |</fo:wrapper>""".stripMargin
+
   def result(num: Int): String = {
     s"""
        |
@@ -174,14 +179,14 @@ class PDFNavigationSpec extends CatsEffectSuite with FileIO with PDFTreeModel {
 
   test("render a tree with all structure elements disabled") {
 
-    result(navigationDepth = 0).assertEquals(withDefaultTemplate(results(1 to 6)))
+    result(navigationDepth = 0).assertEquals(withDefaultTemplate(wrapped(results(1 to 6))))
   }
 
   test("render a tree with navigation elements enabled") {
 
     result().assertEquals(
       withDefaultTemplate(
-        results(1 to 6),
+        wrapped(results(1 to 6)),
         bookmarkRootResult +
           bookmarkTreeResult(1, 3) + bookmarkTreeResult(2, 5) +
           closeBookmarks
@@ -195,9 +200,11 @@ class PDFNavigationSpec extends CatsEffectSuite with FileIO with PDFTreeModel {
 
     result(useTitleDocuments = true).assertEquals(
       withDefaultTemplate(
-        results(1 to 2) +
-          treeTitleResult(2) + results(3 to 4) +
-          treeTitleResult(3) + results(5 to 6),
+        wrapped(
+          results(1 to 2) +
+            treeTitleResult(2) + results(3 to 4) +
+            treeTitleResult(3) + results(5 to 6)
+        ),
         bookmarkRootResult +
           bookmarkTreeResult(1, 3, titleDoc = true) + bookmarkTreeResult(2, 5, titleDoc = true) +
           closeBookmarks


### PR DESCRIPTION
This is a follow-up to #378 which solved the issue for HTML output.

For PDF the situation is slightly more complicated. We also switch to `0.9em` as the default for code fonts in Helium configuration, but that only solves it for inline spans or nested blocks. If there is a top level code block (very common in project documentation for example), it has nothing to inherit from as there is no simple way to declare a default font size for XSL-FO (the interim format used for the PDF renderer). For that reason the renderer will wrap the entire content for the PDF in a top-level `fo:wrapper` tag. This is a type of tag that is not rendered, but allows to specify attributes that get inherited by all nested tags. We can set the font size of the body font in this wrapper, so any relative sizes used within the page have a reference size.

This concludes the fixes for code font sizes as EPUB output has never been affected by this (it always uses relative sizes to automatically adjust to the font size chosen by the user in the ebook reader). 

FYI @TonioGela 