### PR TITLE
Standalone Renderer should not drop Document's configuration

### DIFF
--- a/core/shared/src/test/scala/laika/markdown/InlineParsersSpec.scala
+++ b/core/shared/src/test/scala/laika/markdown/InlineParsersSpec.scala
@@ -234,6 +234,18 @@ class InlineParsersSpec extends FunSuite with TestSourceBuilders {
     )
   }
 
+  test("images - inline image with internal target") {
+    val input = "some ![link](images/foo.jpg) here"
+    runEnclosed(
+      input,
+      ImagePathReference(
+        RelativePath.parse("images/foo.jpg"),
+        source("![link](images/foo.jpg)", input),
+        alt = Some("link")
+      )
+    )
+  }
+
   test("images - inline image with an optional title enclosed in double quotes") {
     runEnclosed(
       """some ![link](http://foo.jpg "a title") here""",


### PR DESCRIPTION
The pure/standalone `Renderer` and `Transformer` implementations that transform a single string input drop the configuration that has been specified by the user in the builder. This is a regression introduced in 0.19.0.

Most common scenarios are not affected, as the major use case is a transformer for an entire input tree/directory, which uses a different code path to apply user configuration. This also means the sbt plugin is not affected by this bug either.

Closes #398  