### PR TITLE
shrink public API surface in core parser library

### DIFF
--- a/core/shared/src/main/scala/laika/markdown/BlockParsers.scala
+++ b/core/shared/src/main/scala/laika/markdown/BlockParsers.scala
@@ -184,7 +184,7 @@ object BlockParsers {
   /** Parses a literal block, text indented by a tab or 4 spaces.
     */
   val literalBlocks: BlockParserBuilder = BlockParserBuilder.standalone {
-    val wsPreProcessor = new WhitespacePreprocessor
+    val wsPreProcessor = WhitespacePreprocessor.forString
     PrefixedParser(' ', '\t') {
       decoratedBlock(tabOrSpace, tabOrSpace, tabOrSpace).map { lines =>
         LiteralBlock(wsPreProcessor(lines.input))

--- a/core/shared/src/main/scala/laika/parse/Parsed.scala
+++ b/core/shared/src/main/scala/laika/parse/Parsed.scala
@@ -155,7 +155,7 @@ object Message {
 
   val ExpectedEOL: Message = fixed("Expected end of line")
 
-  class MessageFactory[T](f: T => String) extends (T => Message) {
+  private class MessageFactory[T](f: T => String) extends (T => Message) {
 
     def apply(value: T): Message = new Message {
 
@@ -174,17 +174,16 @@ object Message {
 
   }
 
-  /** Builds a message instance for the specified
-    * factory function.
+  /** Builds a message instance for the specified factory function.
     */
   def forContext(f: SourceCursor => String): Message = new Message {
     def message(source: SourceCursor): String = f(source)
   }
 
   /** Builds a factory function that produces new messages
-    * based on some arbitrary input type. This allows
-    * to pre-capture some context for the message that
-    * does not relate to the parser context.
+    * based on some arbitrary input type.
+    * This allows to pre-capture some context for the message
+    * that does not relate to the parser context.
     */
   def forRuntimeValue[T](f: T => String): T => Message = new MessageFactory(f)
 

--- a/core/shared/src/main/scala/laika/parse/Parser.scala
+++ b/core/shared/src/main/scala/laika/parse/Parser.scala
@@ -340,7 +340,7 @@ abstract class Parser[+T] {
   }
 
   /** Handle any error, potentially recovering from it, by mapping it to a new parser that
-    * will be applied at the same starting position than the failing parser.
+    * will be applied at the same starting position as the failing parser.
     *
     * This is similar to the `orElse` or `|` method, but allows the alternative
     * parser to inspect the error of the preceding one.

--- a/core/shared/src/main/scala/laika/parse/SourceCursor.scala
+++ b/core/shared/src/main/scala/laika/parse/SourceCursor.scala
@@ -124,7 +124,8 @@ trait SourceFragment extends SourceCursor {
   * For creating a cursor for a fragment of the input, either `BlockSource` or `LineSource` must be used
   * to preserve position tracking in relation to the root input.
   */
-class RootSource(inputRef: InputString, val offset: Int, val nestLevel: Int) extends SourceCursor {
+class RootSource private[parse] (inputRef: InputString, val offset: Int, val nestLevel: Int)
+    extends SourceCursor {
 
   type Self = RootSource
 
@@ -284,11 +285,6 @@ object LineSource {
   * This type of source cursor solves this issue by providing a view to parsers that looks like a consecutive
   * string of inline markup without the stripped decoration, while maintaining the x- and y-offsets of each line
   * in relation to the root source.
-  *
-  * Such a source will be used in multi-pass parsers, where the root parser might strip some markup decoration
-  * from each line and then pass the result down to the next recursion.
-  * In such a case each line might have a different x-offset from the root input.
-  * The use of this instance ensures that the correct position can still be tracked.
   */
 class BlockSource(
     inputRef: InputString,

--- a/core/shared/src/main/scala/laika/parse/combinator/Parsers.scala
+++ b/core/shared/src/main/scala/laika/parse/combinator/Parsers.scala
@@ -16,7 +16,7 @@
 
 package laika.parse.combinator
 
-import laika.parse._
+import laika.parse.*
 import laika.parse.text.TextParsers
 
 import scala.util.{ Try, Failure => TFailure, Success => TSuccess }
@@ -46,8 +46,8 @@ trait Parsers {
     */
   def opt(value: String): Parser[Option[String]] = opt(TextParsers.literal(value))
 
-  /** A parser that only succeeds if the specified parser fails and
-    *  vice versa, it never consumes any input.
+  /** A parser that only succeeds if the specified parser fails and vice versa,
+    * it never consumes any input.
     */
   def not[T](p: Parser[T]): Parser[Unit] = Parser { in =>
     p.parse(in) match {
@@ -56,8 +56,8 @@ trait Parsers {
     }
   }
 
-  /** A parser that only succeeds if the parsing the specified literal value
-    * fails and vice versa, it never consumes any input.
+  /** A parser that only succeeds if parsing the specified literal value fails and vice versa,
+    * it never consumes any input.
     */
   def not(value: String): Parser[Unit] = not(TextParsers.literal(value))
 
@@ -99,8 +99,8 @@ trait Parsers {
   def lookAhead(offset: Int, value: String): Parser[String] =
     lookAhead(offset, TextParsers.literal(value))
 
-  /** Applies the specified parser at the specified offset behind the current
-    *  position. Never consumes any input.
+  /** Applies the specified parser at the specified offset behind the current position.
+    * Never consumes any input.
     */
   def lookBehind[T](offset: Int, parser: => Parser[T]): Parser[T] = {
     val errMsg: Int => Message = Message.forRuntimeValue[Int] { o =>
@@ -118,11 +118,11 @@ trait Parsers {
 
   /** A parser that always succeeds with the specified value.
     */
-  def success[T](v: T) = Parser { in => Success(v, in) }
+  def success[T](v: T): Parser[T] = Parser { in => Success(v, in) }
 
   /** A parser that always fails with the specified message.
     */
-  def failure(msg: String) = Parser { in => Failure(Message.fixed(msg), in) }
+  def failure(msg: String): Parser[Nothing] = Parser { in => Failure(Message.fixed(msg), in) }
 
   /** A parser that succeeds if the specified parser succeeds and all input has been consumed.
     */
@@ -141,8 +141,6 @@ trait Parsers {
     lazy val p0 = p
     Parser[T] { in => p0.parse(in) }
   }
-
-  case class ParserException(result: Failure) extends RuntimeException(result.toString)
 
   /** Provides additional methods to `Try` via implicit conversion.
     */

--- a/core/shared/src/main/scala/laika/parse/implicits.scala
+++ b/core/shared/src/main/scala/laika/parse/implicits.scala
@@ -148,17 +148,17 @@ object implicits {
   implicit class LiteralStringOps(val str: String) extends AnyVal {
     def ~ [U](p: Parser[U]): PrefixedParser[String ~ U] = TextParsers.literal(str) ~ p
 
-    def ~ [U](value: String): PrefixedParser[String ~ String] =
+    def ~ (value: String): PrefixedParser[String ~ String] =
       TextParsers.literal(str) ~ TextParsers.literal(value)
 
     def <~ [U](p: Parser[U]): PrefixedParser[String] = TextParsers.literal(str) <~ p
 
-    def <~ [U](value: String): PrefixedParser[String] =
+    def <~ (value: String): PrefixedParser[String] =
       TextParsers.literal(str) <~ TextParsers.literal(value)
 
     def ~> [U](p: Parser[U]): PrefixedParser[U] = TextParsers.literal(str) ~> p
 
-    def ~> [U](value: String): PrefixedParser[String] =
+    def ~> (value: String): PrefixedParser[String] =
       TextParsers.literal(str) ~> TextParsers.literal(value)
 
     def | (p: PrefixedParser[String]): PrefixedParser[String] = TextParsers.literal(str) | p

--- a/core/shared/src/main/scala/laika/parse/markup/DefaultEscapedTextParsers.scala
+++ b/core/shared/src/main/scala/laika/parse/markup/DefaultEscapedTextParsers.scala
@@ -24,7 +24,7 @@ import laika.parse.implicits._
   *
   * @author Jens Halm
   */
-trait DefaultEscapedTextParsers extends EscapedTextParsers {
+private[markup] trait DefaultEscapedTextParsers extends EscapedTextParsers {
 
   /** Parses a single escape character.
     * In the default implementation any character can be escaped.

--- a/core/shared/src/main/scala/laika/parse/markup/DefaultRecursiveParsers.scala
+++ b/core/shared/src/main/scala/laika/parse/markup/DefaultRecursiveParsers.scala
@@ -24,13 +24,14 @@ import laika.parse.builders._
   *
   * @author Jens Halm
   */
-trait DefaultRecursiveParsers extends RecursiveParsers with DefaultRecursiveSpanParsers {
+private[parse] trait DefaultRecursiveParsers extends RecursiveParsers
+    with DefaultRecursiveSpanParsers {
 
   /** The maximum level of block nesting. Some block types like lists
     * and blockquotes contain nested blocks. To protect against malicious
     * input or accidentally broken markup, the level of nesting is restricted.
     */
-  val maxNestLevel: Int = 12
+  private val maxNestLevel: Int = 12
 
   /** Parses any kind of top-level block supported by a concrete markup language.
     */

--- a/core/shared/src/main/scala/laika/parse/markup/DefaultRecursiveSpanParsers.scala
+++ b/core/shared/src/main/scala/laika/parse/markup/DefaultRecursiveSpanParsers.scala
@@ -25,7 +25,8 @@ import laika.parse.text.{ DelimitedText, PrefixedParser }
   *
   * @author Jens Halm
   */
-trait DefaultRecursiveSpanParsers extends RecursiveSpanParsers with DefaultEscapedTextParsers {
+private[parse] trait DefaultRecursiveSpanParsers extends RecursiveSpanParsers
+    with DefaultEscapedTextParsers {
 
   /** All default span parsers registered for a host markup language.
     */

--- a/core/shared/src/main/scala/laika/parse/markup/InlineDelimiter.scala
+++ b/core/shared/src/main/scala/laika/parse/markup/InlineDelimiter.scala
@@ -26,7 +26,7 @@ import laika.parse.{ Parsed, SourceCursor, Success }
   *
   * @author Jens Halm
   */
-class InlineDelimiter(nestedDelimiters: Set[Char], endDelimiters: Delimiter[String])
+private[markup] class InlineDelimiter(nestedDelimiters: Set[Char], endDelimiters: Delimiter[String])
     extends Delimiter[InlineResult] {
 
   val startChars = nestedDelimiters ++ endDelimiters.startChars
@@ -57,12 +57,13 @@ class InlineDelimiter(nestedDelimiters: Set[Char], endDelimiters: Delimiter[Stri
 
 /** The result of text parsed with an `InlineDelimiter`.
   */
-sealed trait InlineResult
+private[markup] sealed trait InlineResult
 
 /** The result in case the start character of a nested span has been parsed.
   */
-case class NestedDelimiter(startChar: Char, capturedText: String) extends InlineResult
+private[markup] case class NestedDelimiter(startChar: Char, capturedText: String)
+    extends InlineResult
 
 /** The result in case the end delimiter for the text has been parsed.
   */
-case class EndDelimiter(capturedText: String) extends InlineResult
+private[markup] case class EndDelimiter(capturedText: String) extends InlineResult

--- a/core/shared/src/main/scala/laika/parse/markup/InlineParsers.scala
+++ b/core/shared/src/main/scala/laika/parse/markup/InlineParsers.scala
@@ -179,8 +179,8 @@ object InlineParsers extends InlineParsers
 /** Generic base parser that parses inline elements with potentially nested spans.
   *
   * The two embed methods allow the registration of parsers for nested child spans.
-  * They can be invoked multiple times. Child parsers passed first have higher
-  * precedence than those passed later.
+  * They can be invoked multiple times.
+  * Child parsers passed first have higher precedence than those passed later.
   *
   * Only parsers of type `PrefixedParser[T]` can be passed to the embed methods,
   * which are parsers with known, stable prefixes of the child span consisting

--- a/core/shared/src/main/scala/laika/parse/text/Characters.scala
+++ b/core/shared/src/main/scala/laika/parse/text/Characters.scala
@@ -24,7 +24,7 @@ import scala.annotation.tailrec
   *
   * @author Jens Halm
   */
-class Characters[T](
+class Characters[T] private (
     predicate: Char => Boolean,
     resultBuilder: Characters.ResultBuilder[T],
     minChar: Int = 0,
@@ -93,16 +93,18 @@ class Characters[T](
   */
 object Characters {
 
-  type ResultBuilder[T] = (SourceCursor, Int) => T
+  private[Characters] type ResultBuilder[T] = (SourceCursor, Int) => T
 
-  val StringResultBuilder: ResultBuilder[String] = (ctx, consumed) => ctx.capture(consumed)
-  val CountResultBuilder: ResultBuilder[Int]     = (_, consumed) => consumed
-  val UnitResultBuilder: ResultBuilder[Unit]     = (_, _) => ()
+  private[Characters] val StringResultBuilder: ResultBuilder[String] =
+    (ctx, consumed) => ctx.capture(consumed)
+
+  private[Characters] val CountResultBuilder: ResultBuilder[Int] = (_, consumed) => consumed
+  private[Characters] val UnitResultBuilder: ResultBuilder[Unit] = (_, _) => ()
 
   /**  Returns an optimized, Array-based lookup function
     *  for the specified characters.
     */
-  def optimizedLookup(chars: Iterable[Char]): Array[Byte] = {
+  private[text] def optimizedLookup(chars: Iterable[Char]): Array[Byte] = {
     val max: Int = if (chars.nonEmpty) chars.max.toInt else -1
     val lookup   = new Array[Byte](max + 1)
 

--- a/core/shared/src/main/scala/laika/parse/text/DelimitedText.scala
+++ b/core/shared/src/main/scala/laika/parse/text/DelimitedText.scala
@@ -27,17 +27,18 @@ import scala.annotation.tailrec
   *
   * @author Jens Halm
   */
-class DelimitedText(private[laika] val delimiter: TextDelimiter) extends Parser[String] {
+class DelimitedText private[text] (private[laika] val delimiter: TextDelimiter)
+    extends Parser[String] {
 
   private lazy val parser: DelimitedParser[String] = new DelimitedParser[String](delimiter)
 
-  /** Creates a delimiter that also allows reaching the end of the input.
+  /** Creates a delimiter that also allows reaching the end of the input before encountering the delimiter.
     * By default a delimiter based parser fails in that case.
     */
   def acceptEOF: DelimitedText = new DelimitedText(delimiter.copy(acceptEOF = true))
 
-  /** Creates a delimiter that also allows empty result, meaning reaching the delimiter before any non-delimiter
-    * characters have been parsed.
+  /** Creates a delimiter that also allows empty result,
+    * meaning reaching the delimiter before any non-delimiter characters have been parsed.
     * By default a delimiter based parser fails in that case.
     */
   def nonEmpty: DelimitedText = new DelimitedText(delimiter.copy(nonEmpty = true))
@@ -57,8 +58,8 @@ class DelimitedText(private[laika] val delimiter: TextDelimiter) extends Parser[
 
 object DelimitedText {
 
-  /** A parser that reads to the end of the input, unless further conditions
-    * are set on the returned `DelimiterOptions`.
+  /** A parser that reads to the end of the input,
+    * unless further conditions are set on the returned `DelimiterOptions`.
     */
   lazy val Undelimited: DelimitedText = new DelimitedText(TextDelimiter(None)).acceptEOF
 

--- a/core/shared/src/main/scala/laika/parse/text/DelimiterParser.scala
+++ b/core/shared/src/main/scala/laika/parse/text/DelimiterParser.scala
@@ -43,7 +43,7 @@ import laika.parse.{ Failure, Message, Parser, Success }
   *
   * @author Jens Halm
   */
-class DelimiterParser(
+class DelimiterParser private[text] (
     prefix: PrefixedParser[String],
     prevCharInvalid: Char => Boolean = _ => false,
     nextCharInvalid: Char => Boolean = _ => false,

--- a/core/shared/src/main/scala/laika/parse/text/Literal.scala
+++ b/core/shared/src/main/scala/laika/parse/text/Literal.scala
@@ -23,7 +23,7 @@ import laika.parse._
   *
   * @author Jens Halm
   */
-case class Literal(expected: String) extends PrefixedParser[String] {
+private[text] class Literal(expected: String) extends PrefixedParser[String] {
 
   require(expected.nonEmpty, "string may not be empty")
 

--- a/core/shared/src/main/scala/laika/parse/text/PrefixCharacters.scala
+++ b/core/shared/src/main/scala/laika/parse/text/PrefixCharacters.scala
@@ -19,8 +19,7 @@ package laika.parse.text
 import cats.data.NonEmptySet
 
 /** A variant of the Characters type that can be used as a stable prefix for an optimized
-  * span parser as it is always non-empty. It's created by the `oneOf` method in `TextParsers`
-  * and usually not used directly.
+  * span parser as it is always non-empty.
   *
   * @author Jens Halm
   */
@@ -33,8 +32,8 @@ class PrefixCharacters[T](val underlying: Characters[T], val startChars: NonEmpt
       "count must be positive for an optimizable prefix, use TextParsers.anyOf or anyIn if you need to allow empty sequences"
     )
 
-  /** Creates and returns a new parser that fails if it does not consume the specified minimum number
-    *  of characters. It may still consume more characters in case of further matches.
+  /** Creates and returns a new parser that fails if it does not consume the specified minimum number of characters.
+    * It may still consume more characters in case of further matches.
     */
   def min(count: Int): PrefixCharacters[T] = {
     greaterThanZero(count)
@@ -42,7 +41,7 @@ class PrefixCharacters[T](val underlying: Characters[T], val startChars: NonEmpt
   }
 
   /** Creates and returns a new parser that consumes at most the specified maximum number of characters.
-    *  Always succeeds, unless a minimum number of matches is also specified.
+    * Always succeeds, unless a minimum number of matches is also specified.
     */
   def max(count: Int): PrefixCharacters[T] = {
     greaterThanZero(count)
@@ -50,8 +49,8 @@ class PrefixCharacters[T](val underlying: Characters[T], val startChars: NonEmpt
   }
 
   /** Creates and returns a new parser that consumes exactly the specified number of characters.
-    *  Fails if there are less matches, but succeeds in case there are more matches, simply ignoring them.
-    *  Calling `take 3` for example is equivalent to calling `min 3 max 3`.
+    * Fails if there are less matches, but succeeds in case there are more matches, simply ignoring them.
+    * Calling `take 3` for example is equivalent to calling `min 3 max 3`.
     */
   def take(count: Int): PrefixCharacters[T] = {
     greaterThanZero(count)

--- a/core/shared/src/main/scala/laika/parse/text/PrefixedParser.scala
+++ b/core/shared/src/main/scala/laika/parse/text/PrefixedParser.scala
@@ -24,16 +24,15 @@ import laika.parse.{ Parsed, Parser, SourceCursor, SourceFragment }
   * characters for performance optimizations.
   *
   * There is usually no need to create such a parser manually,
-  * as some of the basic building blocks in `TextParsers` create
-  * such a parser (e.g. the `literal`, `oneOf` or `someOf`
-  * parsers).
+  * as some of the basic building blocks in `TextParsers` create such a parser
+  * (e.g. the `literal`, `oneOf` or `someOf` parsers).
   *
-  * This set only has only an effect when this parser is used in
-  * an optimized parser for recursive spans, meaning it is
-  * either registered as a top-level parser (with `SpanParser.standalone`
-  * or `SpanParser.recursive`) or passed to a custom span parser
-  * with `InlineParser.embed`. In all other use cases this
-  * parser behaves just like plain parser.
+  * This set only has only an effect when this parser is used
+  * in an optimized parser for recursive spans,
+  * meaning it is either registered as a top-level parser
+  * (with `SpanParser.standalone` or `SpanParser.recursive`)
+  * or passed to a custom span parser with `InlineParser.embed`.
+  * In all other use cases this parser behaves just like plain parser.
   *
   * @author Jens Halm
   */
@@ -115,7 +114,7 @@ trait PrefixedParser[+T] extends Parser[T] { self =>
   */
 object PrefixedParser {
 
-  import cats.implicits._
+  import cats.syntax.all._
 
   /** Creates a new parser that is only triggered when a character in the specified
     * set is seen on the input.
@@ -134,8 +133,8 @@ object PrefixedParser {
   }
 
   /** Creates a mapping from start characters to their corresponding parser
-    * from the specified sequence of PrefixedParsers. If a character is
-    * a trigger for more than one parser they will be combined using `orElse`
+    * from the specified sequence of PrefixedParsers.
+    * If a character is a trigger for more than one parser they will be combined using `orElse`
     * where the parser which comes first in the sequence has higher precedence.
     */
   def mapAndMerge[T](parsers: Seq[PrefixedParser[T]]): Map[Char, Parser[T]] = parsers
@@ -146,8 +145,5 @@ object PrefixedParser {
     .map { case (char, definitions) =>
       (char, definitions.map(_._2).reduceLeft(_ | _))
     }
-
-  private[laika] def fromLegacyMap[T](map: Map[Char, Parser[T]]): Seq[PrefixedParser[T]] =
-    map.toSeq.map { case (c, p) => PrefixedParser(c)(p) }
 
 }

--- a/core/shared/src/main/scala/laika/parse/text/TextParsers.scala
+++ b/core/shared/src/main/scala/laika/parse/text/TextParsers.scala
@@ -45,7 +45,7 @@ trait TextParsers extends Parsers {
     *
     *  The method is implicit so that strings can automatically be lifted to their parsers.
     */
-  def literal(expected: String): PrefixedParser[String] = Literal(expected)
+  def literal(expected: String): PrefixedParser[String] = new Literal(expected)
 
   /** Parses horizontal whitespace (space and tab).
     * Always succeeds, consuming all whitespace found.

--- a/core/shared/src/main/scala/laika/parse/text/WhitespacePreprocessor.scala
+++ b/core/shared/src/main/scala/laika/parse/text/WhitespacePreprocessor.scala
@@ -20,23 +20,23 @@ import laika.parse.SourceCursor
 import laika.parse.markup.DocumentParser.DocumentInput
 
 /** Processes whitespace, removing or replacing most whitespace characters except
-  *  for newline and space.
+  * for newline and space.
   *
-  *  It modifies string input in the following ways:
+  * It modifies string input in the following ways:
   *
-  *  - Replaces all occurrences of tabs with the corresponding number of spaces,
-  *    depending on the column the tab is placed in and the configured `tabStops` value.
+  * - Replaces all occurrences of tabs with the corresponding number of spaces,
+  *   depending on the column the tab is placed in and the configured `tabStops` value.
   *
-  *  - Removes any return character.
+  * - Removes any return character.
   *
-  *  - Replaces form feed and vertical tab with spaces.
+  * - Replaces form feed and vertical tab with spaces.
   *
-  *  The processor should run on text input before it is passed to the actual
-  *  parsers as they would not be able to deal with tabs properly.
+  * The processor should run on text input before it is passed to the actual
+  * parsers as they would not be able to deal with tabs properly.
   *
   * @author Jens Halm
   */
-class WhitespacePreprocessor extends (String => String) {
+class WhitespacePreprocessor private[text] extends (String => String) {
 
   /** The number of columns between tab stops.
     */
@@ -98,7 +98,7 @@ object WhitespacePreprocessor {
     */
   val forInput: DocumentInput => DocumentInput = { input =>
     val raw          = input.source.input
-    val preprocessed = forString(raw.toString)
+    val preprocessed = forString(raw)
     input.copy(source = SourceCursor(preprocessed, input.path))
   }
 

--- a/core/shared/src/test/scala/laika/parse/text/WhitespacePreprocessorSpec.scala
+++ b/core/shared/src/test/scala/laika/parse/text/WhitespacePreprocessorSpec.scala
@@ -20,7 +20,7 @@ import munit.FunSuite
 
 class WhitespacePreprocessorSpec extends FunSuite {
 
-  private val processor = new WhitespacePreprocessor
+  private val processor = WhitespacePreprocessor.forString
 
   test("replace form feeds and vertical tabs with single spaces") {
     val vt    = '\u000b'


### PR DESCRIPTION
This is the ninth PR for #452.

It covers the packages `laika.parse.combinator`,  `laika.parse.text`, `laika.parse.markup` and the type in the root package `laika.parse`. 

* About half of the types in `laika.parse.markup` are now package-private. They will move to a different internal package in a later milestone.
* Other packages are mostly public library API. Some constructors could be made private, and some nested types could be removed from the public API.